### PR TITLE
rfc7: add reference to black formatter for python

### DIFF
--- a/spec_7.adoc
+++ b/spec_7.adoc
@@ -95,8 +95,7 @@ we also should not write:
 struct foo_struct {};
 ----
 
-Tools That Modify Code to Conform to C Coding Style
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Tools for C formatting
 
 "indent -kr" will bring you most of the way towards conforming to the Flux coding style.
 

--- a/spec_7.adoc
+++ b/spec_7.adoc
@@ -124,3 +124,7 @@ For astyle, the pertinent options would be:
 --indent-coll-comments --style=stroustrup --indent-spaces=4
  --align-pointer=name --max-code-length=80 --convert-tabs
 ----
+
+== Python coding style
+
+* Python code SHALL be formatted with the https://black.readthedocs.io/en/stable/the_black_code_style.html[Black code style].

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -379,4 +379,3 @@ Livermore
 LLC
 LLNS
 SPDX
-


### PR DESCRIPTION
This PR contains a little bit of cleanup, and a new python section for RFC 7 that requires the black code stye.