### PR TITLE
rfc7: Ban the use of "_struct" in structure tags.

### DIFF
--- a/spec_7.adoc
+++ b/spec_7.adoc
@@ -66,7 +66,7 @@ typedef int my_type_t;
 
 Abstract types SHOULD be publicly defined as incomplete types, for example:
 ----
-typedef struct foo_struct foo_t;
+typedef struct foo foo_t;
 ----
 Abstract types SHOULD NOT be defined as pointers to incomplete types,
 
@@ -74,6 +74,20 @@ Typedef names SHOULD be chosen such that they are unique within a framework proj
 For example avoid generic types like `struct a` or typedefs like `ctx_t`. A good
 practice is to include the name of the relevant source file, module or service in
 the typedef (e.g. `fooservice_ctx_t`).
+
+=== Structures
+
+Structure tags SHOULD NOT contain the string "struct".
+
+In the same way that we would not write:
+----
+int count_int;
+float val_float;
+----
+we also should not write:
+----
+struct foo_struct {};
+----
 
 Tools That Modify Code to Conform to C Coding Style
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Ban the use of "_struct" in structure tags.
