### PR TITLE
Break out examples

### DIFF
--- a/data/spec_14/example1.yaml
+++ b/data/spec_14/example1.yaml
@@ -1,0 +1,19 @@
+version: 1
+resources:
+  - type: node
+    count: 4
+    with:
+      - type: slot
+        count: 1
+        label: default
+        with:
+          - type: core
+            count: 2
+tasks:
+  - command: app
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 1 hour

--- a/data/spec_14/example2.yaml
+++ b/data/spec_14/example2.yaml
@@ -1,0 +1,16 @@
+version: 1
+resources:
+  - type: slot
+    count: 4
+    label: default
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: hostname
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 1 hour

--- a/data/spec_14/use_case_1.1.yaml
+++ b/data/spec_14/use_case_1.1.yaml
@@ -1,0 +1,16 @@
+version: 1
+resources:
+  - type: slot
+    count: 4
+    label: default
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: [ "flux", "start" ]
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 1 hour

--- a/data/spec_14/use_case_1.2.yaml
+++ b/data/spec_14/use_case_1.2.yaml
@@ -1,0 +1,20 @@
+version: 1
+resources:
+  - type: slot
+    count:
+      min: 3
+      max: 30
+      operator: "+"
+      operand: 1
+    label: default
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: [ "flux", "start" ]
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 1 hour

--- a/data/spec_14/use_case_1.3.yaml
+++ b/data/spec_14/use_case_1.3.yaml
@@ -1,0 +1,23 @@
+version: 1
+resources:
+  - type: slot
+    count: 4
+    label: default
+    with:
+    - type: node
+      count: 1
+      with:
+        - type: socket
+          count: 2
+          with:
+            - type: core
+              count: 4
+tasks:
+  - command: [ "flux", "start" ]
+    slot:
+      type: node
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 1 hour

--- a/data/spec_14/use_case_1.4.yaml
+++ b/data/spec_14/use_case_1.4.yaml
@@ -1,0 +1,21 @@
+version: 1
+resources:
+  - type: slot
+    with:
+    - type: node
+      count: 4
+      with:
+        - type: socket
+          count: 2
+          with:
+            - type: core
+              count: 4
+tasks:
+  - command: [ "flux", "start" ]
+    slot:
+      type: node
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 1 hour

--- a/data/spec_14/use_case_1.5.yaml
+++ b/data/spec_14/use_case_1.5.yaml
@@ -1,0 +1,41 @@
+version: 1
+resources:
+  - type: cluster
+    count: 1
+    with:
+      - type: slot
+        count: 2
+        label: ib
+        with:
+          - type: node
+            count: 1
+            with:
+              - type: memory
+                count: 4
+                unit: GB
+              - type: ib10g
+                count: 1
+  - type: switch
+    count: 1
+    with:
+      - type: slot
+        count: 2
+        label: bicore
+        with:
+          - type: node
+            count: 1
+            with:
+              - type: core
+                count: 2
+tasks:
+  - command: [ "flux", "start" ]
+    slot: ib
+    count:
+      per_slot: 1
+  - command: [ "flux", "start" ]
+    slot: bicore
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 4 hours

--- a/data/spec_14/use_case_1.6.yaml
+++ b/data/spec_14/use_case_1.6.yaml
@@ -1,0 +1,22 @@
+version: 1
+resources:
+    - type: cluster
+      count: 2
+      with:
+          - type: node
+            count: 15
+            with:
+                - type: slot
+                  count: 1
+                  label: default
+                  with:
+                    - type: core
+                      count: 1
+tasks:
+  - command: [ "flux", "start" ]
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 1 hour

--- a/data/spec_14/use_case_1.7.yaml
+++ b/data/spec_14/use_case_1.7.yaml
@@ -1,0 +1,19 @@
+version: 1
+resources:
+  - type: switch
+    count: 3
+    with:
+      - type: slot
+        count: 1
+        label: default
+        with:
+          - type: core
+            count: 1
+tasks:
+  - command: [ "flux", "start" ]
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 1h

