### PR TITLE
add config file for mergify autorebase/merge service

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,16 @@
+pull_request_rules:
+  - name: rebase and merge when passing all checks
+    conditions:
+      - base=master
+      - status-success=continuous-integration/travis-ci/pr
+      - label="merge-when-passing"
+      - label!="work-in-progress"
+      - "approved-reviews-by=@flux-framework/core"
+      - "#approved-reviews-by>0"
+      - "#changes-requested-reviews-by=0"
+      - -title~="^\[*(WIP|wip)"
+    actions:
+      merge:
+        method: merge
+        strict: smart
+        strict_method: rebase


### PR DESCRIPTION

Maybe trying out mergify.io on the rfc project first will be more acceptable?

This PR adds an initial config file for mergify.io with strict merge enabled.
This config file enables the mergify bot to auto-rebase and merge
PRs once all of the following conditions are met:

 - The label "merge-when-passing" is applied
 - The label "work-in-progress" is not applied
 - The PR title doesn't start with "[wip|WIP]" or "wip" or "WIP"
 - Travis-CI checks pass
 - There is at least one approving review by a member of flux team
 - There are no outstanding changes requested.