### PR TITLE
rfc21: define the events that drive state transitions in more detail

### DIFF
--- a/spec_21.adoc
+++ b/spec_21.adoc
@@ -19,6 +19,7 @@ be interpreted as described in http://tools.ietf.org/html/rfc2119[RFC 2119].
 
 *  link:spec_16{outfilesuffix}[16/KVS Job Schema]
 *  link:spec_18{outfilesuffix}[18/KVS Event Log Format]
+*  link:spec_22{outfilesuffix}[22/Idset String Representation]
 
 == Background
 
@@ -48,6 +49,8 @@ and _inactive_ once it has.
 
 == Implementation
 
+Job state transitions are driven by events.
+
 === State Diagram
 
 image::data/spec_21/states.svg[width=750]
@@ -55,63 +58,199 @@ image::data/spec_21/states.svg[width=750]
 === State Descriptions
 
 NEW::
-Initial state for internal use only.
+Initial state.  The required `submit` event, which logs the job's creation,
+transitions the state to DEPEND.
 
 DEPEND::
 The job is blocked waiting for dependencies to be satisfied.  The job manager
 makes a request to the dependency service and receives a response once
 the job's dependencies are satisfied, then logs the `depend` event.
+The state transitions to SCHED.
 
 SCHED::
 The job is blocked waiting for resources.  The job manager sends an
 allocation request to the scheduler and receives a response once the
 job has been assigned resources, then logs the `alloc` event.
+The state transitions to RUN.
 
 RUN::
 The job is able to run or is running.  The job manager sends a request
 to the exec service to start the job, then logs a `start` event once the
-job shells have been started.  It then sends a request to the exec service to
-wait for completion, then logs a `finish` event once all job shells have
-exited.
+job shells have been started, and a `finish` event once all the job shells
+have exited.  The state transitions to CLEANUP.
 
 CLEANUP::
-The job has completed or an exception has occurred.  If there has been
-a `start` event, any remnants of execution are cleaned up and a `finish`
-event is logged.  If there has been an `alloc` event, resources are released
-to the scheduler and a `free` event is logged.
+The job has completed or an exception has occurred.  Under normal termination,
+the job manager waits for notification from the exec service that job
+resources can be released, logging `release` events, then returns resources
+to the scheduler and logs a `free` event.  Under exceptional termination,
+one or more steps may be unnecessary, depending on prior events.
+Once cleanup is complete, the state transitions to INACTIVE.
 
 INACTIVE::
 Job data in KVS is now read-only (captive state).
 
 === Exceptions
 
-An exception is an extraordinary occurrence that MAY interrupt the
+An exception event is an extraordinary occurrence that MAY interrupt the
 "normal" job life cycle.
 
-When an exception occurs, an event named `exception` SHALL be logged to the
-job's eventlog.  The RFC 18 _context_ SHALL be encoded in space-delimited
-`key=value` form, with any trailing non-conforming text interpreted as a
-human readable message.  The following keys are REQUIRED:
+An exception SHALL be assigned a severity value from 0 (most severe)
+to 7 (least severe).
 
-type=TYPE::
-Specify the type of exception (see below).
-
-severity=SEVERITY::
-Specify the severity of the exception, an integer in the range of 0 to 7.
-`severity=0` is the most severe.
-
-Example:
-
-----
-timestamp exception type=cancel severity=0 user=5588 Never mind!\n
-----
-
-An exception event with `severity=0` SHALL cause the job state to
+An exception event with severity of zero SHALL cause the job state to
 immediately transition to `CLEANUP`.   Exception events with a severity
 other than zero do not affect job state, and are assumed to be meaningful
 to other components managing non-fatal exceptions.
 