--- a/data/spec_14/use_case_2.1.yaml
+++ b/data/spec_14/use_case_2.1.yaml
@@ -1,0 +1,16 @@
+version: 1
+resources:
+  - type: slot
+    label: default
+    count: 4
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: hostname
+    slot: default
+    count:
+      per_slot: 5
+attributes:
+  system:
+    duration: 1 hour

--- a/data/spec_14/use_case_2.2.yaml
+++ b/data/spec_14/use_case_2.2.yaml
@@ -1,0 +1,16 @@
+version: 1
+resources:
+  - type: slot
+    count: 4
+    label: myslot
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: hostname
+    slot: myslot
+    count:
+      total: 5
+attributes:
+  system:
+    duration: 1 hour

--- a/data/spec_14/use_case_2.3.yaml
+++ b/data/spec_14/use_case_2.3.yaml
@@ -1,0 +1,16 @@
+version: 1
+resources:
+  - type: slot
+    label: default
+    count: 10
+    with:
+      - type: core
+        count: 2
+tasks:
+  - command: myapp
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 1 hour

--- a/data/spec_14/use_case_2.4.yaml
+++ b/data/spec_14/use_case_2.4.yaml
@@ -1,0 +1,35 @@
+version: 1
+resources:
+  - type: node
+    count: 1
+    with:
+      - type: slot
+        label: read-db
+        count: 10
+        with:
+          - type: core
+            count: 1
+          - type: memory
+            count: 4
+            unit: GB
+      - type: slot
+        label: db
+        count: 1
+        with:
+          - type: core
+            count: 6
+          - type: memory
+            count: 24
+            unit: GB
+tasks:
+  - command: read-db
+    slot: read-db
+    count:
+      per_slot: 1
+  - command: db
+    slot: db
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 1 hour

--- a/data/spec_14/use_case_2.5.yaml
+++ b/data/spec_14/use_case_2.5.yaml
@@ -1,0 +1,19 @@
+version: 1
+resources:
+  - type: slot
+    label: default
+    count: 10
+    with:
+    - type: memory
+      count: 2
+      unit: GB
+    - type: core
+      count: 1
+tasks:
+  - command: app
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 1 hour

--- a/data/spec_14/use_case_2.6.yaml
+++ b/data/spec_14/use_case_2.6.yaml
@@ -1,0 +1,20 @@
+version: 1
+resources:
+  - type: slot
+    label: 4GB-node
+    count: 2
+    with:
+    - type: node
+      count: 1
+      with:
+        - type: memory
+          count: 4
+          unit: GB
+tasks:
+  - command: app
+    slot: 4GB-node
+    count:
+      total: 10
+attributes:
+  system:
+    duration: 1 hour

--- a/spec_14.adoc
+++ b/spec_14.adoc
@@ -182,7 +182,8 @@ provided SHALL be local to the namespace of the current jobspec.
 +
 A task slot SHALL have at least one edge specified using `with:`, and
 the resources associated with a slot SHALL be exclusively allocated
-to the program described in the jobspec.
+to the program described in the jobspec, unless otherwise specified
+in the `exclusive` field of the associated resource.
 
 === Tasks
 
@@ -196,18 +197,11 @@ descriptor SHALL contain the following keys:
  an executable and its arguments.
 
  *slot*::
- The value of the `slot` key SHALL be used to indicate the *task slot*
+ The value of the `slot` key SHALL match a `label` of a resource vertex
+ of type `slot`.  It is used to indicate the *task slot*
  on which this task or tasks shall be contained and executed. The
  number of tasks executed per task slot SHALL be a function of the
  number of resource slots and total number of tasks requested to execute.
-+
-The value of the `slot` key SHALL be a dictionary with supported key
-of either `label` or `type`. The `label` key SHALL reference a `label`
-of a resource vertex of type `slot`, indicating an explicitly created
-and named *task slot*. The `type` key SHALL reference a real resource type,
-such as `core` or `node`, indicating an implicitly created *task slot* on
-which to map the defined tasks.  `type` SHALL NOT be `slot`; slots must
-be referred to by their `label`.
 
  *count*::
  The value of the `count` key SHALL be a dictionary supporting at least
