### PR TITLE
RFC 13

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -75,8 +75,8 @@ API and wire protocol for communication between MPI runtimes and resource
 managers.  It was added to the MPICH2 MPI-2 reference implementation in
 late 2001, and has since been widely implemented, but was not officially
 standardized by the MPI Forum and has been only lightly documented.
-This RFC is an attempt to document the subset of the PMI-1 API and its
-wire protocol necessary for a modern resource manager like Flux to implement.
+This RFC is an attempt to document PMI-1 to guide developers of resource
+managers that must support current and legacy MPI implementations.
 
 == Change Process
 

--- a/spec_13.adoc
+++ b/spec_13.adoc
@@ -8,8 +8,8 @@ API and wire protocol for communication between MPI runtimes and resource
 managers.  It was added to the MPICH2 MPI-2 reference implementation in
 late 2001, and has since been widely implemented, but was not officially
 standardized by the MPI Forum and has been only lightly documented.
-This RFC is an attempt to document the subset of the PMI-1 API and its
-wire protocol necessary for a modern resource manager like Flux to implement.
+This RFC is an attempt to document PMI-1 to guide developers of resource
+managers that must support current and legacy MPI implementations.
 
 * Name: github.com/flux-framework/rfc/spec_13.adoc
 * Editor: Jim Garlick <garlick@llnl.gov>
@@ -27,23 +27,27 @@ be interpreted as described in http://tools.ietf.org/html/rfc2119[RFC 2119].
 
 == Goals
 
-Lacking official guidance from the MPI Forum on this topic,
-this RFC seeks to:
-
-* Document legacy PMI-1 API from MPICH pmi.h[3] header file.
-* Document PMI-1 wire protocol from Hydra source code.
-* Identify deprecated API functions
-* Decrease the amount of research required to implement a process manager.
-* Document MPI runtime quirks that may influence process manager PMI-1
-requirements.
-* Decrease coupling between process managers and MPI runtimes by
+* Decrease coupling between process managers and MPI implementations by
 clarifying their "contract" for communication.
+* Document the PMI-1 application programming interface (API)
+* Document the PMI-1 wire protocol
+* Identify what changed between PMI 1.0 and 1.1
+* Decrease the amount of research required to implement a process manager.
+* Document MPI PMI implementation quirks that should be dealt with by process
+managers seeking a wide range of compatibility
+* Identify which functions are optional, and under what circumstances.
 
-== PMI Version
+== PMI Versions
 
-This RFC describes PMI version 1.0.
+The main changes between PMI 1.0 and PMI 1.1 are in the wire protocol
+and allowing local process group information to be communicated from
+process manager to program via the key-value store.
 
-The "PMI Version 1.1" section documents the changes in PMI version 1.1.
+PMI version 2 is a separate API and protocol and is not covered here.
+
+PMIx ("x" for exascale, from the OpenMPI community) and PMIX extensions
+to PMI-2 ("X" for extension, from the MVAPICH community) are also not
+covered.
 
 == Overview
 
@@ -51,43 +55,43 @@ PMI was designed as an interface between process managers and parallel
 programs, including, but not limited to, MPI runtimes.  It has two main
 parts, one part designed to assist with bootstrap activities that need
 to take place inside 'MPI_Init()', and the other part designed to
-support MPI-2's new dynamic process management features, such as
+support MPI-2's dynamic process management features, such as
 'MPI_Comm_spawn()'.
 
 A newly-launched MPI process needs to find out (minimally) its rank,
 the total number of ranks in the program, and network addresses of
-other ranks.  This information could be figured out by the process
-manager and communicated to the program, but that would require the
-process manager to have intimate knowledge of interconnects that an
-MPI implementation already has.  To achieve a separation of concerns,
-the PMI designers wisely suggested that the process manager only
-provide a generic mechanism for MPI processes to exchange information.
+other ranks.  The rank and size can be trivially passed to the process
+from the process manager via environment variables.  Network addresses
+could be assigned by the process manager and passed in a similar way,
+but that would require the process manager to have intimate knowledge of
+interconnects and the MPI implementation's internal wire-up topologies.
+To achieve a separation of concerns, the PMI designers wisely suggested
+that the process manager only provide a generic mechanism for MPI
+processes to exchange information.
 
-This mechanism consists of a key value store (KVS).
-What one rank puts into the KVS can be read out by another rank,
-after appropriate synchronization.  A simple barrier function provides 
-this synchronization, sometimes referred to as a fence operation.
-Once all processes have reached the fence, all data has been written,
-and can be read once processes are released from the fence.
+This mechanism consists of a key value store (KVS).  What one process
+puts into the KVS can be read out by another process, after appropriate
+synchronization.  A simple collective barrier function provides this
+synchronization.  Once all processes have reached the barrier, all
+data has been written, and can be read once processes are released
+from the barrier.
 
