### PR TITLE
rfc16: add KVS Job Schema RFC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ SOURCES = \
 	spec_13.adoc \
 	spec_14.adoc \
 	spec_15.adoc \
+	spec_16.adoc \
 
 HTML = $(SOURCES:.adoc=.html)
 PDF = $(SOURCES:.adoc=.pdf)

--- a/README.adoc
+++ b/README.adoc
@@ -90,6 +90,10 @@ This specification describes Flux Security IMP, a privileged service
 used by multi-user Flux instances to launch, monitor, and control
 processes running as users other than the instance owner.
 
+link:spec_16{outfilesuffix}[16/KVS Job Schema]::
+This specification describes the format of data stored in the KVS
+for Flux jobs.
+
 
 == Change Process
 

--- a/spec_16.adoc
+++ b/spec_16.adoc
@@ -1,0 +1,226 @@
+ifdef::env-github[:outfilesuffix: .adoc]
+
+16/KVS Job Schema
+=================
+
+This specification describes the format of data stored in the KVS
+for Flux jobs.
+
+* Name: github.com/flux-framework/rfc/spec_16.adoc
+* Editor: Jim Garlick <garlick@llnl.gov>
+* State: raw
+
+== Language
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
+be interpreted as described in http://tools.ietf.org/html/rfc2119[RFC 2119].
+
+== Related Standards
+
+*  link:spec_12{outfilesuffix}[12/Flux Security Architecture]
+
+== Background
+
+=== Components that use the KVS job schema
+
+Instance components have direct, read/write access to the primary KVS
+namespace:
+
+* _Ingest agent_
+* _Job management service_ (list, cancel, etc.)
+* _Exec service_
+* _Scheduler_
+
+Guest components have direct, read/write access to a private KVS namespace:
+
+* _Job shell_
+* _User tasks_
+* `flux-run` command
+* `flux-queue` command
+* `flux-cancel` command
+
+=== Job Life Cycle
+
+Jobs are submitted to the _ingest agent_ which performs a sanity
+check on the request and either adds the job to the KVS or
+refuses to accept it.
+
+The _scheduler_ takes up submitted jobs and considers them against
+the available resources.  It either rejects the job outright,
+or annotates it and eventually assigns resources to it.
+
+The _exec service_ takes up jobs that have assigned resources,
+instantiates containers for those jobs and starts job shells
+within them.  When job shells and their containers start to exit,
+the _exec service_ "reaps" these shells and allows the _scheduler_
+to reclaim resources assigned to each container.
+
+Jobs therefore transition between the following states,
+not necessarily in a linear order:
+
+submitted::
+  accepted by ingest, resources not yet assigned
+
+runnable::
+  resources assigned
+
+starting::
+  first container started
+
+running::
+  all containers instantiated and job shells started
+
+exiting::
+  first container exited
+
+completed::
+  all containers exited
+
+rejected::
+  scheduler won't run job
+
+== Implementation
+
+=== Primary KVS Namespace
+
+The Flux instance has a default, shared namespace that is accessible
+only by the instance owner.
+
+All job data is stored under a `jobs` directory in the primary namespace.
+
+
+=== Active vs Inactive Job Directories
+
+Each active job has a directory under `jobs.active.<jobid>`,
+where `<jobid>` is a unique sequence number assigned by the
+_ingest agent_.
+
+After a job is no longer active, its directory is moved from
+`jobs.active` to `jobs.inactive`.  Inactive means its state
+is read-only.  The purpose of moving inactive jobs to another
+directory is to keep the size of the active directory manageable.
+The `jobs.inactive` directory may need to be periodically archived
+and purged to keep its size manageable in long-running instances.
+
+
+=== Guest KVS Namespace
+
+A guest-writable KVS namespace is created for the use of the
+job shell and the application.  While the job is active,
+this namespace is mounted in the primary namespace, on
+`jobs.active.<jobid>.guest`.  While mounted, it can be changed
+by the guest components without impacting performance of the primary
+namespace, while still being accessible through the primary namespace.
+
+When the job is inactive, the final snapshot of the guest namespace
+is linked into the primary namespace, and the guest namespace is
+destroyed.
+
+
+=== Event Log
+
+Active jobs undergo state transitions that are recorded under
+the key `jobs.active.<jobid>.eventlog`.  A KVS append operation
+is used to add events to this log.
+
+Each append consists of a valid JSON event object, including
+timestamp and format TBD.
+
+
+=== Debug Log
+
+`jobs.active.<jobid>.debuglog` is a similar log available for
+capturing job-specific debug information from instance services.
+
+Each append consists of a valid JSON event object, including
+timestamp and format TBD.
+
+
+=== Access to Primary Namespace by Guest Users
+
+Site policy allowing limited access to job data by guest users
+is implemented by the _job management_ service.
+
+Examples are listing all active jobs with limited detail,
+listing guest inactive/active jobs with full detail, and removing
+jobs owned by the guest.
+
+
+=== Content Produced by Ingest Agent
+
+A user submits _J_ with attached signature.
+
+The _ingest agent_ validates _J_ and if accepted, assigns the jobid
+and creates `jobs.active.<jobid>.J-signed`.
+
+The _ingest agent_ creates `jobs.active.<jobid>.eventlog`
+and logs the initial state of "submitted".
+
+
+=== Content Consumed/Produced by Scheduler
+
+Upon discovery of a new `jobs.active.<jobid>` in the _submitted_ state,
+the _scheduler_ reads `jobs.active.<jobid>.J-signed` and attempts to
+match resources to the request.
+
+The _scheduler_ may declare the job unrunnable, and move it to
+`jobs.inactive`, logging a _rejected_ state transition to the event log.
+
+The _scheduler_ may add annotations to the job (TBD) that are
+of interest for job management, for example to indicate priority
+or estimated wait time.  The scheduler may also add internal
+annotations that are private to the scheduler, but convenient to
+store in the KVS for recovery.  Annotations are stored as
+keys under `jobs.active.<jobid>.scheduler`.
+
+Upon resource allocation to the job, the _scheduler_ creates
+`jobs.active.<jobid>.R-signed` and logs a _runnable_
+state transition to the event log.
+
+The _scheduler_ may later revoke the allocation (TBD).
+
+
+=== Content Consumed/Produced by Exec Service
+
+Upon discovery of a new `jobs.active.<jobid>` in the _runnable_ state,
+the the _exec service_ reads `jobs.active.<jobid>.J-signed`
+and `jobs.active.<jobid>.R-signed` and instantiates
+containers for the allocated resources, starting the job
+shell(s) and creating the guest namespace, mounting it on
+`jobs.active.<jobid>.guest`.
+
+Container creation(s) are logged to the event log (batched),
+and the job state transitions of _starting_, and _running_
+are appended to the event log.
+
+Container destruction(s) are logged to the event log (batched),
+and the job state transitions of _exiting_ and _completed_ are
+are appended to the event log.
+
+
+=== Content Produced/Consumed by Other Instance Services
+
+Other services not mentioned in this RFC MAY store arbitrary data associated
+with jobs under the `jobs.active.<jobid>.data.<service>` directory,
+where `<service>` is a name unique to the service producing the data.
+For example, a job tracing service may store persistent trace data under
+the `jobs.active.<jobid>.data.trace` directory. 
+
+
+=== Content Consumed/Produced by the Job Shell ===
+
+The _job shell_, running as the guest, spawns tasks, handles
+standard I/O, collects task exit codes, and provides PMI
+service.
+
+Any data produced by the _job shell_ is stored under the guest KVS
+namespace `jobs.active.<jobid>.guest` and is preserved when the
+task becomes inactive.
+
+Any data consumed by the _job shell_ must be proxied through instance
+services such as the _exec service_ or _job management service_
+since the _job shell_ does not have direct access to the primary
+KVS namespace.
+
+Format of this data is TBD.

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -364,3 +364,6 @@ Dirref
 NDIyCg
 Markus
 Niels
