### PR TITLE
rfc18: fix formatting error

### DIFF
--- a/spec_18.adoc
+++ b/spec_18.adoc
@@ -48,7 +48,7 @@ Where:
 * `name` SHALL be a string denoting the name of the event.  It MUST NOT contain
   the space character or the newline character, and SHALL be between one
   and 64 characters in length.  This field is REQUIRED.
- `context` SHALL be a string providing additional arguments or description
+* `context` SHALL be a string providing additional arguments or description
   of the event.  It MUST NOT contain the newline character, and SHALL be
   between one and 256 characters in length.  This field is OPTIONAL.
 


### PR DESCRIPTION
Problem:  two items in bullet list were improperly merged.

Add missing asterisk.