### PR TITLE
rfc3: drop "cmb." prefix from broker services

### DIFF
--- a/spec_3.adoc
+++ b/spec_3.adoc
@@ -106,18 +106,12 @@ a set of words delimited by periods, in which the first word identifies
 the service, and remaining words represent _methods_ within that service.
 For example, "kvs.get" refers to the _get_ method of the _kvs_ service.
 
-Built-in broker services SHALL begin with "cmb.".  Services implemented by
-_comms modules_ (broker plugins)  SHALL begin with the name of the comms
-module.
-
 === Default Request Routing
 
 Request messages MAY be addressed to _any rank_ (FLUX_NODEID_ANY).
 Such messages SHALL be routed to the local broker, then to the
 first match in the following sequence:
 
-. If topic string begins with "cmb." and the sender is not the same rank
-  broker, the message SHALL be handled internally by the broker.
 . If topic string begins with a word matching a local comms module
   and the sender is not the same comms module attached to the same rank
   broker, the message SHALL be routed to the comms module.
@@ -142,11 +136,8 @@ that the message SHALL NOT be delivered on the sending node.
 === Rank Request Routing
 
 Request messages MAY be addressed to a specific rank.
-Such messages SHALL be routed to the target broker rank, then to the
-first match in the following sequence:
+Such messages SHALL be routed to the target broker rank, then as follows:
 
-. If topic string begins with "cmb." and the sender is not the same rank
-  broker, the message SHALL be handled internally by the broker
 . If topic string begins with a word matching a local comms module,
   the message SHALL be routed to the comms module.
 


### PR DESCRIPTION
Problem: the required "cmb." prefix on broker-resident
services makes it impossible to migrate the service
to a comms module without changing the protocol.

Drop this requirement.  The broker routing already uses
a service table rather than this tag to determine where
to route a given request message.  Indeed a large number
of broker-resident services have already dropped the cmb prefix.