+proxied
+unrunnable
+runnable


### PR DESCRIPTION
This PR adds a preliminary version (an incomplete rough draft really) of a "KVS Job Schema" RFC.  While I think it's probably a bit early to settle on fine details here, it's helpful now to anticipate how "instance components" (running as instance owner) and "guest components" (running as the the job submitter) of the system might use the KVS, as we approach new KVS features in the near term:

* flux-framework/flux-core#1197 KVS namespaces
* flux-framework/flux-core#1193 KVS atomic append
* flux-framework/flux-core#1185 KVS checkpoint restart

(The namespaces achieve two goals:  one, to decouple performance of the primary KVS namespace from commit activity within a job, and two, to provide coarse grained multi-user support in the KVS.  The atomic append would allow an "event log" or an I/O stream to be appended to by multiple writers without the race condition and poor performance of read-modify-write, or kludge of the "sequenced keys" approach taken in libkz.  The checkpoint restart feature would allow an instance to recover e.g. job state when restarted)

@grondo and I reviewed the [high level design](https://github.com/flux-framework/flux-core/wiki/Multi-user-parallel-job-launch---High-level-design) that captured an earlier discussion in light of feedback from @morrone as he worked on job ingest.   We worked out how the system could allow the job shells and application to control the guest namespace, and the instance components (ingest, scheduler, exec service) would exclusively use the primary namespace.  Any access needed by the guest to the primary KVS namespace would need to be proxied through a service running as the instance owner.  Tools for listing, cancelling, etc jobs would use a "job management service" in a similar manner to access job data.  This keeps the multi-user security model for the KVS simple and the code for it easily audited.

The design is basically the same as originally proposed in the wiki page.  I think the big change is that the "jobns" is now basically scratch space for the job shell and the application rather than trying to contain more of the per-job state.

@morrone had the idea to move each job through a series of directories rather than log state changes to an event log, to make it easier for the components to pick up the right jobs without searching through them all.  That could be added here (symlinks?), and is now compatible with the event log idea since the append to the event log and directory move could be done under the same commit now, without opportunities for races (since both are in the primary namespace)

Comments welcome.