### PR TITLE
Add pdf make target for all docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,37 @@
-HTML = \
-	README.html \
-	spec_1.html \
-	spec_2.html \
-	spec_3.html \
-	spec_4.html \
-	spec_5.html \
-	spec_6.html \
-	spec_7.html \
-	spec_8.html \
-	spec_9.html \
-	spec_10.html \
-	spec_11.html \
-	spec_12.html \
-	spec_13.html \
-	spec_14.html
+SOURCES = \
+	README.adoc \
+	spec_1.adoc \
+	spec_2.adoc \
+	spec_3.adoc \
+	spec_4.adoc \
+	spec_5.adoc \
+	spec_6.adoc \
+	spec_7.adoc \
+	spec_8.adoc \
+	spec_9.adoc \
+	spec_10.adoc \
+	spec_11.adoc \
+	spec_12.adoc \
+	spec_13.adoc \
+	spec_14.adoc
 
-all: $(HTML)
+HTML = $(SOURCES:.adoc=.html)
+PDF = $(SOURCES:.adoc=.pdf)
+
+all: html
+
+html: $(HTML)
+
+pdf: $(PDF)
 
 %.html: %.adoc
 	asciidoc -o $@ $^
 
-clean:
-	rm -f $(HTML)
+%.pdf: %.adoc
+	a2x -f pdf $^
 
+clean:
+	rm -f $(HTML) $(PDF)
 
 check:
 	ASPELL=aspell ./spellcheck *.adoc

--- a/spec_10.adoc
+++ b/spec_10.adoc
@@ -177,6 +177,7 @@ blob            = 0*(OCTET)
 ; PROTO and [routing] are as defined in RFC 3.
 ----
 
+[sect2]
 == References
 
 * https://camlistore.org/[Camlistore is your personal storage system for life].

--- a/spec_13.adoc
+++ b/spec_13.adoc
@@ -787,6 +787,7 @@ If the process mapping value is too long to fit in a KVS value, the process
 manager SHALL return a value consisting of an empty string, indicating that
 the mapping is unknown.
 
+[sect2]
 == References
 
 * [1] https://drive.google.com/file/d/0B273EWJxZUxsbS15SEkzZGtXU2c/view?usp=sharing[Process Management in MPICH Draft 2.1]

--- a/spec_14.adoc
+++ b/spec_14.adoc
@@ -826,6 +826,7 @@ tasks:
     count:
       total: 10
 
+[sect2]
 == References
 
 * [1]http://yaml.org/spec/current.html#representation[YAML Ain't Markup Language (YAML™) Version 1.1], O. Ben-Kiki, C. Evans, B. Ingerson, 2004.

--- a/spec_3.adoc
+++ b/spec_3.adoc
@@ -253,6 +253,7 @@ sequence	= 4OCTET
 unused		= %x00.00.00.00
 ----
 
+[sect2]
 == References
 
 * http://www.rfc-editor.org/rfc/rfc7159.txt[RFC 7159: The JavaScript Object

--- a/spec_4.adoc
+++ b/spec_4.adoc
@@ -39,6 +39,8 @@ goals of this model are to:
 
 == Related Specifications
 
+TBD
+
 == Design
 
 The sections below describe in detail the Flux Resource Model


### PR DESCRIPTION
Add pdf make target that use a2x to convert asciidoc files
into pdf files.

a2x is using docbook, and docbook does not not like empty
sections or sections named "References".  We ad "TBD" to empty
sections to make them non-empty, and explicitly declare the
sections type as "[sect2]" for "== References" sections.

Note that an alternate way of dealing with the "References"
section name problem is to convert to using actual footnotes
and/or bibliography support in asciidoc.