### PR TITLE
rfc7: Add rule about unique typedef names

### DIFF
--- a/spec_7.adoc
+++ b/spec_7.adoc
@@ -70,6 +70,10 @@ typedef struct foo_struct foo_t;
 ----
 Abstract types SHOULD NOT be defined as pointers to incomplete types,
 
+Typedef names SHOULD be chosen such that they are unique within a framework project.
+For example avoid generic types like `struct a` or typedefs like `ctx_t`. A good
+practice is to include the name of the relevant source file, module or service in
+the typedef (e.g. `fooservice_ctx_t`).
 
 Tools That Modify Code to Conform to C Coding Style
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -328,3 +328,5 @@ JSDL
 userid
 rolemask
 dequeue
+ctx
+fooservice


### PR DESCRIPTION
Add new rule to require that typedef names be unique
accross a project (e.g. avoid using ctx_t in multiple places).

This change was suggested in issue #972.