### PR TITLE
update rfc7 abstract type rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ HTML = \
 	spec_5.html \
 	spec_6.html \
 	spec_7.html \
-	spec_8.html
+	spec_8.html \
+	spec_9.html
 
 all: $(HTML)
 

--- a/README.adoc
+++ b/README.adoc
@@ -49,6 +49,11 @@ A Flux workload can include further instances of Flux, to arbitrary
 recursive depth. The goal of this RFC is to specify in detail the
 services required to execute a Flux workload.
 
+link:spec_9{outfilesuffix}[9/Distributed Communication and Synchronization Best Practices]::
+Establishes best practices, preferred patterns and anti-patterns for
+distributed services in the flux framework.
+
+/Flux Task and Program Execution Services]::
 == Change Process
 
 The change process is

--- a/spec_7.adoc
+++ b/spec_7.adoc
@@ -62,10 +62,11 @@ C typedef names for non-functions SHOULD end in `_t`, for example:
 typedef int my_type_t;
 ----
 
-Abstract types SHOULD be publicly defined as pointers to incomplete types, for example:
+Abstract types SHOULD be publicly defined as incomplete types, for example:
 ----
-typedef struct foo_struct *foo_t;
+typedef struct foo_struct foo_t;
 ----
+Abstract types SHOULD NOT be defined as pointers to incomplete types,
 
 
 Tools That Modify Code to Conform to C Coding Style


### PR DESCRIPTION
Although we still have prominent examples in our code (e.g. `flux_t`), I believe we concluded in PR #219 that abstract types should not obscure the fact that they are a pointer.