-Programs such as MPI runtimes use PMI-1 in one of two ways:
+Programs generally use PMI-1 by linking against a shared library
+which includes the "standard" API functions described here.
 
-1. Programs link against a shared library called "libpmi.so" provided
-by the process manager, which includes the "standard" API functions
-described here.
-2. Programs are given a connection to the process manager by passing
-an inherited file descriptor, whose number is communicated with an
-environment variable.  Programs then use the wire protocol over that
-file descriptor to communicate with the process manager.
+The PMI library, on behalf of a process, MAY communicate with the process
+manager using the PMI-1 wire protocol.  If that method is used, the
+process manager SHOULD pass a "pre-connected" file descriptor, whose
+number is communicated via an environment variable to the process.
+The process then uses the wire protocol over that file descriptor to
+communicate with the process manager.  In principle such a PMI library
+could be independent of both process manager and program.  In practice,
+most PMI libraries are provided by process managers, and use proprietary
+protocols.
 
-This specification describes a subset of the PMI-1 API and wire protocol,
-culled of:
-
-* Functions necessary for MPI-2[2] dynamic process management
-* API functions that are not used by extant MPI runtimes
-
-MPI-2 implementations that support dynamic process management SHOULD
-use the much improved interfaces in PMI-2.
+If the PMI_FD environment variable is set, this indicates that the PMI
+wire protocol is offered, and a program MAY bypass the PMI library and
+communicate directly with the process manager using the wire protocol.
 
 == Terminology
 
@@ -105,43 +109,58 @@ group or a program.
 
 == Caveats
 
-Some deficiencies of PMI-1 are noted in the PMI-2 paper[7]:
+Some deficiencies of PMI 1.0 are noted in the PMI-2 paper[7]:
 
 * The process manager may not share information with the program
 using the PMI KVS, as no portion of its namespace was reserved for
-this purpose.
+this purpose, though PMI 1.1 does allow local process group information
+to be shared in this way.
 * There is no mechanism to scope a key locally for a subset of processes.
 * PMI-1 is not thread safe.
 * There is no way for a program to access the PMI KVS of another cooperating
 program.
 * There is no mechanism for respawning processes when a fault occurs.
 
+In addition, the lack of strong guidance from the MPI Forum has limited
+acceptance of the PMI wire protocol, resulted in incomplete and
+non-scalable PMI implementations, and resulted in stronger coupling
+between process managers and MPI implementations than necessary.
+
 == Environment
 
 The process manager MAY use the UNIX environment to communicate basic
-bootstrap information to processes.
+process group information to processes.
 
-If PMI_FD, PMI_SIZE, and PMI_RANK are set, the process MAY use the PMI
-wire protocol directly on the file descriptor number stored in PMI_FD.
-bypassing the PMI library and API.
-
-The process MAY open the PMI library and call 'PMI_init()', whose
-implementation may require the above or process manager specific
-environment variables to be set to determine size, rank, etc..
+If the PMI wire protocol is offered, the process manager SHALL set PMI_FD,
+PMI_SIZE, and PMI_RANK to the file descriptor, size, and rank.
+In addition, if the program was created by 'PMI_Spawn_multiple()',
+the PMI_SPAWNED environment variable SHALL be set to (1).
 
 A process manager SHOULD alter the LD_LIBRARY_PATH environment
 variable so that programs it launches can bind at runtime with the
 correct PMI library.
 
-A process manager MAY set PMI_LIBRARY to the fully qualified path
-to its PMI library as a hint to programs that open the PMI library
-using 'dlopen()'.  Note: Intel MPI looks for I_MPI_PMI_LIBRARY[6].
+A process manager MAY set the PMI_LIBRARY environment variable to the
+fully qualified path to its PMI library as a hint to programs that open
+the PMI library using 'dlopen()'.
 
 == Application Programming Interface
+
+The PMI library for PMI version 1 SHALL be named "libpmi" and SHALL
+have a shared library major version of 1.
+
+All function signatures below SHALL be present in a PMI library.
+Functions tagged as OPTIONAL below that are not supported by a process
+manager MAY be stubbed so that they return PMI_FAIL and have no effect.
 
 Programs SHALL NOT strongly bind to a particular process manager's
 PMI library, for example with rpath, as this complicates running
 a compiled program under multiple process managers.
+
+Function signatures not described below SHALL NOT be present in a PMI
+library.  There is no defined mechanism for a process manager to
+extend PMI-1 without inadvertently coupling users of the extension
+to the process manager.
 
 === Return Codes
 
