### PR TITLE
represent KVS values internally as opaque data, and cleanup

### DIFF
--- a/spec_11.adoc
+++ b/spec_11.adoc
@@ -26,7 +26,7 @@ be interpreted as described in http://tools.ietf.org/html/rfc2119[RFC 2119].
 == Goals
 
 * Facilitate services implementing private KVS namespaces.
-* Users may directly walk a KVS namespace, starting with a blobref/treeref.
+* Users may directly walk a KVS namespace, starting with a dirref.
 * Tree objects can be exchanged between Flux instances.
 * Tree objects can be parsed years after they were written (provenance).
 * Values exceeding the blob size limit (RFC 10) can be represented.
@@ -38,6 +38,9 @@ be interpreted as described in http://tools.ietf.org/html/rfc2119[RFC 2119].
 
 == Implementation
 
+In contrast to the original KVS prototype, in this specification, KVS
+values are unstructured, opaque data.
+
 All tree objects SHALL be represented as JSON objects containing three top
 level names:
 
@@ -47,14 +50,19 @@ level names:
 
 There are six types:
 
-* _valref_, data is an array of blobrefs comprising opaque data
-* _val_, data is a base64 string representing opaque data
-* _dirref_, data is an array of blobrefs comprising a _dir_ or _hdir_ object
-* _dir_, data is a map of names to tree objects
-* _hdir_, data is a map of integer-hashed names to _dirref_ objects
-* _symlink_, data is a hierarchical key name
+* _valref_, data is an array of blobrefs.  The concatenated blobs are
+an opaque data value (not a _val_ object).
+* _val_, data is a base64 string representing opaque data.
+* _dirref_, data is an array of blobrefs.  The concatenated blobs are
+interpreted as a _dir_ or _hdir_ object.
+* _dir_, data is a map of names to tree objects.
+* _hdir_, data is a map of integer-hashed names to _dirref_ objects.
+* _symlink_, data is a hierarchical key name.
 
 === Valref ===