@@ -285,8 +279,7 @@ resources:
             count: 2
 tasks:
   - command: app
-    slot:
-      label: default
+    slot: default
     count:
       per_slot: 1
 attributes:
@@ -294,19 +287,21 @@ attributes:
     duration: 1 hour
 ----
 
-A simpler example using implicit *task slot* definition to run 4 tasks
-across 4 nodes
+Another example, running one task on each of four nodes.
 
 [source,yaml]
 ----
 version: 1
 resources:
-  - type: node
+  - type: slot
     count: 4
+    label: default
+    with:
+      - type: node
+        count: 1
 tasks:
   - command: hostname
-    slot:
-      type: node
+    slot: default
     count:
       per_slot: 1
 attributes:
@@ -330,7 +325,7 @@ draft version 0.6.
    "version" : 1
 }
 
-$label := string
+$slot_label := string
 
 $vertex_common = {
     "count" : ( 1.. | $complex_range),
@@ -340,7 +335,7 @@ $vertex_common = {
 
 slot_vertex = {
     "type"  : "slot",
-    "label" : $label,
+    "label" : $slot_label,
     $vertex_common,
 }
 
@@ -362,7 +357,7 @@ $complex_range = {
 
 $tasks = {
     "command" : [ string + ],
-    "slot" : { "label" : string  | "type": string },
+    "slot" : $slot_label,
     "count" : { "per_slot" : 1.. | "total" : 1.. },
     "distribution" : string,
     ?"attributes" : { /.*/ : any },
@@ -410,12 +405,15 @@ Jobspec YAML::
 [source,yaml]
 version: 1
 resources:
-  - type: node
+  - type: slot
     count: 4
+    label: default
+    with:
+      - type: node
+        count: 1
 tasks:
   - command: [ "flux", "start" ]
-    slot:
-      type: node
+    slot: default
     count:
       per_slot: 1
 attributes:
@@ -438,16 +436,19 @@ Jobspec YAML::
 [source,yaml]
 version: 1
 resources:
-  - type: node
+  - type: slot
     count:
       min: 3
       max: 30
       operator: "+"
       operand: 1
+    label: default
+    with:
+      - type: node
+        count: 1
 tasks:
   - command: [ "flux", "start" ]
-    slot:
-      type: node
+    slot: default
     count:
       per_slot: 1
 attributes:
@@ -467,21 +468,25 @@ Existing Equivalents::
 | Slurm (a)| `srun -N4 --sockets-per-node=2 --cores-per-socket=4`
 | Slurm (b)| `srun -N4 -B '2:4:*'`
 | OAR      | `oarsub -l nodes=4/sockets=2/cores=4`
-|=== 
+|===
 +
 Jobspec YAML::
 +
 [source,yaml]
 version: 1
 resources:
-  - type: node
+  - type: slot
     count: 4
+    label: default
     with:
-      - type: socket
-        count: 2
-        with:
-          - type: core
-            count: 4
+    - type: node
+      count: 1
+      with:
+        - type: socket
+          count: 2
+          with:
+            - type: core
+              count: 4
 tasks:
   - command: [ "flux", "start" ]
     slot:
@@ -548,25 +553,37 @@ resources:
   - type: cluster
     count: 1
     with:
-      - type: node
+      - type: slot
         count: 2
+        label: ib
         with:
-          - type: memory
-            count: 4
-            unit: GB
-          - type: ib10g
-            count: 4
-      - type: switch
-        with:
-          type: node
-            count: 2
+          - type: node
+            count: 1
             with:
-                - type: core
-                  count: 1
+              - type: memory
+                count: 4
+                unit: GB
+              - type: ib10g
+                count: 1
+  - type: switch
+    count: 1
+    with:
+      - type: slot
+        count: 2
+        label: bicore
+        with:
+          - type: node
+            count: 1
+            with:
+              - type: core
+                count: 2
 tasks:
   - command: [ "flux", "start" ]
-    slot:
-      type: node
+    slot: ib
+    count:
+      per_slot: 1
+  - command: [ "flux", "start" ]
+    slot: bicore
     count:
       per_slot: 1
 attributes:
@@ -596,12 +613,15 @@ resources:
           - type: node
             count: 15
             with:
-              - type: core
-                count: 1
+                - type: slot
+                  count: 1
+                  label: default
+                  with:
+                    - type: core
+                      count: 1
 tasks:
   - command: [ "flux", "start" ]
-    slot:
-      type: node
+    slot: default
     count:
       per_slot: 1
 attributes:
@@ -628,12 +648,15 @@ resources:
   - type: switch
     count: 3
     with:
-      - type: core
+      - type: slot
         count: 1
+        label: default
+        with:
+          - type: core
+            count: 1
 tasks:
   - command: [ "flux", "start" ]
-    slot:
-      type: node
+    slot: default
     count:
       per_slot: 1
 attributes:
@@ -669,8 +692,8 @@ resources:
     label: default
     count: 4
     with:
-    - type: node
-      count: 1
+      - type: node
+        count: 1
 tasks:
   - command: hostname
     slot: default
@@ -698,25 +721,6 @@ Jobspec YAML::
 ----
 version: 1
 resources:
-  - type: node
-    count: 4
-tasks:
-  - command: hostname
-    slot:
-      type: node
-    count:
-      total: 5
-attributes:
-  system:
-    duration: 1 hour
-----
-+
-or, with explicit task slots:
-+
-[source,yaml]
-----
-version: 1
-resources:
   - type: slot
     count: 4
     label: myslot
@@ -725,14 +729,12 @@ resources:
         count: 1
 tasks:
   - command: hostname
-    slot:
-      label: myslot
+    slot: myslot
     count:
       total: 5
 attributes:
   system:
     duration: 1 hour
-
 ----
 
 '''
@@ -771,8 +773,8 @@ attributes:
 Use Case 2.4:: Run different binaries with differing resource
 requirements as single program
 +
-Specific Example:: 11 tasks, one node, first 10 using one core and 4G of RAM for
-`read-db`, last using 6 cores and 24G of RAM for `db`
+Specific Example:: 11 tasks, one node, the first 10 tasks each using one core and 4G of RAM for
+`read-db`, the last task using 6 cores and 24G of RAM for `db`
 +
 Existing Equivalents:: None Known
 +
@@ -782,6 +784,7 @@ Jobspec YAML::
 version: 1
 resources:
   - type: node
+    count: 1
     with:
       - type: slot
         label: read-db

--- a/spec_14.adoc
+++ b/spec_14.adoc
@@ -266,47 +266,14 @@ task slot for a total of 4 tasks.
 
 [source,yaml]
 ----
-version: 1
-resources:
-  - type: node
-    count: 4
-    with:
-      - type: slot
-        count: 1
-        label: default
-        with:
-          - type: core
-            count: 2
-tasks:
-  - command: app
-    slot: default
-    count:
-      per_slot: 1
-attributes:
-  system:
-    duration: 1 hour
+include::data/spec_14/example1.yaml[]
 ----
 
 Another example, running one task on each of four nodes.
 
 [source,yaml]
 ----
-version: 1
-resources:
-  - type: slot
-    count: 4
-    label: default
-    with:
-      - type: node
-        count: 1
-tasks:
-  - command: hostname
-    slot: default
-    count:
-      per_slot: 1
-attributes:
-  system:
-    duration: 1 hour
+include::data/spec_14/example2.yaml[]
 ----
 
 === Content Rules
@@ -403,23 +370,9 @@ Existing Equivalents::
 Jobspec YAML::
 +
 [source,yaml]
-version: 1
-resources:
-  - type: slot
-    count: 4
-    label: default
-    with:
-      - type: node
-        count: 1
-tasks:
-  - command: [ "flux", "start" ]
-    slot: default
-    count:
-      per_slot: 1
-attributes:
-  system:
-    duration: 1 hour
-
+----
+include::data/spec_14/use_case_1.1.yaml[]
+----
 '''
 Use Case 1.2:: Request a range of a type of resource
 +
@@ -434,26 +387,9 @@ Existing Equivalents::
 Jobspec YAML::
 +
 [source,yaml]
-version: 1
-resources:
-  - type: slot
-    count:
-      min: 3
-      max: 30
-      operator: "+"
-      operand: 1
-    label: default
-    with:
-      - type: node
-        count: 1
-tasks:
-  - command: [ "flux", "start" ]
-    slot: default
-    count:
-      per_slot: 1
-attributes:
-  system:
-    duration: 1 hour
+----
+include::data/spec_14/use_case_1.2.yaml[]
+----
 
 '''
 Use Case 1.3:: Request M nodes with a minimum number of sockets per node
@@ -473,29 +409,9 @@ Existing Equivalents::
 Jobspec YAML::
 +
 [source,yaml]
-version: 1
-resources:
-  - type: slot
-    count: 4
-    label: default
-    with:
-    - type: node
-      count: 1
-      with:
-        - type: socket
-          count: 2
-          with:
-            - type: core
-              count: 4
-tasks:
-  - command: [ "flux", "start" ]
-    slot:
-      type: node
-    count:
-      per_slot: 1
-attributes:
-  system:
-    duration: 1 hour
+----
+include::data/spec_14/use_case_1.1.yaml[]
+----
 
 '''
 Use Case 1.4:: Exclusively allocate nodes, while constraining cores and
@@ -507,27 +423,9 @@ least two sockets and 4 cores per socket:
 Jobspec YAML::
 +
 [source,yaml]
-version: 1
-resources:
-  - type: slot
-    with:
-    - type: node
-      count: 4
-      with:
-        - type: socket
-          count: 2
-          with:
-            - type: core
-              count: 4
-tasks:
-  - command: [ "flux", "start" ]
-    slot:
-      type: node
-    count:
-      per_slot: 1
-attributes:
-  system:
-    duration: 1 hour
+----
+include::data/spec_14/use_case_1.4.yaml[]
+----
 
 '''
 Use Case 1.5:: Complex example from OAR
@@ -548,47 +446,9 @@ Existing Equivalents::
 Jobspec YAML::
 +
 [source,yaml]
-version: 1
-resources:
-  - type: cluster
-    count: 1
-    with:
-      - type: slot
-        count: 2
-        label: ib
-        with:
-          - type: node
-            count: 1
-            with:
-              - type: memory
-                count: 4
-                unit: GB
-              - type: ib10g
-                count: 1
-  - type: switch
-    count: 1
-    with:
-      - type: slot
-        count: 2
-        label: bicore
-        with:
-          - type: node
-            count: 1
-            with:
-              - type: core
-                count: 2
-tasks:
-  - command: [ "flux", "start" ]
-    slot: ib
-    count:
-      per_slot: 1
-  - command: [ "flux", "start" ]
-    slot: bicore
-    count:
-      per_slot: 1
-attributes:
-  system:
-    duration: 4 hours
+----
+include::data/spec_14/use_case_1.5.yaml[]
+----
 
 '''
 Use Case 1.6:: Request resources across multiple clusters
@@ -605,28 +465,9 @@ Existing Equivalents::
 Jobspec YAML::
 +
 [source,yaml]
-version: 1
-resources:
-    - type: cluster
-      count: 2
-      with:
-          - type: node
-            count: 15
-            with:
-                - type: slot
-                  count: 1
-                  label: default
-                  with:
-                    - type: core
-                      count: 1
-tasks:
-  - command: [ "flux", "start" ]
-    slot: default
-    count:
-      per_slot: 1
-attributes:
-  system:
-    duration: 1 hour
+----
+include::data/spec_14/use_case_1.6.yaml[]
+----
 
 '''
 Use Case 1.7:: Request N cores across M switches
@@ -643,25 +484,9 @@ Existing Equivalents::
 Jobspec YAML::
 +
 [source,yaml]
-version: 1
-resources:
-  - type: switch
-    count: 3
-    with:
-      - type: slot
-        count: 1
-        label: default
-        with:
-          - type: core
-            count: 1
-tasks:
-  - command: [ "flux", "start" ]
-    slot: default
-    count:
-      per_slot: 1
-attributes:
-  system:
-    duration: 1h
+----
+include::data/spec_14/use_case_1.7.yaml[]
+----
 
 '''
 
@@ -686,22 +511,9 @@ Existing Equivalents::
 Jobspec YAML::
 +
 [source,yaml]
-version: 1
-resources:
-  - type: slot
-    label: default
-    count: 4
-    with:
-      - type: node
-        count: 1
-tasks:
-  - command: hostname
-    slot: default
-    count:
-      per_slot: 5
-attributes:
-  system:
-    duration: 1 hour
+----
+include::data/spec_14/use_case_2.1.yaml[]
+----
 
 '''
 Use Case 2.2:: Run N tasks across M nodes, unequal distribution
@@ -719,22 +531,7 @@ Jobspec YAML::
 +
 [source,yaml]
 ----
-version: 1
-resources:
-  - type: slot
-    count: 4
-    label: myslot
-    with:
-      - type: node
-        count: 1
-tasks:
-  - command: hostname
-    slot: myslot
-    count:
-      total: 5
-attributes:
-  system:
-    duration: 1 hour
+include::data/spec_14/use_case_2.2.yaml[]
 ----
 
 '''
@@ -752,22 +549,9 @@ Existing Equivalents::
 Jobspec YAML::
 +
 [source,yaml]
-version: 1
-resources:
-  - type: slot
-    label: default
-    count: 10
-    with:
-      - type: core
-        count: 2
-tasks:
-  - command: myapp
-    slot: default
-    count:
-      per_slot: 1
-attributes:
-  system:
-    duration: 1 hour
+----
+include::data/spec_14/use_case_2.3.yaml[]
+----
 
 '''
 Use Case 2.4:: Run different binaries with differing resource
@@ -781,41 +565,9 @@ Existing Equivalents:: None Known
 Jobspec YAML::
 +
 [source,yaml]
-version: 1
-resources:
-  - type: node
-    count: 1
-    with:
-      - type: slot
-        label: read-db
-        count: 10
-        with:
-          - type: core
-            count: 1
-          - type: memory
-            count: 4
-            unit: GB
-      - type: slot
-        label: db
-        count: 1
-        with:
-          - type: core
-            count: 6
-          - type: memory
-            count: 24
-            unit: GB
-tasks:
-  - command: read-db
-    slot: read-db
-    count:
-      per_slot: 1
-  - command: db
-    slot: db
-    count:
-      per_slot: 1
-attributes:
-  system:
-    duration: 1 hour
+----
+include::data/spec_14/use_case_2.4.yaml[]
+----
 
 '''
 Use Case 2.5:: Run command requesting minimum amount of RAM per core
@@ -833,25 +585,7 @@ Jobspec YAML::
 +
 [source,yaml]
 ----
-version: 1
-resources:
-  - type: slot
-    label: default
-    count: 10
-    with:
-    - type: memory
-      count: 2
-      unit: GB
-    - type: core
-      count: 1
-tasks:
-  - command: app
-    slot: default
-    count:
-      per_slot: 1
-attributes:
-  system:
-    duration: 1 hour
+include::data/spec_14/use_case_2.5.yaml[]
 ----
 '''
 Use Case 2.6:: Run N copies of a command with minimum amount of RAM per node
@@ -869,26 +603,9 @@ Existing Equivalents::
 Jobspec YAML::
 +
 [source,yaml]
-version: 1
-resources:
-  - type: slot
-    label: 4GB-node
-    count: 2
-    with:
-    - type: node
-      count: 1
-      with:
-        - type: memory
-          count: 4
-          unit: GB
-tasks:
-  - command: app
-    slot: 4GB-node
-    count:
-      total: 10
-attributes:
-  system:
-    duration: 1 hour
+----
+include::data/spec_14/use_case_2.6.yaml[]
+----
 
 [sect2]
 == References


### PR DESCRIPTION
All of the jobspec yaml examples are broken out into individual
files.  This will make it easier to run each example through an
automated validator in the future.
