### PR TITLE
RFC 17: describe interfaces for execution and submission of Flux jobs

### DIFF
--- a/spec_17.adoc
+++ b/spec_17.adoc
@@ -1,0 +1,43 @@
+ifdef::env-github[:outfilesuffix: .adoc]
+
+17/Flux Job Submission and Execution Interface
+==============================================
+
+This specification describes the base interface for the Flux commands
+and APIs for the execution and submission of parallel jobs.
+
+* Name: github.com/flux-framework/rfc/spec_17.adoc
+* Editor: Mark Grondona <mgrondona@llnl.gov>
+* State: raw
+
+== Language
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
+be interpreted as described in http://tools.ietf.org/html/rfc2119[RFC 2119].
+
+== Related Standards
+
+*  link:spec_12{outfilesuffix}[16/KVS Job Schema]
+*  link:spec_14{outfilesuffix}[14/Canonical Job Specification]
+
+== Background
+
+The commands and APIs used to submit and execute parallel jobs are fundamental
+to Flux design and offer the main interface for users to interact with
+the scheduling and resource management aspects of the system. Therefore,
+a standard, base specification of these interfaces is required to prevent
+disruptive changes to these interfaces for users.
+
+== Commands
+
+Commands for submitting, executing, and manipulating Flux jobs SHALL
+be kept under the `flux job` command. The `flux job` subcommands
+described in this RFC are the `flux job run` and `flux job submit` commands.
+
+=== flux job submit
+
+=== flux job run
+
+== APIs
+


### PR DESCRIPTION
The purpose of this RFC is to collaborate and eventually specify the base interfaces in Flux for the submission and execution of jobs, i.e. define the UI for the `flux job run` and `flux job submit` commands. I also added the potential for a section on APIs, however, it is expected the API will be simple since it needs to only take (signed) jobspec, so perhaps that doesn't belong here.

The goal of the RFC is define the interface we'll be happy with (for a long time, as @trws puts it), as such we should perhaps keep it simple at first.

Here are some points to get the discussion started:

 * `flux job run` executes a parallel job, either interactively or requests execution and exits.
    It is somewhat a command with 3 phases:
  1. From user options, existing file or files, other means, etc, generate canonical jobspec
  2. Submit the signed jobspec to the instance's job ingest system (using submit/execute API)
  3. Monitor job status and I/O interactively -- this is actually dependent on the job shell being used,
      and therefore after submission `flux job run` may do something like optionally execute a front-end
      portion of the job shell, or load some extensions provided by the job shell.

For `flux job run` what we're probably most interested in the command line interface in step 1.

 * `flux job submit` submits work for later execution by the scheduler, but should take the same options and arguments as `flux job run` (if any) to generate jobspec. There are also two kinds of "jobs" users may want to submit:
  * Execution of a single parallel job (e.g. exactly what you'd run with `flux job run` but non-interactively)
  * "batch script" execution, in which case `flux job submit` will need to create a jobspec that requests a new instance with the batch script as initial program.

Because the generation of jobspec is common to `flux job submit` and `flux job run`, we may want to entertain the idea of having a separate generator command that emits jobspec from some kind of user input, which is then fed into these job commands. This could be done invisibly to the user somehow.

Sorry, these initial comments are kind of all over the place, and the existing text in the proposed RFC is almost non-existent, however, hopefully this gets our discussion started and we can make some progress here.