### PR TITLE
Replace the "bootstrap instance" term with "system instance".

### DIFF
--- a/spec_12.adoc
+++ b/spec_12.adoc
@@ -46,14 +46,14 @@ Flux runs in single and multi-user mode.  A single-user Flux instance
 only launches work as the instance owner.  A multi-user Flux instance
 launches work as other users.
 
-The bootstrap instance of Flux runs as a system service started by
+The system instance of Flux runs as a system service started by
 systemd(8) or equivalent and runs in multi-user mode.  Other instances
 may run in single or multi-user mode, and may be launched by Flux,
 another resource manager, or with a standalone launcher.
 
 == Implementation
 
-This early draft is mainly focused on single-user, non-bootstrap
+This early draft is mainly focused on single-user, non-system
 Flux instances.
 
 === Instance Owner ===
@@ -64,7 +64,7 @@ SHALL have control over the instance and its resources; however,
 the instance owner SHALL NOT have the capability to launch work as
 other users without their consent.
 
-A bootstrap instance MAY run as a dedicated user, such as "flux".
+A system instance MAY run as a dedicated user, such as "flux".
 
 The instance owner SHALL NOT be the root user.
 

--- a/spec_8.adoc
+++ b/spec_8.adoc
@@ -168,16 +168,10 @@ initial programs, running initialization scripts and so on.
 
 == Bootstrap Mechanism
 
-The initial instance of a Flux installation SHALL be started under
-a bootstrap mechanism. The bootstrap mechanism SHALL provide the
-bare minimum services to simulate an enclosing instance, which
-will then be used to launch the initial instance. The bootstrap
-mechanism itself SHALL be launched by standard available process
-execution mechanisms and MAY use static configuration and/or database
-information to initialize and launch the initial Flux instance.
-The initial instance SHALL be a program with access to all resources
-that are to be managed by Flux.
-
+All instances of Flux SHALL be started under a bootstrap mechanism.
+The bootstrap mechanism SHALL provide the bare minimum
+services required to provide the processes with their initial configuration
+data and to assist them with network discovery.
 
 == Program Containers
 


### PR DESCRIPTION
We want to leave the term "bootstrap" as a verb that descibes
the process of starting up process, providing their initial
configuration information, and performing network discovery.

Instead we call the long-lived multi-user instance that is one
of the primary parent instances in cluster or center a "system
instance".

Since exact details of the "system instance" architecture are still
a hotly debated topic (e.g. whether or not the system instance spans
both management and compute nodes as a single instance), we leave
the "Bootstrap Mechanism" of spec 8 to only descript bootstrapping,
not system instances.  We can describe system instances later
when we know what exactly they are.