@@ -166,8 +185,6 @@ indicating the result of the operation:
 
 === Initialization
 
-The PMI library SHALL provide the following functions:
-
 [source,c]
 ----
 int PMI_Init (int *spawned);
@@ -181,12 +198,6 @@ Errors:
 * 'PMI_ERR_INVALID_ARG' - invalid argument
 * 'PMI_FAIL' - initialization failed
 
-Notes:
-
-* In SLURM[5], spawned is set to the value of the PMI_SPAWNED environment
-variable, or (0).
-* Called by: openmpi-1.6, mvapich2-1.7
-
 [source,c]
 ----
 int PMI_Initialized (int *initialized);
@@ -199,7 +210,32 @@ Errors:
 
 * 'PMI_ERR_INVALID_ARG' - invalid argument
 * 'PMI_FAIL' - unable to set the variable
-* Called by: openmpi-1.6
+
+[source,c]
+----
+int PMI_KVS_Get_name_length_max (int *length);
+int PMI_KVS_Get_key_length_max (int *length);
+int PMI_KVS_Get_value_length_max (int *length);
+int PMI_Get_id_length_max (int *length);
+----
+Obtain the maximum length (including terminating NULL) of KVS name,
+key, value, and id strings.  Upon success, the PMI library SHALL
+set the value of 'length' to the maximum name length for the requested
+parameter.
+
+Errors:
+
+* 'PMI_ERR_INVALID_ARG' - invalid argument
+* 'PMI_FAIL' - unable to set the length
+
+Notes:
+
+* Process Management in MPICH[1] recommends minimum lengths for
+name, key, and value of 16, 32, and 64, respectively.
+* 'PMI_Get_id_length_max()' SHALL be considered an alias for
+'PMI_Get_name_length_max()'.
+* 'PMI_Get_id_length_max()' was dropped from pmi.h[3] on 2011-01-28 in
+http://git.mpich.org/mpich.git/commit/f17423ef535f562bcacf981a9f7e379838962c6e[commit f17423ef].
 
 [source,c]
 ----
@@ -211,10 +247,6 @@ Errors:
 
 * 'PMI_FAIL' - finalization failed
 
-Notes:
-
-* Called by: openmpi-1.6, mvapich2-1.7
-
 [source,c]
 ----
 int PMI_Abort (int exit_code, const char error_msg[]);
@@ -223,14 +255,7 @@ Abort the process group associated with this process.
 The PMI library SHALL print 'error_msg' to standard error, then exit this
 process with with 'exit_code'.  This function SHALL NOT return.
 
-Notes:
-
-* SLURM[5] prints error message to stderr; terminate job step or
-'kill (0, SIGKILL)' if job ID and step are 0; then call 'exit()'.
-
 === Process Group Information
-
-The PMI library SHALL provide the following functions:
 
 [source,c]
 ----
@@ -245,11 +270,6 @@ Errors:
 * 'PMI_ERR_INVALID_ARG' - invalid argument
 * 'PMI_FAIL' - unable to return the size
 
-Notes:
-
-* In SLURM[5], size is set to the value of SLURM_NPROCS or PMI_SIZE environment variables, or (1).
-* Called by: openmpi-1.6, mvapich2-1.7
-
 [source,c]
 ----
 int PMI_Get_rank (int *rank);
@@ -261,11 +281,6 @@ Errors:
 
 * 'PMI_ERR_INVALID_ARG' - invalid argument
 * 'PMI_FAIL' - unable to return the rank
-
-Notes:
-
-* In SLURM[5], rank is set to the value of SLURM_PROCID or PMI_RANK environment variables, or (0).
-* Called by: openmpi-1.6, mvapich2-1.7
 
 [source,c]
 ----
@@ -282,9 +297,7 @@ Errors:
 
 Notes:
 
-* In SLURM[5], process group size and universe size are presumed identical.
 * See MPI-2[2] section https://www.mpi-forum.org/docs/mpi-2.0/mpi-20-html/node111.htm[5.5.1. Universe Size].
-* Called by: openmpi-1.6
 
 [source,c]
 ----
@@ -296,17 +309,13 @@ the application number.
 Errors:
 
 * 'PMI_ERR_INVALID_ARG' - invalid argument
-* 'PMI_FAIL' - unable to return the size
+* 'PMI_FAIL' - unable to return the appnum
 
 Notes
 
-* In SLURM[5], appnum is set to the value of the SLURM_JOB_ID environment variable, or (0).
 * See MPI-2[2] section https://www.mpi-forum.org/docs/mpi-2.0/mpi-20-html/node113.htm[5.5.3. MPI_APPNUM].