+
+A _valref_ refers to opaque data in the content store (the actual data,
+not a _val_ object).
 
 ----
 { "ver":1,
@@ -65,6 +73,8 @@ There are six types:
 
 === Val ===
 
+A _val_ represents opaque data directly, base64-encoded.
+
 ----
 { "ver":1,
   "type":"val",
@@ -74,6 +84,9 @@ There are six types:
 
 === Dirref ===
 
+A _dirref_ refers to a _dir_ or _hdir_ object that was serialized and
+stored in the content store.
+
 ----
 { "ver":1,
   "type":"dirref",
@@ -82,6 +95,8 @@ There are six types:
 ----
 
 === Dir ===
+
+A _dir_ is a dictionary mapping keys to any of the tree object types.
 
 ----
 { "ver":1,
@@ -96,6 +111,10 @@ There are six types:
 ----
 
 === Hdir ===
+
+A _hdir_ is a dictionary mapping keys to any of the tree object types,
+though a level of indirection.  The _hdir_ object is for efficiently
+representing large directories.
 
 A _dir_ SHALL be converted to an _hdir_ once the number of entries exceeds
 a configurable _maxdirent_ value.  The _hdir_ SHALL have a fixed number of
@@ -121,6 +140,9 @@ _dirref_ object.
 ----
 
 === Symlink ===
+
+A _symlink_ is a symbolic pointer to a another KVS key, which may
+or may not be fully qualified.
 
 ----
 { "ver":1,

--- a/spec_11.adoc
+++ b/spec_11.adoc
@@ -43,23 +43,23 @@ level names:
 
 * _ver_, an integer version number
 * _type_, a string type name
-* _val_, a type dependent JSON object
+* _data_, a type dependent JSON object
 
 There are six types:
 
-* _valref_, val is an array of blobrefs comprising opaque data
-* _treeref_, val is an array of blobrefs comprising a tree object
-* _dir_, val is a map of names to tree objects
-* _hdir_, val is a map of integer-hashed names to _treeref_ objects
-* _symlink_, val is a hierarchical key name
-* _value_, val is an arbitrary JSON object, array, or value
+* _valref_, data is an array of blobrefs comprising opaque data
+* _treeref_, data is an array of blobrefs comprising a tree object
+* _dir_, data is a map of names to tree objects
+* _hdir_, data is a map of integer-hashed names to _treeref_ objects
+* _symlink_, data is a hierarchical key name
+* _value_, data is an arbitrary JSON object, array, or value
 
 === Valref ===
 
 ----
 { "ver":1,
   "type":"valref",
-  "val":["sha1-aaa...","sha1-bbb...",...],
+  "data":["sha1-aaa...","sha1-bbb...",...],
 }
 ----
 
@@ -68,7 +68,7 @@ There are six types:
 ----
 { "ver":1,
   "type":"treeref",
-  "val":["sha1-aaa...","sha1-bbb...",...],
+  "data":["sha1-aaa...","sha1-bbb...",...],
 }
 ----
 
@@ -77,11 +77,11 @@ There are six types:
 ----
 { "ver":1,
   "type":"dir",
-  "val":{
-     "a":{"ver":1,"type":"treeref","val":["sha1-aaa"]},
-     "b":{"ver":1,"type":"value","val":42}
-     "c":{"ver":1,"type":"valref","val":["sha1-aaa","sha1-bbb"]},
-     "d":{"ver":1,"type":"dir","val":{...},
+  "data":{
+     "a":{"ver":1,"type":"treeref","data":["sha1-aaa"]},
+     "b":{"ver":1,"type":"value","data":42}
+     "c":{"ver":1,"type":"valref","data":["sha1-aaa","sha1-bbb"]},
+     "d":{"ver":1,"type":"dir","data":{...},
   }
 }
 ----
@@ -97,14 +97,14 @@ Hash buckets MAY be sparsely populated.
 ----
 { "ver":1,
   "type":"hdir",
-  "val":{
+  "data":{
     "size":8,
     "func":"city32",
     "bucket":[
-      {"ver":1,"type":"treeref","val":["sha1-aaa"]},
+      {"ver":1,"type":"treeref","data":["sha1-aaa"]},
       ,,,,,
-      {"ver":1,"type":"treeref","val":["sha1-eee"]},
-      {"ver":1,"type":"treeref","val":["sha1-fff"]},
+      {"ver":1,"type":"treeref","data":["sha1-eee"]},
+      {"ver":1,"type":"treeref","data":["sha1-fff"]},
     ]
   }
 }
@@ -115,7 +115,7 @@ Hash buckets MAY be sparsely populated.
 ----
 { "ver":1,
   "type":"symlink",
-  "val":"a.aa",
+  "data":"a.aa",
 }
 ----
 
@@ -124,7 +124,7 @@ Hash buckets MAY be sparsely populated.
 ----
 { "ver":1,
   "type":"value",
-  "val":42,
+  "data":42,
 }
 ----
 

--- a/spec_11.adoc
+++ b/spec_11.adoc
@@ -48,11 +48,11 @@ level names:
 There are six types:
 
 * _valref_, data is an array of blobrefs comprising opaque data
+* _val_, data is a base64 string representing opaque data
 * _dirref_, data is an array of blobrefs comprising a _dir_ or _hdir_ object
 * _dir_, data is a map of names to tree objects
 * _hdir_, data is a map of integer-hashed names to _dirref_ objects
 * _symlink_, data is a hierarchical key name
-* _value_, data is an arbitrary JSON object, array, or value
 
 === Valref ===
 
@@ -60,6 +60,15 @@ There are six types:
 { "ver":1,
   "type":"valref",
   "data":["sha1-aaa...","sha1-bbb...",...],
+}
+----
+
+=== Val ===
+
+----
+{ "ver":1,
+  "type":"val",
+  "data":"NDIyCg==",
 }
 ----
 
@@ -79,7 +88,7 @@ There are six types:
   "type":"dir",
   "data":{
      "a":{"ver":1,"type":"dirref","data":["sha1-aaa"]},
-     "b":{"ver":1,"type":"value","data":42}
+     "b":{"ver":1,"type":"val","data":"NDIyCg=="}
      "c":{"ver":1,"type":"valref","data":["sha1-aaa","sha1-bbb"]},
      "d":{"ver":1,"type":"dir","data":{...},
   }
@@ -119,14 +128,4 @@ _dirref_ object.
   "data":"a.aa",
 }
 ----
-
-=== Value ===
-
-----
-{ "ver":1,
-  "type":"value",
-  "data":42,
-}
-----
-
 

--- a/spec_11.adoc
+++ b/spec_11.adoc
@@ -48,9 +48,9 @@ level names:
 There are six types:
 
 * _valref_, data is an array of blobrefs comprising opaque data
-* _treeref_, data is an array of blobrefs comprising a tree object
+* _dirref_, data is an array of blobrefs comprising a _dir_ or _hdir_ object
 * _dir_, data is a map of names to tree objects
-* _hdir_, data is a map of integer-hashed names to _treeref_ objects
+* _hdir_, data is a map of integer-hashed names to _dirref_ objects
 * _symlink_, data is a hierarchical key name
 * _value_, data is an arbitrary JSON object, array, or value
 
@@ -63,11 +63,11 @@ There are six types:
 }
 ----
 
-=== Treeref ===
+=== Dirref ===
 
 ----
 { "ver":1,
-  "type":"treeref",
+  "type":"dirref",
   "data":["sha1-aaa...","sha1-bbb...",...],
 }
 ----
@@ -78,7 +78,7 @@ There are six types:
 { "ver":1,
   "type":"dir",
   "data":{
-     "a":{"ver":1,"type":"treeref","data":["sha1-aaa"]},
+     "a":{"ver":1,"type":"dirref","data":["sha1-aaa"]},
      "b":{"ver":1,"type":"value","data":42}
      "c":{"ver":1,"type":"valref","data":["sha1-aaa","sha1-bbb"]},
      "d":{"ver":1,"type":"dir","data":{...},
@@ -92,7 +92,8 @@ A _dir_ SHALL be converted to an _hdir_ once the number of entries exceeds
 a configurable _maxdirent_ value.  The _hdir_ SHALL have a fixed number of
 buckets represented by _size_, fixed when the _hdir_ is created.  The hash
 function used to map keys to buckets SHALL be identified with _func_.
-Hash buckets MAY be sparsely populated.
+Hash buckets MAY be sparsely populated.  Each hash bucket contains a single
+_dirref_ object.
 
 ----
 { "ver":1,
@@ -101,10 +102,10 @@ Hash buckets MAY be sparsely populated.
     "size":8,
     "func":"city32",
     "bucket":[
-      {"ver":1,"type":"treeref","data":["sha1-aaa"]},
+      {"ver":1,"type":"dirref","data":["sha1-aaa"]},
       ,,,,,
-      {"ver":1,"type":"treeref","data":["sha1-eee"]},
-      {"ver":1,"type":"treeref","data":["sha1-fff"]},
+      {"ver":1,"type":"dirref","data":["sha1-eee"]},
+      {"ver":1,"type":"dirref","data":["sha1-fff"]},
     ]
   }
 }

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -140,7 +140,6 @@ blobrefs
 dir
 namespaces
 symlink
-treeref
 valref
 ver
 Google
@@ -360,3 +359,6 @@ Provos
 alice
 minimumDuration
 truncatable
+dirref
+Dirref
+NDIyCg


### PR DESCRIPTION
_Note: This spec was proposed a while back but never implemented.  We're now getting around to that, and I'm working with @chu11 to refine the spec and work out implementation details.  Once we're further along, I'll write some descriptive text to document this better._

This PR proposes that KVS values be internally represented as unstructured, opaque data, rather than requiring them to be JSON.  The previous specification was kind of trying to have it both ways with the _value_ object that was JSON and a _valref_ object that referred to opaque data in the content store.

Note that API's won't have to change - the main API's can remain JSON oriented, but internally the KVS will treat values as opaque.  We'll add functions for accessing the raw data too so users won't have to layer on base64 encoding when they want to do that.  The `flux-kvs` command will likely require some fine tuning where it expects values to be JSON.

The rest of this PR is cleanup:
* renamed _treeref_ to _dirref_, and constrained its use to only refer to directories
* renamed _value_ to _val_  so now we have _valref_ and _val_, _dirref_ and _dir_; and changed _val_ to always represent value as a base64 string as discussed above
* renamed JSON object key from `val` to `data` to avoid confusion with the _val_ object