-Exception types SHALL include:
+The exception event format is described below.
+
+=== Event Descriptions
+
+Job state transitions are driven by events that are logged to
+`jobs.active.<jobid>.eventlog` as required by RFC 16.
+
+The event _context_ (described in RFC 18) SHALL consist of a JSON object,
+encoded without newline characters.  Specific requirements for each event
+are described below:
+
+==== Submit Event
+
+Job was submitted.
+
+The following keys are REQUIRED in the event context object:
+
+priority::
+(integer) Initial priority in the range of 0-31.
+
+userid::
+(integer) Authenticated user ID of submitter.
+
+flags::
+(integer) Mask of flags (1=debug).
+
+Example:
+
+----
+1552593348.073045 submit {"priority":16,"userid":5588,"flags":0}
+----
+
+==== Priority Event
+
+Job is to be re-prioritized.
+
+The following keys are REQUIRED in the event context object:
+
+priority::
+(integer) New priority in the range of 0-31.
+
+userid::
+(integer) Authenticated user ID of requester.
+
+----
+1552593547.411336 priority {"priority":0,"userid":5588}
+----
+
+==== Alloc Event
+
+Resources have been allocated by the scheduler.
+
+The following keys are OPTIONAL in the event context object:
+
+note::
+(string) Scheduler annotation for resource allocation.
+
+Example:
+
+----
+1552593348.088391 alloc {"note":"rank0/core[0-1]"}
+----
+
+==== Free Event
+
+Resources have been released to the scheduler.
+
+The context SHALL be empty.
+
+Example:
+
+----
+1552593348.093541 free
+----
+
+==== Start Event
+
+Job shells have started.
+
+The context SHALL be empty.
+
+Example:
+
+----
+1552593348.089787 start
+----
+
+==== Release Event
+
+Resources have been released.
+
+Example:
+
+The following keys are REQUIRED in the event context object:
+
+ranks::
+(string) An idset of broker ranks or "all", indicating a subset
+of resources that are being released.
+
+final::
+(boolean) True if all resources allocated to the job have been released.
+
+----
+1552593348.092830 release {"ranks":"all","final":true}
+----
+
+==== Finish Event
+
+Job shells have terminated.
+
+The context SHALL be empty.
+
+Future: context will contain or refer to global exit status.
+
+Example:
+
+----
+1552593348.090927 finish
+----
+
+==== Exception Event
+
+An exception occurred.
+
+The following keys are REQUIRED in the event context object:
+
+type::
+(string) Specify the type of exception (see below).
+
+severity::
+(integer) Specify the severity of the exception, in range of 0 (most severe)
+to to 7 (least severe).
+
+The following keys are OPTIONAL:
+
+note::
+(string) Brief human-readable explanation of the exception.
+
+userid::
+(integer) User ID that initiated the exception, if other than instance owner.
+
+Example:
+
+----
+1552593986.335602 exception {"type":"oom","severity":0,"userid":5588,"note":"out of memory on foo42"}
+----
+
+Exception types include but are not limited to:
 
 cancel::
 The job was canceled.
@@ -128,11 +267,21 @@ A problem occurred during scheduling.
 start::
 A problem occurred while starting job shells.
 
-finish::
-A problem occurred while waiting for job shells to finish.
-
 free::
 A problem occurred while releasing resources to the scheduler.
+
+==== Debug Event
+
+Debug event names are prefixed with "debug."  They are optional and
+are intended to provide context in the eventlog that aids debugging.
+
+There are no specific requirements for the event context.
+
+Example:
+
+----
+1552594649.848032 debug.free-request
+----
 
 === Synchronization
 

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -400,3 +400,4 @@ invariants
 unutilized
 idset
 starttime
+oom


### PR DESCRIPTION
Add detail regarding the events that the job manager logs to the primary job eventlog.

Back out the requirement that the event context use a `key=value [key=value...]` format, and use JSON instead so that we don't set ourselves on a path of reinventing yet another half-baked serialization format.

The transition to JSON was discussed in flux-framework/flux-core#2076

This is a rather big update but I would say the original draft was pretty drafty, and now that we've got some implementation out of the way, we can set more details down here.  There are still some changes required to support partial release of resources and reporting of global exit status, but I thought we are better off documenting what we have now and adding that later.