-* Called by: openmpi-1.6, mvapich2-1.7
 
 === Local Process Group Information
-
-The PMI library SHALL provide the following functions:
 
 [source,c]
 ----
@@ -333,7 +342,8 @@ Notes:
 'PMI_Get_clique_size()'.
 * This function was dropped from pmi.h[3] on 2011-01-28 in
 http://git.mpich.org/mpich.git/commit/f17423ef535f562bcacf981a9f7e379838962c6e[commit f17423ef]
-* Called by: openmpi-1.6
+* In PMI 1.1 implementations, this information MAY be retrieved from the KVS
+as described under "PMI 1.1 KVS Schema".
 
 [source,c]
 ----
@@ -346,13 +356,15 @@ Errors:
 
 * 'PMI_ERR_INVALID_ARG' - invalid argument
 * 'PMI_FAIL' - unable to return the clique size
+
+Notes:
+
 * This function was dropped from pmi.h[3] on 2011-01-28 in
 http://git.mpich.org/mpich.git/commit/f17423ef535f562bcacf981a9f7e379838962c6e[commit f17423ef]
-* Called by: openmpi-1.6
+* In PMI 1.1 implementations, this information MAY be retrieved from the KVS
+as described under "PMI 1.1 KVS Schema".
 
 === Key Value Store
-
-The PMI library SHALL provide the following functions:
 
 [source,c]
 ----
@@ -362,8 +374,10 @@ Put a key/value pair in a keyval space.
 The user SHALL set 'kvsname' to the name returned from 'PMI_KVS_Get_my_name()'.
 The user SHALL set 'key' and 'value' to NULL terminated strings no longer
 (with NULL) than the sizes returned by 'PMI_KVS_Get_key_length_max()' and
-'PMI_KVS_Get_value_length_max()' respectively.  Upon success, the PMI
-library SHALL enqueue the key and value for later 'PMI_KVS_Commit()'.
+'PMI_KVS_Get_value_length_max()' respectively.
+
+Upon success, the PMI value SHALL be visible to other processes after
+'PMI_KVS_Commit()' and 'PMI_Barrier()' are called.
 
 Errors:
 
@@ -374,14 +388,9 @@ Errors:
 
 Notes:
 
-* The value is not visible to other processes until 'PMI_KVS_Commit()' is
-called.
-* The function may complete locally.
-* After 'PMI_KVS_Commit()' is called, the value may be retrieved by calling
-'PMI_KVS_Get()'.
-* All keys put to a keyval space must be unique to the keyval space.
-* You may not put more than once with the same key.
-* Called by: openmpi-1.6, mvapich2-1.7
+* The function MAY complete locally.
+* All keys put to a keyval space SHALL be unique to the keyval space.
+* A key SHALL NOT be put more than once to a keyval space.
 
 [source,c]
 ----
@@ -400,8 +409,8 @@ Notes:
 
 * This function commits all previous puts since the last 'PMI_KVS_Commit()'
 into the specified keyval space.
-* It is a process local operation.
-* Called by: openmpi-1.6, mvapich2-1.7
+* It is a process local operation, thus in some implementations,
+it MAY have no effect and still return PMI_SUCCESS.
 
 [source,c]
 ----
@@ -412,8 +421,9 @@ The user SHALL set 'kvsname' to the name returned from 'PMI_KVS_Get_my_name()'.
 The user SHALL set 'length' to the length of the 'value' array, which SHALL
 be no shorter than the length returned by 'PMI_KVS_Get_value_length_max()'.
 The user SHALL set 'key' to a NULL terminated string no longer (with NULL)
-than the size returned by 'PMI_KVS_Get_key_length_max()'.  Upon success,
-the PMI library SHALL fill 'value' with the value of 'key'.
+than the size returned by 'PMI_KVS_Get_key_length_max()'.
+
+Upon success, the PMI library SHALL fill 'value' with the value of 'key'.
 
 Errors:
 
@@ -423,19 +433,19 @@ Errors:
 * 'PMI_ERR_INVALID_LENGTH' - invalid length argument
 * 'PMI_FAIL' - get failed
 
-Notes:
-
-* Called by: openmpi-1.6, mvapich2-1.7
-
 [source,c]
 ----
 int PMI_KVS_Get_my_name (char kvsname[], int length);
+int PMI_Get_kvs_domain_id (char kvsname[], int length);
+int PMI_Get_id( char kvsname[], int length );
 ----
 This function returns the common keyval space for this process group.
 The user SHALL set set 'length' to the length of the 'kvsname' array,
 which SHALL be no shorter than the length returned by
