### PR TITLE
RFC 18: KVS Event Log Format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ SOURCES = \
 	spec_14.adoc \
 	spec_15.adoc \
 	spec_16.adoc \
+	spec_18.adoc
 
 HTML = $(SOURCES:.adoc=.html)
 PDF = $(SOURCES:.adoc=.pdf)

--- a/spec_16.adoc
+++ b/spec_16.adoc
@@ -78,6 +78,9 @@ exiting::
 completed::
   all containers exited
 
+canceled::
+  user requested the job be canceled
+
 rejected::
   scheduler won't run job
 
@@ -165,7 +168,7 @@ and appends the initial _submitted_ event.
 === Content Consumed/Produced by Scheduler
 
 Upon discovery of a new `jobs.active.<jobid>` (with a _submitted_ event and
-without a _cancelled_ event in the event log), the _scheduler_ reads
+without a _canceled_ event in the event log), the _scheduler_ reads
 `jobs.active.<jobid>.J-signed` and attempts to match resources to the request.
 
 The _scheduler_ may declare the job unrunnable, and move it to

--- a/spec_16.adoc
+++ b/spec_16.adoc
@@ -19,6 +19,7 @@ be interpreted as described in http://tools.ietf.org/html/rfc2119[RFC 2119].
 == Related Standards
 
 *  link:spec_12{outfilesuffix}[12/Flux Security Architecture]
+*  link:spec_18{outfilesuffix}[18/KVS Event Log Format]
 
 == Background
 
@@ -56,7 +57,7 @@ within them.  When job shells and their containers start to exit,
 the _exec service_ "reaps" these shells and allows the _scheduler_
 to reclaim resources assigned to each container.
 
-Jobs therefore transition between the following states,
+Jobs therefore experience the following events,
 not necessarily in a linear order:
 
 submitted::
@@ -123,12 +124,12 @@ namespace, and the guest namespace is destroyed.
 
 === Event Log
 
-Active jobs undergo state transitions that are recorded under
+Active jobs undergo events that are recorded under
 the key `jobs.active.<jobid>.eventlog`.  A KVS append operation
 is used to add events to this log.
 
-Each append consists of a valid JSON event object, including
-timestamp and format TBD.
+Each append consists of a string matching the format described in
+link:spec_18{outfilesuffix}[RFC 18/KVS Event Log Format].
 
 
 === Debug Log
@@ -136,8 +137,8 @@ timestamp and format TBD.
 `jobs.active.<jobid>.debuglog` is a similar log available for
 capturing job-specific debug information from instance services.
 
-Each append consists of a valid JSON event object, including
-timestamp and format TBD.
+Each append consists of a string matching the format described in
+link:spec_18{outfilesuffix}[RFC 18/KVS Event Log Format].
 
 
 === Access to Primary Namespace by Guest Users
@@ -158,17 +159,17 @@ The _ingest agent_ validates _J_ and if accepted, assigns the jobid
 and creates `jobs.active.<jobid>.J-signed`.
 
 The _ingest agent_ creates `jobs.active.<jobid>.eventlog`
-and logs the initial state of "submitted".
+and appends the initial _submitted_ event.
 
 
 === Content Consumed/Produced by Scheduler
 
-Upon discovery of a new `jobs.active.<jobid>` in the _submitted_ state,
-the _scheduler_ reads `jobs.active.<jobid>.J-signed` and attempts to
-match resources to the request.
+Upon discovery of a new `jobs.active.<jobid>` (with a _submitted_ event and
+without a _cancelled_ event in the event log), the _scheduler_ reads
+`jobs.active.<jobid>.J-signed` and attempts to match resources to the request.
 
 The _scheduler_ may declare the job unrunnable, and move it to
-`jobs.inactive`, logging a _rejected_ state transition to the event log.
+`jobs.inactive`, appending a _rejected_ event to the event log.
 
 The _scheduler_ may add annotations to the job (TBD) that are
 of interest for job management, for example to indicate priority
@@ -178,7 +179,7 @@ store in the KVS for recovery.  Annotations are stored as
 keys under `jobs.active.<jobid>.scheduler`.
 
 Upon resource allocation to the job, the _scheduler_ creates
-`jobs.active.<jobid>.R`, and then logs a _runnable_ state transition
+`jobs.active.<jobid>.R`, and then appends a _runnable_ event
 to the event log.
 
 The _scheduler_ may later revoke the allocation (TBD).
@@ -186,11 +187,10 @@ The _scheduler_ may later revoke the allocation (TBD).
 
 === Content Consumed/Produced by Exec Service
 
