### PR TITLE
spec14: clarify UC1.3

### DIFF
--- a/data/spec_14/use_case_1.3.yaml
+++ b/data/spec_14/use_case_1.3.yaml
@@ -8,10 +8,12 @@ resources:
       count: 1
       with:
         - type: socket
-          count: 2
+          count:
+            min: 2
           with:
             - type: core
-              count: 4
+              count:
+                min: 4
 tasks:
   - command: [ "flux", "start" ]
     slot: nodelevel

--- a/data/spec_14/use_case_1.3.yaml
+++ b/data/spec_14/use_case_1.3.yaml
@@ -5,6 +5,7 @@ resources:
     label: nodelevel
     with:
     - type: node
+      exclusive: false
       count: 1
       with:
         - type: socket

--- a/data/spec_14/use_case_2.5.yaml
+++ b/data/spec_14/use_case_2.5.yaml
@@ -5,7 +5,8 @@ resources:
     count: 10
     with:
     - type: memory
-      count: 2
+      count:
+        min: 2
       unit: GB
     - type: core
       count: 1

--- a/data/spec_14/use_case_2.6.yaml
+++ b/data/spec_14/use_case_2.6.yaml
@@ -8,7 +8,8 @@ resources:
       count: 1
       with:
         - type: memory
-          count: 4
+          count:
+            min: 4
           unit: GB
 tasks:
   - command: app

--- a/spec_14.adoc
+++ b/spec_14.adoc
@@ -132,16 +132,24 @@ A resource vertex SHALL contain the following keys:
  of two possible values: either a single integer value representing
  a fixed count, or a dictionary which SHALL contain the following keys:
 +
-[horizontal]
+[horizontal width=20%]
    *min*::: The minimum required count or amount of this resource
 
++
+and additionally MAY contain the following keys:
++
+[horizontal width=30%]
    *max*::: The maximum required count or amount of this resource
 
    *operator*::: An operator applied between `min` and `max` which
    returns the next acceptable value
 
    *operand*::: The operand used in conjunction with `operator`
-   to get the next value between `min` and `max`.
+
++
+The default value for `max` SHALL be  _infinite_, therefore a `count`
+which specifies only the `min` key SHALL be considered a request for
+_at least_ that number of a resource.
 
 A resource vertex MAY additionally contain one or more of the
 following keys


### PR DESCRIPTION
This PR is meant to address the main issue brought up in #105, which I think
everyone agreed was valid and should be fixed in the RFC.

The description of Use Case 1.3 is worded with "at least", but the actual
example jobspec specified the exact count of sockets and cores. Update the
example to use a `min` count instead with no `max` (implying "at least").

Adjust the wording for the task `count` key to allow specification of `min`
without `max`, to make the new UC1.3 adhere to the spec.

Closes #105