### PR TITLE
rfc3: add 'matchtag' field to PROTO

### DIFF
--- a/spec_3.adoc
+++ b/spec_3.adoc
@@ -211,10 +211,10 @@ json		= JSON			; payload 0MQ frame, encoded JSON
 ; Protocol frame
 PROTO		= request / response / event / keepalive
 
-request		= signature version %x01 flags (nodeid / nodeid-any)
-response	= signature version %x02 flags errnum
-event		= signature version %x04 flags sequence
-keepalive	= signature version %x08 flags %x00
+request		= signature version %x01 flags nodeid matchtag
+response	= signature version %x02 flags errnum matchtag
+event		= signature version %x04 flags sequence %x00
+keepalive	= signature version %x08 flags %x00 %x00
 
 ; Constants
 signature	= %x8E			; magic cookie
@@ -227,8 +227,12 @@ flag-payload	= %x02			; message has payload frame
 flag-json	= %x04			;         and payload is JSON
 flag-route	= %x08			; message has route delimiter frame
 
+; Match-tag to correlate request/response
+matchtag	= OCTET / matchtag-any
+matchtag-any    = %x00
+
 ; Target node ID in network byte order
-nodeid		= 4OCTET
+nodeid		= 4OCTET / nodeid-any
 nodeid-any	= %xFF.FF.FF.FF
 
 ; UNIX errno in network byte order


### PR DESCRIPTION
This 8-bit field is used to correlate request - response message
pairs, allowing up to 255 requests to be outstanding in one handle
at any given time.

Matching requests and responses based on topic strings (as in our
prototype code) artificially limits the number of outstanding requests
per handle to one per unique topic string.
