### PR TITLE
rfc21: change title, add clean event

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -109,8 +109,9 @@ link:spec_20{outfilesuffix}[20/Resource Set Specification]::
 This specification defines the version 1 format of the resource-set
 representation or _R_ in short.
 
-link:spec_21{outfilesuffix}[21/Job States]::
-This specification describes Flux job states.
+link:spec_21{outfilesuffix}[21/Job States and Events]::
+This specification describes Flux job states and the events that trigger
+job state transitions.
 
 link:spec_22{outfilesuffix}[22/Idset String Representation]::
 This specification describes a compact form for expressing a set of

--- a/spec_21.adoc
+++ b/spec_21.adoc
@@ -85,7 +85,8 @@ the job manager waits for notification from the exec service that job
 resources can be released, logging `release` events, then returns resources
 to the scheduler and logs a `free` event.  Under exceptional termination,
 one or more steps may be unnecessary, depending on prior events.
-Once cleanup is complete, the state transitions to INACTIVE.
+Once cleanup is complete, the job manager logs a `clean` event.
+The state transitions to INACTIVE.
 
 INACTIVE::
 Job data in KVS is now read-only (captive state).
@@ -221,6 +222,18 @@ Example:
 
 ----
 1552593348.090927 finish
+----
+
+==== Clean Event
+
+Cleanup has completed.
+
+The context SHALL be empty.
+
+Example:
+
+----
+1552593348.104432 clean
 ----
 
 ==== Exception Event

--- a/spec_21.adoc
+++ b/spec_21.adoc
@@ -1,9 +1,10 @@
 ifdef::env-github[:outfilesuffix: .adoc]
 
-21/Job States
-=============
+21/Job States and Events
+========================
 
-This specification describes Flux job states.
+This specification describes Flux job states and the events that trigger
+job state transitions.
 
 * Name: github.com/flux-framework/rfc/spec_21.adoc
 * Editor: Jim Garlick <garlick@llnl.gov>
@@ -44,12 +45,11 @@ and _inactive_ once it has.
 * All job state transitions SHALL be initiated by the job manager.
 * A state SHALL exist for synchronization on job completion, such that
   job data in the KVS is stable once this state is reached.
-* Events that drive state transitions SHALL be logged to the job eventlog.
+* All job state transitions SHALL be driven by events.
+* Events SHALL be logged to the job eventlog.
 * Replaying the job eventlog SHALL accurately reproduce the current job state.
 
 == Implementation
-
-Job state transitions are driven by events.
 
 === State Diagram
 

--- a/spec_21.adoc
+++ b/spec_21.adoc
@@ -104,6 +104,8 @@ immediately transition to `CLEANUP`.   Exception events with a severity
 other than zero do not affect job state, and are assumed to be meaningful
 to other components managing non-fatal exceptions.
 
+More than one exception MAY occur per job.
+
 The exception event format is described below.
 
 === Event Descriptions


### PR DESCRIPTION
Update RFC 21 to add a `clean` event, used to indicate that CLEANUP state activities are over.

Also since the RFC now contains quite a lot of detail about job events, update the title to
_21/Job States and Events_.

Finally, I noticed we didn't mention that a job can have multiple exceptions.  Make that explicit.