### PR TITLE
rfc16: remove job states, sync with job manager design changes

### DIFF
--- a/spec_16.adoc
+++ b/spec_16.adoc
@@ -57,33 +57,6 @@ within them.  When job shells and their containers start to exit,
 the _exec service_ "reaps" these shells and allows the _scheduler_
 to reclaim resources assigned to each container.
 
-Jobs therefore experience the following events,
-not necessarily in a linear order:
-
-submitted::
-  accepted by ingest, resources not yet assigned
-
-runnable::
-  resources assigned
-
-starting::
-  first container started
-
-running::
-  all containers instantiated and job shells started
-
-exiting::
-  first container exited
-
-completed::
-  all containers exited
-
-canceled::
-  user requested the job be canceled
-
-rejected::
-  scheduler won't run job
-
 == Implementation
 
 === Primary KVS Namespace

--- a/spec_16.adoc
+++ b/spec_16.adoc
@@ -37,14 +37,12 @@ Guest components have direct, read/write access to a private KVS namespace:
 
 * _Job shell_
 * _User tasks_
-* `flux-run` command
-* `flux-queue` command
-* `flux-cancel` command
+* _Command line tools_
 
 === Job Life Cycle
 
-Jobspec is submitted to the _ingest agent_ which validates it, adds it
-to the KVS, and informs the _job manager_ of the new job.
+A job is submitted to the _ingest agent_ which validates jobspec, adds
+the job to the KVS, and informs the _job manager_ of the new job.
 Upon success, the jobid is returned to the user.  The _job manager_ then
 takes the active role in moving a job through its life cycle:
 
@@ -91,7 +89,8 @@ _ingest agent_.
 After a job is no longer active, its directory is moved from
 `jobs.active` to `jobs.inactive`.  Inactive means its state
 is read-only.  The purpose of moving inactive jobs to another
-directory is to keep the size of the active directory manageable.
+directory is to permit recovery of the active job queue from the KVS
+during a restart, and keep the size of the active directory manageable.
 The `jobs.inactive` directory may need to be periodically archived
 and purged to keep its size manageable in long-running instances.
 
@@ -99,18 +98,23 @@ and purged to keep its size manageable in long-running instances.
 === Guest KVS Namespace
 
 A guest-writable KVS namespace is created by the _exec service_
-for the use of the job shell and the application.  While the job
-is active, this namespace is mounted in the primary namespace, on
-`jobs.active.<jobid>.guest`.  While mounted, it can be changed
+for the use of the _job shell_ and the application.  While the job
+is active, this namespace is linked from `jobs.active.<jobid>.guest`
+in the primary KVS namespace.  While linked, it can be changed
 by the guest components without impacting performance of the primary
-namespace, while still being accessible through the primary namespace.
-
-Access to contents of the primary KVS namespace MAY be granted to
-the guest by copying them to the guest KVS namespace.
+namespace, while still being accessible through the link in the
+primary namespace.
 
 When the job transitions to inactive, the final snapshot of the
 guest namespace content is linked by the _exec service_ into the primary
 namespace, and the guest namespace is destroyed.
+
+
+=== Access to Primary Namespace by Guest Users
+
+Guests may access data in the primary KVS namespace only through instance
+services that allow selective guest access, by proxy or by staging copies
+to the guest namespace.
 
 
 === Event Log
@@ -123,77 +127,101 @@ Each append consists of a string matching the format described in
 link:spec_18{outfilesuffix}[RFC 18/KVS Event Log Format].
 
 
-=== Debug Log
-
-`jobs.active.<jobid>.debuglog` is a similar log available for
-capturing job-specific debug information from instance services.
-
-Each append consists of a string matching the format described in
-link:spec_18{outfilesuffix}[RFC 18/KVS Event Log Format].
-
-
-=== Access to Primary Namespace by Guest Users
-
-Site policy allowing limited access to job data by guest users
-is implemented by the _job management_ service.
-
-Examples are listing all active jobs with limited detail,
-listing guest inactive/active jobs with full detail, and removing
-jobs owned by the guest.
-
-
 === Content Produced by Ingest Agent
 
 A user submits _J_ with attached signature.
 
