### PR TITLE
rfc10: fix blobref example

### DIFF
--- a/spec_10.adoc
+++ b/spec_10.adoc
@@ -72,7 +72,7 @@ A blobref SHALL consist of a string formed by the concatenation of:
 
 Example:
 ----
-sha1-F1D2D2F924E986AC86FDF7B36C94BCDF32BEEC15
+sha1-f1d2d2f924e986ac86fdf7b36c94bcdf32beec15
 ----
 
 Note: "blobrefs" were shamelessly borrowed from Camlistore


### PR DESCRIPTION
I changed the description of blobrefs to be lower case per discussion, but forgot to update the example.