### PR TITLE
rfc3, rfc6: allow RPC error response string, clarify payloads

### DIFF
--- a/spec_3.adoc
+++ b/spec_3.adoc
@@ -226,6 +226,8 @@ flag-payload	= %x02			; message has payload frame
 flag-route	= %x08			; message has route delimiter frame
 flag-upstream   = %x10                  ; request should be routed upstream
 					;   of nodeid sender
+flag-private	= %x20			; event message is requested to be
+					;   private to sender, instance owner
 
 ; Userid assigned by connector at message ingress
 userid		= 4OCTET / userid-unknown

--- a/spec_3.adoc
+++ b/spec_3.adoc
@@ -39,7 +39,7 @@ the following specific goals:
 `flux-broker` is a message broker daemon for the Flux resource manager
 framework.  A _comms session_ is a set of interconnected `flux-broker` tasks
 that together provide a shared communications substrate for distributed
-resource manager services within a job .  Services and utilities communicate
+resource manager services within a job.  Services and utilities communicate
 by passing messages through the session brokers.  There are four
 types of messages: events, requests, responses, and keepalives, which
 share a common structure described herein.

--- a/spec_3.adoc
+++ b/spec_3.adoc
@@ -151,6 +151,18 @@ this determination SHALL respond with error number 113, "No route to host".
 Event messages SHALL only be published by the rank 0 broker.  Other ranks MAY
 cause an event to be sent by first forwarding it to rank 0.
 
+=== Payload Conventions
+
+Request, response, and event messages MAY contain a payload.  Payloads MAY
+consist of any byte sequence.  To maximize interoperability, norms are
+established for common payload types:
+
+. String payloads SHALL include a terminating NULL character.
+. Structured objects are RECOMMENDED to be represented as JSON.
+. JSON payloads SHALL conform to Internet RFC 7159.
+. JSON payloads SHALL be objects, not arrays or bare values.
+. JSON payloads SHALL include a terminating NULL character.
+
 === General Message Format
 
 CMB1 messages are multi-part ZeroMQ messages.
@@ -169,10 +181,7 @@ delimiter, if any.  When the topic string part is first, it is compatible
 with ZeroMQ PUB-SUB sockets.
 
 Finally, CMB1 messages MAY include a payload part, positioned before
-the PROTO part.  Payload parts SHALL use either raw encoding or JSON
-encoding, as indicated by flags.  JSON payloads SHALL conform to
-Internet RFC 7159, and the outermost JSON type SHALL be a JSON object, e.g.
-beginning with the "{" character.
+the PROTO part.  Payloads MAY consist of any byte sequence.
 
 CMB1 messages are specified in detail by the following ABNF grammar.
 
@@ -182,9 +191,9 @@ CMB1		= C:request *S:response
 		/ C:keepalive
 
 ; Multi-part ZeroMQ messages
-C:request	= [routing] topic [payload / json] PROTO
-S:response	= [routing] topic [payload / json] PROTO
-S:event		= [routing] topic [payload / json] PROTO
+C:request	= [routing] topic [payload] PROTO
+S:response	= [routing] topic [payload] PROTO
+S:event		= [routing] topic [payload] PROTO
 C:keepalive	= PROTO
 
 ; Route frame stack, ZeroMQ DEALER-ROUTER format
@@ -197,7 +206,6 @@ topic		= 1*(ALPHA / DIGIT / ".")
 
 ; Payload frame
 payload		= *OCTET		; payload ZeroMQ frame
-json		= JSON			; payload ZeroMQ frame, encoded JSON
 
 ; Protocol frame
 PROTO		= request / response / event / keepalive
@@ -215,7 +223,6 @@ version		= %x01			; version for CMB1
 flags		= OCTET
 flag-topic	= %x01			; message has topic string frame
 flag-payload	= %x02			; message has payload frame
-flag-json	= %x04			;         and payload is JSON
 flag-route	= %x08			; message has route delimiter frame
 flag-upstream   = %x10                  ; request should be routed upstream
 					;   of nodeid sender

--- a/spec_6.adoc
+++ b/spec_6.adoc
@@ -47,6 +47,8 @@ mutually-exclusive--comms modules often act in both roles.
 +--------+    Response     +--------+
 ----
 
+=== Request Message
+
 Per RFC 3, the request message SHALL include a nodeid and topic string
 used to aid the broker in selecting appropriate routes to the server.
 The client MAY address the request in a location-neutral manner
@@ -54,28 +56,39 @@ by setting nodeid to FLUX_NODEID_ANY, then the tree-based overlay network
 will be followed to the root looking for a matching service closest
 to the client.
 
+The request message MAY include a service-defined payload.
+
+=== Response Messages
+
 The server SHALL send zero or more responses to each request, as
 established by prior agreement between client and server (e.g. defined
-in their protocol specification).  Responses SHALL contain topic string
-and matchtag values copied from the request, to facilitate client response
-matching.
+in their protocol specification).
 
-The server MAY respond to different requests in any order.
+Responses SHALL contain topic string and matchtag values copied from
+the request, to facilitate client response matching.
 
-The server SHALL set errnum in the response to zero to indicate success,
-or a nonzero value to indicate failure, using
-link:http://man7.org/linux/man-pages/man3/errno.3.html[POSIX.1 errno encoding]. 
+If the request succeeds, the server SHALL set errnum in the response
+to zero and MAY include a service-defined payload.
+
+If the request fails, the server SHALL set errnum in the response to
+a nonzero value conforming to
+link:http://man7.org/linux/man-pages/man3/errno.3.html[POSIX.1 errno encoding]
+and MAY include an error string payload.  The error string, if included
+SHALL consist of a brief, human readable message.  It is RECOMMENDED that
+the error string be less than 80 characters and not include line
+terminators.
+
+The server MAY respond to requests in any order.
+
+=== Streaming Responses
 
 Protocols which allow multiple responses to a request SHALL define a way
 for the client to determine that all responses have been received,
-so that the RPC matchtag can be safely retired and reused.  Protocols MAY
-send a response with errnum set to ENODATA (61) to signify "end of response
-stream".  Servers SHALL stop sending responses to a given request
-once a response with errnum set to a nonzero value has been sent.
+so that the RPC matchtag can be safely retired and reused.
 
-Payload frames are OPTIONAL in both request and response messages.
-However, a response with errnum set to a nonzero value SHALL NOT
-return a payload frame.
+Protocols MAY send a response with errnum set to ENODATA (61) to signify
+"end of response stream".  Servers SHALL stop sending responses to a
+given request after a response with errnum set to a nonzero value has been sent.
 
 === Matchtag Field
 


### PR DESCRIPTION
This change allows RPC error responses to include a brief, human readable description of the error.

In addition, it clarifies evolving payload norms and drops the FLUX_MSGFLAG_JSON flag as proposed in #123.