### PR TITLE
rfc7: add std for variable names and typedefs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ HTML = \
 	spec_4.html \
 	spec_5.html \
 	spec_6.html \
+	spec_7.html \
+	spec_8.html
 
 all: $(HTML)
 

--- a/README.adoc
+++ b/README.adoc
@@ -42,6 +42,13 @@ link:spec_7{outfilesuffix}[7/Flux Coding Style Guide]::
 This specification presents the recommended standards when
 contributing C code to the Flux code base.
 
+link:spec_8{outfilesuffix}[8/Flux Task and Program Execution Services]::
+A core service of Flux is to launch, monitor, and handle I/O for
+distributed sets of tasks in order to execute a parallel workload.
+A Flux workload can include further instances of Flux, to arbitrary
+recursive depth. The goal of this RFC is to specify in detail the
+services required to execute a Flux workload.
+
 == Change Process
 
 The change process is

--- a/spec_7.adoc
+++ b/spec_7.adoc
@@ -40,6 +40,34 @@ In general, Flux follows the "Kernighan & Ritchie coding style" with the followi
 int *ptr;
 ----
 
+=== Variable Names
+
+Variable names SHOULD NOT include upper case letters.
+For example `msg_count` is OK, but `MsgCount` or `MSG_COUNT` do not conform.
+
+Preprocessor macro names SHOULD NOT include lower case letters. 
+For example `FLUX_FOO_MAGIC` is OK but `flux_foo_magic` and `FluxFooMagic` do not conform.
+
+=== Typedefs
+
+C typedef names SHOULD NOT include upper case letters.
+
+C typedef names for functions SHOULD end in `_f` and SHOULD be defined as function pointers, for example:
+----
+typedef int (*flux_foo_f)(int arg1, int arg2);
+----
+
+C typedef names for non-functions SHOULD end in `_t`, for example:
+----
+typedef int my_type_t;
+----
+
+Abstract types SHOULD be publicly defined as pointers to incomplete types, for example:
+----
+typedef struct foo_struct *foo_t;
+----
+
+
 Tools That Modify Code to Conform to C Coding Style
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
There was some  discussion in PR flux-framework/flux-core#205 about names for function pointer typedefs.

I'm proposing that we add SHOULD-level guidelines for
* lower case C variable names
* upper case C preprocessor macros
* non-function typedefs: lower case ending in `_t`
* function typedefs: lower case ending in `_f` and defined as function pointers
* use typedef pointer to incomplete type to publicly define abstract data types