-The _ingest agent_ validates _J_ and if accepted, assigns the jobid
-and creates `jobs.active.<jobid>.J-signed`.
+The _ingest agent_ validates _J_ and if accepted, populates the KVS with:
 
-The _ingest agent_ creates `jobs.active.<jobid>.eventlog`
-and appends the initial _submitted_ event.
+`jobs.active.<jobid>.J-signed`::
+signed J for passing to IMP in a multi-user instance.
+
+`jobs.active.<jobid>.jobspec`::
+jobspec in JSON form
+
+`jobs.active.<jobid>.priority`::
+integer priority (0-31)
+
+`jobs.active.<jobid>.userid`::
+authenticated userid (must match signature)
+
+`jobs.active.<jobid>.eventlog`::
+eventlog described above
+
+The _ingest agent_ logs one event to the eventlog:
+
+`submit`::
+job was submitted
+
+
+=== Content Consumed/Produced by Job Manager
+
+Upon notification of a new `jobs.active.<jobid>`, the _job manager_ takes
+the active role in moving a job through its life cycle, and logs the
+following events the the eventlog as appropriate:
+
+`cancel`::
+job was canceled
+
+`alloc`::
+resources were allocated
+
+`start`::
+execution was started
+
+`finish`::
+execution completed
+
+`kill`::
+signal was sent
+
+`free`::
+resources were freed
+
+`priority`::
+priority was changed
+
+`timelimit`::
+wall clock limit reached
+
+When a job reaches the inactive state, the _job manager_ moves it to
+`jobs.inactive`.
+
+When the _job manager_ is restarted, it recovers its state by scanning
+`jobs.active`.
 
 
 === Content Consumed/Produced by Scheduler
 
-Upon discovery of a new `jobs.active.<jobid>` (with a _submitted_ event and
-without a _canceled_ event in the event log), the _scheduler_ reads
-`jobs.active.<jobid>.J-signed` and attempts to match resources to the request.
+When the _scheduler_ receives an allocation request containing a jobid,
+it reads the jobspec from `jobs.active.<jobid>.jobspec`.
 
-The _scheduler_ may declare the job unrunnable, and move it to
-`jobs.inactive`, appending a _rejected_ event to the event log.
+The scheduler allocates resources by writing a resource set
+to `jobs.active.<jobid>.R` and answering the allocation request.
 
-The _scheduler_ may add annotations to the job (TBD) that are
-of interest for job management, for example to indicate priority
-or estimated wait time.  The scheduler may also add internal
-annotations that are private to the scheduler, but convenient to
-store in the KVS for recovery.  Annotations are stored as
-keys under `jobs.active.<jobid>.scheduler`.
-
-Upon resource allocation to the job, the _scheduler_ creates
-`jobs.active.<jobid>.R`, and then appends a _runnable_ event
-to the event log.
-
-The _scheduler_ may later revoke the allocation (TBD).
+The scheduler frees resources by answering the free request,
+leaving `R` in place for job provenance.  During a restart, the
+_job manager_ uses the eventlog to determine whether `R` is currently
+allocated.
 
 
 === Content Consumed/Produced by Exec Service
 
-Upon discovery of a new `jobs.active.<jobid>` with a _runnable_ event in the
-event log, the _exec service_ reads `jobs.active.<jobid>.J-signed` and
-`jobs.active.<jobid>.R`, initializes the guest namespace, then instantiates
-containers for the allocated resources and starts the job shell(s).
+When the _exec system_ receives a start request containing a jobid,
+it reads the `jobs.active.<jobid>.R` and `jobs.active.<jobid>.jobspec`
+and uses this information to launch _job shells_ and subsequently tasks.
 
-Initializing the guest namespace consists of creating it, mounting it
-on `jobs.active.<jobid>.guest`, and populating the initial contents with:
+The _exec system_ creates the job's guest namespace and links it to
+`jobs.active.<jobid>.guest`.  Its initial contents are populated with
 
 `exec.R`::
