### PR TITLE
rfc20: allow multiple ranks per R_lite entry

### DIFF
--- a/spec_20.adoc
+++ b/spec_20.adoc
@@ -23,6 +23,7 @@ in this document are to be interpreted as described in RFC 2119.
 * link:spec_14{outfilesuffix}[14/Canonical Job Specification]
 * link:spec_15{outfilesuffix}[15/Independent Minister of Privilege for Flux]
 * link:spec_16{outfilesuffix}[16/KVS Job Schema]
+* link:spec_22{outfilesuffix}[22/Idset String Representation]
 
 == Overview
 
@@ -103,12 +104,10 @@ the following two keys:
    extensions.
 
 [horizontal]
-    *core*::: The `core` key contains a logical compute core IDs string.
-     It SHALL be a comma-separated list of core IDs (e.g., 1,3,4,5) or
-     hyphenated ranges for consecutive integer IDs (e.g., 1,3-5).
-    *gpu*::: This OPTIONAL key contains a logical GPU IDs string.
-     It SHALL be a comma-separated list of gpu IDs or hyphenated ranges
-     for consecutive integer IDs.
+    *core*::: The `core` key SHALL contain a logical compute core IDs string
+     in RFC 22 *idset format*.
+    *gpu*::: The OPTIONAL `gpu` key SHALL contain a logical GPU IDs string
+     in RFC 22 *idset format*.
 
 An `R_lite` dictionary entry MAY also contain any of the following optional
 keys:

--- a/spec_20.adoc
+++ b/spec_20.adoc
@@ -94,9 +94,10 @@ and `expiration`. `R_lite`
 is a strict list of dictionaries each of which SHALL contain at least
 the following two keys:
 
-  *rank*:: The value of the `rank` key SHALL be the integer broker rank that
-  manages the target compute node. This SHALL disambiguate the case where multiple
-  brokers manage a same node.
+  *rank*:: The value of the `rank` key SHALL be a string list of
+   broker rank identifiers in *idset format* (See RFC 22). This list
+   SHALL indicate the broker ranks to which other information in
+   the current entry applies.
 
   *children*:: The `children` key encodes the information about certain compute resources
    contained within this compute node. The value of this key SHALL contain a dictionary

--- a/spec_20.adoc
+++ b/spec_20.adoc
@@ -88,11 +88,12 @@ the format version.
 
 === Execution
 
-The value of the `execution` key SHALL contain exactly three keys
-with other keys reserved for future extensions: `R_lite`, `starttime`,
-and `expiration`. `R_lite`
-is a strict list of dictionaries each of which SHALL contain at least
-the following two keys:
+The value of the `execution` key SHALL contain at least the single key
+`R_lite`, with optional keys `starttime` and `expiration` and other keys
+reserved for future extensions.
+
+`R_lite` is a strict list of dictionaries each of which SHALL contain
+at least the following two keys:
 
   *rank*:: The value of the `rank` key SHALL be a string list of
    broker rank identifiers in *idset format* (See RFC 22). This list
@@ -116,11 +117,22 @@ keys:
   *node*:: The value of the `node` key, if present, SHALL be the string
    hostname of the target compute node.
 
-`starttime` and `expiration` SHALL encode the start and end times
-of the resource set. The values of `starttime` and `expiration` SHALL
-be the number of seconds elapsed since the Unix Epoch (1970-01-01 UTC).
-They MUST be greater than zero and the value for `expiration` MUST
-be greater than `starttime`.
+The `execution` key MAY contain any of the following optional keys:
+
+  *starttime*:: The value of the `starttime` key, if present, SHALL
+   encode the start time at which the resource set is valid. The
+   value SHALL be the number of seconds elapsed since the Unix Epoch
+   (1970-01-01 00:00:00 UTC) with optional microsecond precision.
+   If `starttime` is unset, then the resource set has no specified
+   start time and is valid beginning at any time up to `expiration`.
+
+  *expiration:: The value of the `expiration` key, if present, SHALL
+   encode the end or expiration time of the resource set in seconds
+   since the Unix Epoch, with optional microsecond precision. If
+   `starttime` is also set, `expiration` MUST be greater than
+   `starttime`. If `expiration` is unset, the resource set has no
+   specified end time and is valid beginning at `starttime` without
+   expiration.
 
 === Scheduling
 

--- a/spec_20.adoc
+++ b/spec_20.adoc
@@ -90,10 +90,8 @@ the format version.
 The value of the `execution` key SHALL contain exactly three keys
 with other keys reserved for future extensions: `R_lite`, `starttime`,
 and `expiration`. `R_lite`
-is a strict list of dictionaries each of which SHALL contain three keys:
-
-  *node*:: The value of the `node` key SHALL be the string hostname
-   of the target compute node.
+is a strict list of dictionaries each of which SHALL contain at least
+the following two keys:
 
   *rank*:: The value of the `rank` key SHALL be the integer broker rank that
   manages the target compute node. This SHALL disambiguate the case where multiple
@@ -111,6 +109,12 @@ is a strict list of dictionaries each of which SHALL contain three keys:
     *gpu*::: This OPTIONAL key contains a logical GPU IDs string.
      It SHALL be a comma-separated list of gpu IDs or hyphenated ranges
      for consecutive integer IDs.
+
+An `R_lite` dictionary entry MAY also contain any of the following optional
+keys:
+
+  *node*:: The value of the `node` key, if present, SHALL be the string
+   hostname of the target compute node.
 
 `starttime` and `expiration` SHALL encode the start and end times
 of the resource set. The values of `starttime` and `expiration` SHALL


### PR DESCRIPTION
As discussed in #161, allow multiple ranks per R_lite "entry" object to allow for condensed representation.

Also makes `node` an optional member of *R_lite* entries (not sure hostnames belong in R_lite anyway), and reference an TBD (to be drafted) RFC for the *idset* format.

Closes #161