-'PMI_KVS_Get_name_length_max()'.  Upon success, the PMI library SHALL
-set 'kvsname' to a NULL terminated string representing the keyval space.
+'PMI_KVS_Get_name_length_max()'.
+
+Upon success, the PMI library SHALL set 'kvsname' to a NULL terminated
+string representing the keyval space.
 
 Errors:
 
@@ -447,66 +457,10 @@ Notes:
 
 * length SHALL be greater than or equal to the length returned
 by 'PMI_KVS_Get_name_length_max()'.
-* In SLURM[5], kvsname is returned as "jobid.stepid", taken from the
-value of SLURM_JOB_ID and SLURM_STEPID environment variables, or "0.0".
-* Called by: openmpi-1.6, mvapich2-1.7
-
-[source,c]
-----
-int PMI_KVS_Get_name_length_max (int *length);
-----
-Obtain the array length necessary to store a kvsname, including terminating
-NULL.  Upon success, the PMI library SHALL set the value of 'length' to the
-maximum name length.
-
-Errors:
-
-* 'PMI_ERR_INVALID_ARG' - invalid argument
-* 'PMI_FAIL' - unable to set the length
-
-Notes:
-
-* Process Management in MPICH[1] recommends minimum length of 16
-* In SLURM[5], length is 256.
-* Called by: openmpi-1.6, mvapich2-1.7
-
-[source,c]
-----
-int PMI_KVS_Get_key_length_max (int *length);
-----
-Obtain the array length necessary to store a key, including terminating NULL.
-Upon success, the PMI library SHALL set the value of 'length' to the
-maximum key length.
-
-Errors:
-
-* 'PMI_ERR_INVALID_ARG' - invalid argument
-* 'PMI_FAIL' - unable to set the length
-
-Notes:
-
-* Process Management in MPICH[1] recommends minimum length of 32
-* In SLURM[5], length is 256.
-* Called by: openmpi-1.6, mvapich2-1.7
-
-[source,c]
-----
-int PMI_KVS_Get_value_length_max (int *length);
-----
-Obtain the array length necessary to store a value, including terminating
-NULL.  Upon success, the PMI library SHALL set the value of 'length' to the
-maximum value length.
-
-Errors:
-
-* 'PMI_ERR_INVALID_ARG' - invalid argument
-* 'PMI_FAIL' - unable to set the length
-
-Notes:
-
-* Process Management in MPICH[1] recommends minimum length of 64
-* In SLURM[5], length is 1024.
-* Called by: openmpi-1.6, mvapich2-1.7
+* 'PMI_Get_kvs_domain_id()' and 'PMI_Get_id()' SHALL be considered
+an alias for 'PMI_KVS_Get_my_name()'.
+* 'PMI_Get_kvs_domain_id()' and 'PMI_Get_id()' were dropped from pmi.h[3]
+on 2011-01-28 in http://git.mpich.org/mpich.git/commit/f17423ef535f562bcacf981a9f7e379838962c6e[commit f17423ef].
 
 [source,c]
 ----
@@ -523,122 +477,11 @@ Errors:
 
 Notes:
 
