### PR TITLE
rfc3: loopback routing clarification, draft status

### DIFF
--- a/spec_3.adoc
+++ b/spec_3.adoc
@@ -9,7 +9,7 @@ http://rfc.zeromq.org/spec:23/ZMTP[ZeroMQ Message Transfer Protocol (ZMTP)].
 
 * Name: github.com/flux-framework/rfc/spec_3.adoc
 * Editor: Jim Garlick <garlick@llnl.gov>
-* State: raw
+* State: draft
 
 == Language
 
@@ -25,15 +25,14 @@ the following specific goals:
 
 * Endpoint-count scalability (e.g. to 100K nodes) through multi-hop
   overlay networks.
-* Overlays sharable by multiple Flux services and utilities.
+* Overlay networks sharable by multiple Flux services and utilities.
 * Provide request-response (RPC) communication idiom.
-* Provide publish-subscribe communications idiom.
+* Provide publish-subscribe communication idiom.
 * Handle common failure cases such as hard-hung brokers or crashed nodes,
   but OK to propagate errors to services when necessary to keep running.
-* Moderately good latency and bandwith for anticipated services.
-  RDMA complexity should be avoided here.
+* Peer network transit latency of O(10^-3^sec) for small messages
 * Protect messages with strong crypto:  privacy, integrity.
-* Fast, malloc-free message codec
+* Fast codec, minimizing heap memory allocations
 
 == Background
 
@@ -110,17 +109,18 @@ Request messages MAY be addressed to _any rank_ (FLUX_NODEID_ANY).
 Such messages SHALL be routed to the local broker instance, then to the
 first match in the following sequence:
 
-. If topic string begins with "cmb.",
-  the message SHALL be handled internally by the broker
-. If topic string begins with a word matching a local comms module,
-  the message SHALL be routed to the comms module.
+. If topic string begins with "cmb." and the sender is not the same rank
+  broker, the message SHALL be handled internally by the broker.
+. If topic string begins with a word matching a local comms module
+  and the sender is not the same comms module attached to the same rank
+  broker, the message SHALL be routed to the comms module.
 . If the broker is not the root node of the tree based overlay network,
   the message SHALL be routed to a parent node in the tree based overlay
   network, which SHALL re-apply this routing algorithm.
 
-If the message is received by a module, but the remaining words of the
-topic string do not match a method implemented by the comms module, the
-comms module SHALL respond with error number 38, "Function not implemented".
+If the message is received by a comms module, but the remaining words of the
+topic string do not match a method it implements, the comms module SHALL
+respond with error number 38, "Function not implemented".
 
 If the message reaches the root node, but none of the above conditions
 are met, the root broker SHALL respond with error number 38,
@@ -132,14 +132,15 @@ Request messages MAY be addressed to a specific rank.
 Such messages SHALL be routed to the target broker instance, then to the
 first match in the following sequence:
 
-. If topic string begins with "cmb.",
-  the message SHALL be handled internally by the broker
-. If topic string begins with a word matching a local comms module,
+. If topic string begins with "cmb." and the sender is not the same rank
+  broker, the message SHALL be handled internally by the broker
+. If topic string begins with a word matching a local comms module and
+  the sender is not the same comms module attached to the same rank broker,
   the message SHALL be routed to the comms module.
 
-If the message is received by a module, but the remaining words of the
-topic string do not match a method implemented by the comms module, the
-comms module SHALL respond with error number 38, "Function not implemented".
+If the message is received by a comms module, but the remaining words of the
+topic string do not match a method it implements, the comms module SHALL
+respond with error number 38, "Function not implemented".
 
 If the message reaches the target node, but none of the above conditions
 are met, the broker SHALL respond with error number 38,
@@ -156,8 +157,25 @@ a "cmb.pub" request message.
 
 === General Message Format
 
-CMB1 messages are multi-part ZeroMQ messages, defined in the following
-ABNF grammar.
+CMB1 messages are multi-part ZeroMQ messages.
+
+CMB1 messages MUST include a PROTO message part, positioned last for fast
+access.  The PROTO part includes flags that indicate the presence of
+additional message parts.
+
+CMB1 messages MAY include a stack of message identity parts comprising
+a source address route, positioned first for compatibility with ZeroMQ
+DEALER-ROUTER sockets.  If message identity parts are present, a zero-size
+route delimiter frame MUST be present and positioned next.
+
+CMB1 messages MAY include a topic string part, positioned after route
+delimiter, if any.  When the topic string part is first, it is compatible
+with ZeroMQ PUB-SUB sockets.
+
+Finally, CMB1 messages MAY include a payload part, positioned before
+the PROTO part.
+
+CMB1 messages are specified in detail by the following ABNF grammar.
 
 ----
 CMB1		= C:request *S:response


### PR DESCRIPTION
Change RFC status from raw -> draft.

Clean up Goals section somewhat.  Specify an actual latency target.
Say "minimizing heap allocations" instead of "malloc free".

Clarify that FLUX_NODEID_ANY requests are never routed back to the
sender; they go up the TBON.

Finally, add some text before the ABNF that describes each message
part.  Figuring it all out from the ABNF might be a little much to ask
of a casual reader.
