### PR TITLE
rfc22: add idset string specification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ SOURCES = \
 	spec_18.adoc \
 	spec_19.adoc \
 	spec_20.adoc \
-	spec_21.adoc
+	spec_21.adoc \
+	spec_22.adoc
 
 HTML = $(SOURCES:.adoc=.html)
 PDF = $(SOURCES:.adoc=.pdf)

--- a/README.adoc
+++ b/README.adoc
@@ -112,6 +112,10 @@ representation or _R_ in short.
 link:spec_21{outfilesuffix}[21/Job States]::
 This specification describes Flux job states.
 
+link:spec_22{outfilesuffix}[22/Idset String Representation]::
+This specification describes a compact form for expressing a set of
+non-negative, integer ids.
+
 == Change Process
 
 The change process is

--- a/spec_22.adoc
+++ b/spec_22.adoc
@@ -1,0 +1,50 @@
+ifdef::env-github[:outfilesuffix: .adoc]
+
+22/Idset String Representation
+==============================
+
+This specification describes a compact form for
+expressing a set of non-negative, integer ids.
+
+* Name: github.com/flux-framework/rfc/spec_22.adoc
+* Editor: Jim Garlick <garlick@llnl.gov>
+* State: raw
+
+== Language
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
+be interpreted as described in http://tools.ietf.org/html/rfc2119[RFC 2119].
+
+== Background
+
+It is often necessary to represent a set of non-negative, integer ids
+as a compact string for human input, output, or in messages.  For example:
+
+* A set of task ranks.
+* A set of broker ranks.
+* A set of resource ids or indices.
+
+== Implementation
+
+An idset SHALL consist of unique, non-negative integer ids.
+
+An idset string SHALL consist of ids in ascending numerical order,
+delimited by commas, e.g. `1,2,3,5,6,42`.
+
+Ids in an idset string SHALL be represented in decimal form.
+
+Ids in an idset string SHALL NOT include leading zeroes.
+
+Consecutive ids in an idset string MAY be compressed into hyphenated
+ranges, e.g. `1-3,5-6,42`.
+
+An idset string MAY be surrounded by square brackets to promote readability,
+e.g. `[1-3,5-6,42]`.
+
+An idset string SHALL consist only of the following characters:
+
+* The decimal digits: `0 1 2 3 4 5 6 7 8 9`
+* Comma: `,`
+* Hyphen: `-`
+* Square brackets: `[ ]`

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -398,3 +398,4 @@ sched
 svg
 invariants
 unutilized
+idset


### PR DESCRIPTION
This RFC defines the (simple!) idset string format, so that other RFCs don't have to.  @grondo suggested it and I thought it was a good idea.