-  copy of `jobs.active.<jobid>.R`
+copy of `jobs.active.<jobid>.R`
 
-Container creation(s) are logged to the event log (batched), and the job events
-of _starting_, and _running_ are appended to the event log.
+`exec.jobspec`::
+copy of `jobs.active.<jobid>.jobspec`
 
-Container destruction(s) are logged to the event log (batched), and the job
-events of _exiting_ and _completed_ are are appended to the event log.
+`exec.eventlog`::
+An eventlog for the use of _job shells_, TBD.
 
 
 === Content Produced/Consumed by Other Instance Services
@@ -204,23 +232,6 @@ where `<service>` is a name unique to the service producing the data.
 For example, a job tracing service may store persistent trace data under
 the `jobs.active.<jobid>.data.trace` directory.
 
-
-=== Content Consumed/Produced by the Job Shell ===
-
-The _job shell_, running as the guest, spawns tasks, handles
-standard I/O, collects task exit codes, and provides PMI
-service.
-
-Any data produced by the _job shell_ is stored in the guest KVS
-namespace under `shell` and is preserved when the task
-becomes inactive.
-
-Any data consumed by the _job shell_ but not included in the guest KVS
-namespace must be proxied through instance services such as the _exec
-service_ or _job management service_ since the _job shell_ does not have
-direct access to the primary KVS namespace.
-
-Format of this data is TBD.
 
 === Content Consumed/Produced by Other Guest Services ===
 

--- a/spec_16.adoc
+++ b/spec_16.adoc
@@ -29,7 +29,7 @@ Instance components have direct, read/write access to the primary KVS
 namespace:
 
 * _Ingest agent_
-* _Job management service_ (list, cancel, etc.)
+* _Job manager_
 * _Exec service_
 * _Scheduler_
 
@@ -43,19 +43,34 @@ Guest components have direct, read/write access to a private KVS namespace:
 
 === Job Life Cycle
 
-Jobs are submitted to the _ingest agent_ which performs a sanity
-check on the request and either adds the job to the KVS or
-refuses to accept it.
+Jobspec is submitted to the _ingest agent_ which validates it, adds it
+to the KVS, and informs the _job manager_ of the new job.
+Upon success, the jobid is returned to the user.  The _job manager_ then
+takes the active role in moving a job through its life cycle:
 
-The _scheduler_ takes up submitted jobs and considers them against
-the available resources.  It either rejects the job outright,
-or annotates it and eventually assigns resources to it.
+1) If a job has dependencies, interacting with a job dependency
+subsystem to ensure they are met before proceeding.
 
-The _exec service_ takes up jobs that have assigned resources,
-instantiates containers for those jobs and starts job shells
-within them.  When job shells and their containers start to exit,
-the _exec service_ "reaps" these shells and allows the _scheduler_
-to reclaim resources assigned to each container.
+2) Submitting an allocation request to the _scheduler_ to obtain resources.
+
+3) Once resources are allocated, submitting a start request to the
+_exec service_.
+
+4) The _exec service_ starts _job shells_ directly in a single-user instance.
+In a multi-user instance, it directs the IMP to start them with guest
+credentials, with appropriate containment.
+
+5) The _job shell_ examines jobspec and allocated resource set, then
+launches tasks on local resources.  It provides standard I/O, parallel
+bootstrap, signal propagation, and exit code collection services.
+It is a user-replaceable component.
+
+6) Once tasks exit, or an exceptional condition such as cancellation or
+expiration of wall clock allocation occurs, the _job manager_ directs the
+_exec service_ to clean up any lingering tasks and _job shells_, then
+frees resources back to the _scheduler_.
+
+The job is now complete.
 
 == Implementation
 

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -382,3 +382,4 @@ SPDX
 france
 FLUIDs
 felix
+eventlog

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -383,3 +383,4 @@ france
 FLUIDs
 felix
 eventlog
+timelimit


### PR DESCRIPTION
RFC 16 (job schema) had fallen behind the design of our execution system a bit.  I dropped the "job states" (events) listed at the top, and updated the description to better match the current design.  I suspect we'll change this a few more times as we work through the new system.