-Upon discovery of a new `jobs.active.<jobid>` in the _runnable_ state,
-the _exec service_ reads `jobs.active.<jobid>.J-signed`
-and `jobs.active.<jobid>.R`, initializes the guest namespace, then
-instantiates containers for the allocated resources and starts the job
-shell(s).
+Upon discovery of a new `jobs.active.<jobid>` with a _runnable_ event in the
+event log, the _exec service_ reads `jobs.active.<jobid>.J-signed` and
+`jobs.active.<jobid>.R`, initializes the guest namespace, then instantiates
+containers for the allocated resources and starts the job shell(s).
 
 Initializing the guest namespace consists of creating it, mounting it
 on `jobs.active.<jobid>.guest`, and populating the initial contents with:
@@ -198,13 +198,11 @@ on `jobs.active.<jobid>.guest`, and populating the initial contents with:
 `exec.R`::
   copy of `jobs.active.<jobid>.R`
 
-Container creation(s) are logged to the event log (batched),
-and the job state transitions of _starting_, and _running_
-are appended to the event log.
+Container creation(s) are logged to the event log (batched), and the job events
+of _starting_, and _running_ are appended to the event log.
 
-Container destruction(s) are logged to the event log (batched),
-and the job state transitions of _exiting_ and _completed_ are
-are appended to the event log.
+Container destruction(s) are logged to the event log (batched), and the job
+events of _exiting_ and _completed_ are are appended to the event log.
 
 
 === Content Produced/Consumed by Other Instance Services
@@ -213,7 +211,7 @@ Other services not mentioned in this RFC MAY store arbitrary data associated
 with jobs under the `jobs.active.<jobid>.data.<service>` directory,
 where `<service>` is a name unique to the service producing the data.
 For example, a job tracing service may store persistent trace data under
-the `jobs.active.<jobid>.data.trace` directory. 
+the `jobs.active.<jobid>.data.trace` directory.
 
 
 === Content Consumed/Produced by the Job Shell ===

--- a/spec_18.adoc
+++ b/spec_18.adoc
@@ -1,0 +1,52 @@
+ifdef::env-github[:outfilesuffix: .adoc]
+
+18/KVS Event Log Format
+=======================
+
+This specification describes the format for Flux job events stored in the KVS
+event log.
+
+* Name: github.com/flux-framework/rfc/spec_18.adoc
+* Editor: Stephen Herbein <sherbein@llnl.gov>
+* State: raw
+
+== Language
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
+be interpreted as described in http://tools.ietf.org/html/rfc2119[RFC 2119].
+
+== Related Standards
+
+*  link:spec_16{outfilesuffix}[16/KVS Job Schema]
+
+== Background
+
+As stated in RFC 16:
+
+__________________________________________________
+Active jobs undergo state transitions that are recorded under
+the key `jobs.active.<jobid>.eventlog`.  A KVS append operation
+is used to add events to this log.
+__________________________________________________
+
+== Event Log Format
+
+The event log SHALL be append-only.  An event appended to the KVS job event log
+MUST take the following format:
+
+----
+timestamp name [context]
+----
+
+Where:
+
+* `timestamp` SHALL be the floating point representation of the number of seconds
+  since the epoch, with at least millisecond resolution
+* `name` SHALL be a non-whitespace string denoting the name or description of
+  the event being appended to the log
+* `context` SHALL be an optional string containing any characters other than the
+  newline character that provides additional information about the event
+
+The elements (i.e., timestamp, name, and context) within a single event are
+spaced-delimited, and events themselves are newline delimited.

--- a/spec_18.adoc
+++ b/spec_18.adoc
@@ -41,8 +41,8 @@ timestamp name [context]
 
 Where:
 
-* `timestamp` SHALL be the floating point representation of the number of seconds
-  since the epoch, with at least millisecond resolution
+* `timestamp` SHALL be the number of seconds since the Unix Epoch (1970-01-01
+  UTC), expressed with optional sub-second precision in decimal notation.
 * `name` SHALL be a non-whitespace string denoting the name or description of
   the event being appended to the log
 * `context` SHALL be an optional string containing any characters other than the

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -371,3 +371,4 @@ username
 ENODATA
 contentrules
 footnoteref
+Herbein

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -372,3 +372,4 @@ ENODATA
 contentrules
 footnoteref
 Herbein
+UTC


### PR DESCRIPTION
This RFC is a rough first cut at describing the KVS event log format used for job events.  The KVS event log is initially described in RFC16, but the event format was never defined.  This is the log format that @garlick, @grondo, and I settled on during an afternoon brainstorming session.

Closes #133