### PR TITLE
rfc5: remove service_name symbol

### DIFF
--- a/spec_5.adoc
+++ b/spec_5.adoc
@@ -98,10 +98,6 @@ type of error on failure.
 
 A Flux extension module MAY export the following global symbols:
 
-+const char *service_name;+::
-A null-terminated C string defining the service name provided by the
-module, if different from the module name.
-
 A base component MAY call +dlopen()+ with _RTLD_LOCAL_ flag,
 then access these symbols with +dlsym()+.
 


### PR DESCRIPTION
Remove the optional `service_name` extension module symbol. It is
no longer used by the broker to determine a secondary service
name for modules.

(Assuming PR flux-framework/flux-core#1753 goes in)