### PR TITLE
rfc7: forbid typedefs for fixed length arrays

### DIFF
--- a/spec_7.adoc
+++ b/spec_7.adoc
@@ -76,6 +76,11 @@ For example avoid generic types like `struct a` or typedefs like `ctx_t`. A good
 practice is to include the name of the relevant source file, module or service in
 the typedef (e.g. `fooservice_ctx_t`).
 
+Typedefs SHOULD NOT be used for fixed length character arrays, as this
+obscures the fact that they are merely pointers when used in function
+prototypes, and give different `sizeof` results depending on context.
+
+
 === Structures
 
 Structure tags SHOULD NOT contain the string "struct".

--- a/spec_7.adoc
+++ b/spec_7.adoc
@@ -68,7 +68,8 @@ Abstract types SHOULD be publicly defined as incomplete types, for example:
 ----
 typedef struct foo foo_t;
 ----
-Abstract types SHOULD NOT be defined as pointers to incomplete types,
+Abstract types SHOULD NOT be defined as pointers to incomplete types, as
+this obscures the fact that they are pointers when used in declarations.
 
 Typedef names SHOULD be chosen such that they are unique within a framework project.
 For example avoid generic types like `struct a` or typedefs like `ctx_t`. A good

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -373,3 +373,4 @@ contentrules
 footnoteref
 Herbein
 UTC
+sizeof


### PR DESCRIPTION
This follows up on a discussion in flux-framework/flux-core#1668