-* Called by: openmpi-1.6, mvapich2-1.7
-
-[source,c]
-----
-int PMI_Get_kvs_domain_id (char id_str[], int length);
-----
-Obtain the ID of the PMI domain, which uniquely identifies
-the PMI domain where keyval spaces can be shared.
-The user SHALL set set 'length' to the length of the 'id_str' array,
-which SHALL be no shorter than the length returned by
-'PMI_Get_id_length_max()'.  Upon success, the PMI library SHALL
-set 'id_str' to a NULL terminated string representing the PMI domain.
-
-Errors:
-
-* 'PMI_ERR_INVALID_ARG' - invalid argument
-* 'PMI_ERR_INVALID_LENGTH' - invalid length argument
-* 'PMI_FAIL' - unable to return the id
-
-Notes:
-
-* length should be greater than or equal to the length returned
-by 'PMI_Get_id_length_max()'.
-* In SLURM[5], id is returned as "jobid.stepid", taken from the
-value of SLURM_JOB_ID and SLURM_STEPID environment variables, or "0.0".
-* This function was dropped from pmi.h[3] on 2011-01-28 in
-http://git.mpich.org/mpich.git/commit/f17423ef535f562bcacf981a9f7e379838962c6e[commit f17423ef],
-when MPICH users transitioned to 'PMI_KVS_Get_my_name()'
-* Called by openmpi-1.6
-
-[source,c]
-----
-int PMI_Get_id_length_max (int *length);
-----
-Obtain the array length necessary to store an id string, including
-terminating NULL.  Upon success, the PMI library SHALL set the value
-of 'length' to the maximum id length.
-
-Errors:
-
-* 'PMI_ERR_INVALID_ARG' - invalid argument
-* 'PMI_FAIL' - unable to return the maximum length
-
-Notes:
-
-* In SLURM[5], length is 16.
-* This function was dropped from pmi.h[3] on 2011-01-28 in
-http://githmpich.org/mpich.git/commit/f17423ef535f562bcacf981a9f7e379838962c6e[commit f17423ef],
-when MPICH users transitioned to 'PMI_KVS_Get_name_length_max()'
-* Called by openmpi-1.6
-
-=== Deprecated API Functions
-
-The PMI library SHALL provide the following functions.
-The implementations MAY be stubbed such that they have no effect
-and the return code is always PMI_FAIL.
-
-[source,c]
-----
-typedef struct {
-    const char * key;
-    char * val;
-} PMI_keyval_t;
-
-int PMI_Spawn_multiple(int count,
-                       const char * cmds[],
-                       const char ** argvs[],
-                       const int maxprocs[],
-                       const int info_keyval_sizesp[],
-                       const PMI_keyval_t * info_keyval_vectors[],
-                       int preput_keyval_size,
-                       const PMI_keyval_t preput_keyval_vector[],
-                       int errors[]);
-----
-
-Notes:
-
-* See MPI-2[2] section https://www.mpi-forum.org/docs/mpi-2.0/mpi-20-html/node98.htm[5.3.5.1. Manager-worker Example, Using MPI_SPAWN.]
-* [5]: Not implemented in SLURM[5] - returns PMI_FAIL.
-
-[source,c]
-----
-int PMI_Parse_option(int num_args, char *args[], int *num_parsed, PMI_keyval_t **keyvalp, int *size);
-int PMI_Args_to_keyval(int *argcp, char *((*argvp)[]), PMI_keyval_t **keyvalp, int *size);
-int PMI_Free_keyvals(PMI_keyval_t keyvalp[], int size);
-int PMI_Get_options(char *str, int *length);
-----
-
-* These functions were dropped from pmi.h[3] on 2009-05-01 in
-http://git.mpich.org/mpich.git/commit/52c462d2be6a8d0720788d36e1e096e991dcff38[commit 52c462d]
-* Implemented in SLURM[5].
-
-[source,c]
-----
-int PMI_Publish_name( const char service_name[], const char port[] );
-int PMI_Unpublish_name( const char service_name[] );
-int PMI_Lookup_name( const char service_name[], char port[] );
-----
-
-Notes:
-
-* See MPI-2[2] section https://www.mpi-forum.org/docs/mpi-2.0/mpi-20-html/node104.htm[5.4.4. Name Publishing].
-* Not implemented in SLURM[5] - returns PMI_FAIL.
-
-[source,c]
-----
-int PMI_Get_id( char id_str[], int length );
-----
-
-Notes:
-
-* In SLURM[5], id is returned as "jobid.stepid", taken from the
-value of SLURM_JOB_ID and SLURM_STEPID environment variables, or "0.0".
-* This function was dropped from pmi.h[3] on 2011-01-28 in
-http://git.mpich.org/mpich.git/commit/f17423ef535f562bcacf981a9f7e379838962c6e[commit f17423ef],
-when MPICH users transitioned to 'PMI_KVS_Get_my_name()'
+* This operation is the only collective defined for PMI-1.
+* Some implementations MAY piggyback a KVS data exchange on the barrier
+operation internally.
+* The barrier operation MUST be usable as a generic synchronization mechanism,
+without requiring KVS data to be queued for exchange.
 
 [source,c]
 ----
