### PR TITLE
rfc6: allow multiple RPC responses

### DIFF
--- a/spec_6.adoc
+++ b/spec_6.adoc
@@ -35,7 +35,7 @@ by comms modules.  Flux RPC has the following goals:
 == Implementation
 
 A remote procedure call SHALL consist of one request message
-sent from a client to a server, and zero or one response messages sent
+sent from a client to a server, and zero or more response messages sent
 from a server to a client.  The client and server roles are not
 mutually-exclusive--comms modules often act in both roles.
 
@@ -54,15 +54,24 @@ by setting nodeid to FLUX_NODEID_ANY, then the tree-based overlay network
 will be followed to the root looking for a matching service closest
 to the client.
 
-The server SHALL send zero or one responses to each request, as
+The server SHALL send zero or more responses to each request, as
 established by prior agreement between client and server (e.g. defined
 in their protocol specification).  Responses SHALL contain topic string
 and matchtag values copied from the request, to facilitate client response
-matching.  Responses MAY be sent in any order.
+matching.
+
+The server MAY respond to different requests in any order.
 
 The server SHALL set errnum in the response to zero to indicate success,
 or a nonzero value to indicate failure, using
 link:http://man7.org/linux/man-pages/man3/errno.3.html[POSIX.1 errno encoding]. 
+
+Protocols which allow multiple responses to a request SHALL define a way
+for the client to determine that all responses have been received,
+so that the RPC matchtag can be safely retired and reused.  Protocols MAY
+send a response with errnum set to ENODATA (61) to signify "end of response
+stream".  Servers SHALL stop sending responses to a given request
+once a response with errnum set to a nonzero value has been sent.
 
 Payload frames are OPTIONAL in both request and response messages.
 However, a response with errnum set to a nonzero value SHALL NOT

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -368,3 +368,4 @@ proxied
 unrunnable
 runnable
 username
+ENODATA


### PR DESCRIPTION
This loosens RFC 6's definition of an RPC to allow for more than one response to a request.  This practice has been used in our code base for some time but never formalized.

My biggest concern about allowing this without some sort of open/close stream abstraction was the potential for a matchtag to be reused in another RPC, creating hard to find, intermittent bugs.  To address this concern, this PR proposes that clients and servers agree that any error response (no payload, errnum != 0) should signifiy the end of an RPC, and suggests that services could optionally use an error response of ENODATA as an EOF of sorts.