### PR TITLE
rfc3: explain informal ABNF usage

### DIFF
--- a/spec_14.adoc
+++ b/spec_14.adoc
@@ -105,7 +105,7 @@ program. The dictionary MUST contain the keys `resources`, `tasks`,
 Each of the listed jobspec keys SHALL meet the form and requirements
 listed in detail in the sections below. For reference, a ruleset for
 compliant canonical jobspec is provided using *JSON Content Rules*
-footnoteref:[contentrules,https://tools.ietf.org/id/draft-newton-json-content-rules-06.txt[JSON Content Rules (jcr-version 0.6)]&#44; A. Newton&#44; P. Cordell&#44; 2016]
+footnoteref:[contentrules,https://tools.ietf.org/id/draft-newton-json-content-rules-06.txt[JSON Content Rules (jcr-version 0.6)]; A. Newton; P. Cordell; 2016]
  in the *Content Rules* at the end of this section.
 
 === Resources

--- a/spec_3.adoc
+++ b/spec_3.adoc
@@ -159,6 +159,7 @@ established for common payload types:
 
 . String payloads SHALL include a terminating NULL character.
 . Structured objects are RECOMMENDED to be represented as JSON.
+footnote:[http://www.rfc-editor.org/rfc/rfc7159.txt[RFC 7159: The JavaScript Object Notation (JSON) Data Interchange Format], T. Bray, Google, Inc, March 2014.]
 . JSON payloads SHALL conform to Internet RFC 7159.
 . JSON payloads SHALL be objects, not arrays or bare values.
 . JSON payloads SHALL include a terminating NULL character.
@@ -261,8 +262,3 @@ sequence	= 4OCTET
 unused		= %x00.00.00.00
 ----
 
-[sect2]
-== References
-
-* http://www.rfc-editor.org/rfc/rfc7159.txt[RFC 7159: The JavaScript Object
-Notation (JSON) Data Interchange Format], T. Bray, Google, Inc, March 2014.

--- a/spec_3.adoc
+++ b/spec_3.adoc
@@ -183,7 +183,14 @@ with ZeroMQ PUB-SUB sockets.
 Finally, CMB1 messages MAY include a payload part, positioned before
 the PROTO part.  Payloads MAY consist of any byte sequence.
 
-CMB1 messages are specified in detail by the following ABNF grammar.
+CMB1 messages are specified in terms of ZeroMQ messages by the following
+ABNF grammar
+footnote:[For convenience:  the `C:request`, `S:response`, `S:event`, and
+`C:keepalive` ABNF non-terminals refer to ZeroMQ messages, sent by client
+or server, and built from ordered ZeroMQ message parts (frames).  Other
+non-terminals are built from concatenated ABNF terminals per usual.
+Thus it is meaningful for `delimiter`, a message frame, to have zero length,
+since a zero-length message frame is valid ZMTP.]
 
 ----
 CMB1		= C:request *S:response


### PR DESCRIPTION
As noted in #120, the ABNF usage in RFC3 took some undocumented liberties.  Add a footnote to explain this.

Also, fix my cut and paste error in PR #125.