@@ -650,16 +493,107 @@ int PMI_KVS_Iter_next(const char kvsname[], char key[], int key_len, char val[],
 
 Notes:
 
-* Implemented in SLURM[5].
-* These functions were dropped from pmi.h[3] on 2011-01-28 in
+* These functions are OPTIONAL.
+* Dropped from pmi.h[3] on 2011-01-28 in
 http://git.mpich.org/mpich.git/commit/f17423ef535f562bcacf981a9f7e379838962c6e[commit f17423ef],
 
-== Wire Protocol
+=== Dynamic Process Management
+
+[source,c]
+----
+typedef struct {
+    const char * key;
+    char * val;
+} PMI_keyval_t;
+
+int PMI_Spawn_multiple (int count,
+                        const char * cmds[],
+                        const char ** argvs[],
+                        const int maxprocs[],
+                        const int info_keyval_sizesp[],
+                        const PMI_keyval_t * info_keyval_vectors[],
+                        int preput_keyval_size,
+                        const PMI_keyval_t preput_keyval_vector[],
+                        int errors[]);
+----
+This function spawns a set of processes into a new process group.
+'count' refers to the size of the array parameters 'cmd', 'argvs',
+'maxprocs', 'info_keyval_sizes' and 'info_keyval_vectors'.
+'preput_keyval_size' refers to the size of the 'preput_keyval_vector' array.
+
+'preput_keyval_vector' contains keyval pairs that will be put in the
+keyval space of the newly created process group before the processes
+are started.
+
+The 'maxprocs' array specifies the desired number of processes
+to create for each 'cmd' string.  The actual number of processes
+may be less than the numbers specified in maxprocs.  The acceptable
+number of processes spawned may be controlled by ``soft'' keyvals in
+the info arrays.
+
+Environment variables may be passed to the spawned processes through PMI
+implementation specific 'info_keyval' parameters.
+
+Errors:
+
+* PMI_ERR_INVALID_ARG - invalid argument
+* PMI_FAIL - spawn failed
+
+Notes:
+
+* This function is OPTIONAL in process managers that do not support
+dynamic process management.
+* The ``soft'' option is specified by mpiexec in the MPI-2 standard.
+* See MPI-2[2] section https://www.mpi-forum.org/docs/mpi-2.0/mpi-20-html/node98.htm[5.3.5.1. Manager-worker Example, Using MPI_SPAWN.]
+
+[source,c]
+----
+int PMI_Publish_name (const char service_name[], const char port[]);
+int PMI_Unpublish_name (const char service_name[]);
+int PMI_Lookup_name (const char service_name[], char port[]);
+----
+Publish/unpublish/lookup a name.
+
+Errors:
+
+* PMI_ERR_INVALID_ARG - invalid argument
+* PMI_FAIL - unable to publish service
+
+Notes:
+
+* These functions are OPTIONAL in process managers that do not support
+dynamic process management.
+* See MPI-2[2] section https://www.mpi-forum.org/docs/mpi-2.0/mpi-20-html/node104.htm[5.4.4. Name Publishing].
+
+[source,c]
+----
+int PMI_Parse_option (int num_args, char *args[], int *num_parsed, PMI_keyval_t **keyvalp, int *size);
+int PMI_Args_to_keyval (int *argcp, char *((*argvp)[]), PMI_keyval_t **keyvalp, int *size);
+int PMI_Free_keyvals (PMI_keyval_t keyvalp[], int size);
+int PMI_Get_options (char *str, int *length);
+----
+
+Notes:
+
+* These functions are OPTIONAL.
+* These functions were dropped from pmi.h[3] on 2009-05-01 in
+http://git.mpich.org/mpich.git/commit/52c462d2be6a8d0720788d36e1e096e991dcff38[commit 52c462d]
+
+== PMI 1.1 KVS Schema
+
+In PMI 1.1, the process manager SHALL store the local process group information
+in the KVS under the "PMI_process_mapping" key.
+
+TBD
+
+See https://github.com/flux-framework/flux-core/issues/665[flux-framework/flux-core#665]
+
+== PMI 1.1 Wire Protocol
 
 The PMI-1 wire protocol was deduced from the MPICH simple PMI
 implementation[4] used by the Hydra process manager.
 
-=== PMI_Init
+=== Initialization
 
 ----
 C: cmd=init pmi_version=1 pmi_subversion=1\n
@@ -668,60 +602,77 @@ C: cmd=get_maxes\n
 S: cmd=maxes rc=0 kvsname_max=256 keylen_max=256 vallen_max=256\n
 ----
 
-=== PMI_Get_universe_size
+----
+C: cmd=finalize\n
+S: cmd=finalize_ack rc=0\n
+----
+
+=== Process Group Information
 
 ----
 C: cmd=get_universe_size\n
 S: cmd=universe_size rc=0 size=<integer>\n
 ----
 
-=== PMI_Get_appnum
-
 ----
 C: cmd=get_appnum\n
 S: cmd=appnum rc=0 appnum=<integer>\n
 ----
 
-=== PMI_Barrier
-
-----
-C: cmd=barrier_in\n
-S: cmd=barrier_out rc=0\n
-----
-
-=== PMI_Finalize
-
-----
-C: cmd=finalize\n
-S: cmd=finalize_ack rc=0\n
-----
-
-=== PMI_KVS_Get_my_name
-
-----
-C: cmd=get_my_kvsname\n
-S: cmd=my_kvsname rc=0 kvsname=<string>\n
-----
-
-=== PMI_KVS_Put
+=== Key Value Store
 
 ----
 C: cmd=put kvsname=<string> key=<string> value=<string>\n
 S: cmd=put_result rc=1\n
 ----
 
-=== PMI_KVS_Get
+----
+C: cmd=get_my_kvsname\n
+S: cmd=my_kvsname rc=0 kvsname=<string>\n
+----
+
+----
+C: cmd=barrier_in\n
+S: cmd=barrier_out rc=0\n
+----
 
 ----
 C: cmd=get kvsname=<string> key=<string>\n
 S: cmd=get_result rc=0 value=<string>\n
 ----
 
-== PMI Version 1.1
+=== Dynamic Process Management
 
 TBD
 
-See https://github.com/flux-framework/flux-core/issues/665[flux-framework/flux-core#665]
+== MPI Quirks
+
+Process managers SHOULD take into account the following requirements
+specific to popular MPI implementations.
+
+=== MPICH
+
+TBD
+
+=== MVAPICH
+
+MVAPICH, a derivative of MPICH, requires the following environment variables
+to be set to enable PMI:
+
+* MPIRUN_NTASKS - set to the process group size
+* MPIRUN_RANK - set to the process rank
+* MPIRUN_RSH_LAUNCH - set to 1
+
+=== Intel MPI
+
+Intel MPI[6], a derivative of MPICH, requires the following environment
+variable to be set to enable PMI
+
+* I_PMI_MPI_LIBRARY - set to path of PMI library
+
+=== OpenMPI
+
+TBD
 
 == References
 

--- a/spec_13.adoc
+++ b/spec_13.adoc
@@ -603,6 +603,11 @@ S: cmd=maxes rc=0 kvsname_max=256 keylen_max=256 vallen_max=256\n
 ----
 
 ----
+C: cmd=abort exitcode=<integer>\n
+S: \n
+----
+
+----
 C: cmd=finalize\n
 S: cmd=finalize_ack rc=0\n
 ----
@@ -643,7 +648,51 @@ S: cmd=get_result rc=0 value=<string>\n
 
 === Dynamic Process Management
 
-TBD
+FIXME: This section needs testing and verification.
+
+----
+C: mcmd=spawn\n
+C: nprocs=<integer>\n
+C: execname=<string>\n
+C: totspawns=<integer>\n
+C: spawnssofar=<integer>\n
+C: arg0=<string>\n
+C: arg1=<string>\n
+C: ...
+C: argcnt=<integer>\n
+
+C: preput_num=<integer>\n
+C: preput_key_0=<string>\n
+C: preput_val_0=<string>\n
+C: preput_key_1=<string>\n
+C: preput_val_1=<string>\n
+C: ...
+
+C: info_num=<integer>\n
+C: info_key_0=<string>\n
+C: info_val_0=<string>\n
+C: info_key_1=<string>\n
+C: info_val_1=<string>\n
+C: ...
+C: endcmd\n
+
+S: cmd=spawn_result rc=0 errcodes 0,0,0,...\n
+----
+
+----
+C: cmd=publish_name service=<string> port=<string>\n
+S: cmd=publish_result rc=0 info=ok\n
+----
+
+----
+C: cmd=unpublish_name service=<string>\n
+S: cmd=unpublish_result rc=0 info=ok\n
+----
+
+----
+C: cmd=lookup_name service=<string>\n
+S: cmd=lookup_result rc=0 info=ok port=<string>\n
+----
 
 == MPI Quirks
 
@@ -652,7 +701,8 @@ specific to popular MPI implementations.
 
 === MPICH
 
-TBD
+If configured without specifying any PMI options, MPICH attempts to use
+the PMI-1 simple wire protocol.
 
 === MVAPICH
 

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -240,3 +240,10 @@ scalable
 LD
 runtime
 rpath
+OpenMPI
+mpiexec
+unpublish
+exascale
+MPIRUN
+NTASKS
+RSH

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -247,3 +247,14 @@ exascale
 MPIRUN
 NTASKS
 RSH
+argcnt
+endcmd
+errcodes
+execname
+exitcode
+FIXME
+mcmd
+nprocs
+ok
+spawnssofar
+totspawns


### PR DESCRIPTION
OK, more cleanup in this PMI-1 RFC. 

This update tightens up the description of PMI 1.0 versus 1.1, which it turns out can be only a wire protocol change; the PMI API can be the same across both versions to keep things simple for implementations.

This adds an MPI Quirks section where I thought we could try to collect things like environment varaibles and build-time configuration runes necessary to get specific implementations to use PMI-1, preferably configured in a way that doesn't couple the MPI to a specific process manager.