### PR TITLE
rfc14: allow attributes to have any value type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,22 +23,19 @@ SOURCES = \
 	spec_22.adoc
 
 HTML = $(SOURCES:.adoc=.html)
-PDF = $(SOURCES:.adoc=.pdf)
+
+# N.B. 'apt-get install codray' to enable inline source highlighting
+ADOC_FLAGS = --attribute=source-highlighter=coderay
 
 all: html
 
 html: $(HTML)
 
-pdf: $(PDF)
-
 %.html: %.adoc
-	asciidoc -o $@ $^
-
-%.pdf: %.adoc
-	a2x -f pdf $^
+	asciidoctor $(ADOC_FLAGS) -o $@ $^
 
 clean:
-	rm -f $(HTML) $(PDF)
+	rm -f $(HTML)
 
 check:
 	ASPELL=aspell ./spellcheck *.adoc

--- a/data/spec_14/schema.json
+++ b/data/spec_14/schema.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://github.com/flux-framework/rfc/tree/master/data/spec_14/schema.json",
+  "title": "jobspec-01",
+
+  "description":         "Flux jobspec version 1",
+
+  "definitions": {
+    "complex_range": {
+      "description": "a complex range of numbers",
+      "type": "object",
+      "properties":{
+        "min": { "type": "integer", "minimum" : 1 },
+        "max": { "type": "integer", "minimum" : 1 },
+        "operator": { "type": "string", "enum": ["+", "*", "^"] },
+        "operand": { "type": "integer", "minimum" : 1 }
+      },
+      "required": ["min"],
+      "dependencies": {
+         "max":      { "required": ["operator", "operand"] },
+         "operator": { "required": ["max", "operand"] },
+         "operand":  { "required": ["max", "operator"] }
+      },
+      "additionalProperties": false
+    },
+    "resource_vertex_base": {
+      "description": "base schema for slot/other resource vertex",
+      "type": "object",
+      "required": ["type", "count"],
+      "properties": {
+        "type": { "type": "string" },
+        "count": {
+          "oneOf": [
+            { "type": "integer", "minimum" : 1 },
+            { "$ref": "#/definitions/complex_range" }
+          ]
+        },
+        "exclusive": { "type": "boolean" },
+        "with": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/resource_vertex" }
+        },
+        "id": { "type": "string" },
+        "unit": { "type": "string" },
+        "label": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "resource_vertex_slot": {
+      "description": "special slot resource type - label assigns to task slot",
+      "allOf": [
+        { "$ref": "#/definitions/resource_vertex_base" },
+        {
+          "properties": {
+            "type": { "enum": ["slot"] }
+          },
+          "required": ["label"]
+        }
+      ]
+    },
+    "resource_vertex_other": {
+      "description": "other (non-slot) resource type",
+      "allOf": [
+        { "$ref": "#/definitions/resource_vertex_base" },
+        {
+          "properties": {
+            "type": { "not": { "enum": ["slot"] } }
+          }
+        }
+      ]
+    },
+    "resource_vertex": {
+      "oneOf":[
+        { "$ref": "#/definitions/resource_vertex_slot" },
+        { "$ref": "#/definitions/resource_vertex_other" }
+      ]
+    }
+  },
+
+  "type": "object",
+  "required": ["version", "resources", "attributes", "tasks"],
+  "properties": {
+    "version": {
+      "description": "the jobspec version",
+      "type": "integer",
+      "enum": [1]
+    },
+    "resources": {
+      "description": "requested resources",
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/resource_vertex" }
+    },
+    "attributes": {
+      "description": "system and user attributes",
+      "type": ["object", "null"],
+      "properties": {
+        "system": {
+          "type": "object",
+          "properties": {
+            "duration": { "type": "string" }
+          }
+        },
+        "user": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    "tasks": {
+      "description": "task configuration",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["command", "slot", "count" ],
+        "properties": {
+          "command": {
+            "type": ["string", "array"],
+            "minItems": 1,
+            "items": { "type": "string" }
+          },
+          "slot": { "type": "string" },
+          "count": {
+            "type": "object",
+            "properties": {
+              "per_slot": { "type": "integer", "minimum" : 1 },
+              "total": { "type": "integer", "minimum" : 1 }
+            }
+          },
+          "distribution": { "type": "string" },
+          "attributes": {
+            "type": "object",
+	    "additionalProperties": { "type": "string" }
+          }
+        },
+	"additionalProperties": false
+      }
+    }
+  }
+}

--- a/spec_14.adoc
+++ b/spec_14.adoc
@@ -571,9 +571,3 @@ Jobspec YAML::
 ----
 include::data/spec_14/use_case_2.6.yaml[]
 ----
-
-
-[sect2]
-== References
-
-* https://www.ogf.org/documents/GFD.56.pdf[Job Submission Description Language (JSDL) Specification, Version 1.0, Ali Anjomshoaa, et al., 2005]

--- a/spec_14.adoc
+++ b/spec_14.adoc
@@ -257,8 +257,8 @@ descriptor SHALL contain the following keys:
 === Attributes
 
 The value of the `attributes` key SHALL be a dictionary of dictionaries.
-The `attributes` dictionary MAY contain one or more of the following keys
-which, if present, must have dictionary values:
+The `attributes` dictionary MAY contain one or both of the following keys
+which, if present, must have values.  Values MAY have any valid YAML type.
 
  *user*::
  Attributes in the `user` dictionary are unrestricted, and may be used

--- a/spec_14.adoc
+++ b/spec_14.adoc
@@ -105,9 +105,7 @@ program. The dictionary MUST contain the keys `resources`, `tasks`,
 
 Each of the listed jobspec keys SHALL meet the form and requirements
 listed in detail in the sections below. For reference, a ruleset for
-compliant canonical jobspec is provided using *JSON Schema*
-footnoteref:[jsonschema,https://json-schema.org/latest/json-schema-core.html[JSON Schema: A Media Type for Describing JSON Documents]; H. Andrews; 2018]
- in the *Schema* at the end of this section.
+compliant canonical jobspec is provided in the *Schema* section below.
 
 === Resources
 
@@ -308,7 +306,7 @@ include::data/spec_14/example2.yaml[]
 
 A jobspec conforming to version 1 of the language definition SHALL
 adhere to the following ruleset, described using JSON Schema
-footnoteref:[jsonschema]
+footnote:[https://json-schema.org/latest/json-schema-core.html[JSON Schema: A Media Type for Describing JSON Documents]; H. Andrews; 2018].
 
 [source,json]
 ----

--- a/spec_14.adoc
+++ b/spec_14.adoc
@@ -105,9 +105,9 @@ program. The dictionary MUST contain the keys `resources`, `tasks`,
 
 Each of the listed jobspec keys SHALL meet the form and requirements
 listed in detail in the sections below. For reference, a ruleset for
-compliant canonical jobspec is provided using *JSON Content Rules*
-footnoteref:[contentrules,https://tools.ietf.org/id/draft-newton-json-content-rules-06.txt[JSON Content Rules (jcr-version 0.6)]; A. Newton; P. Cordell; 2016]
- in the *Content Rules* at the end of this section.
+compliant canonical jobspec is provided using *JSON Schema*
+footnoteref:[jsonschema,https://json-schema.org/latest/json-schema-core.html[JSON Schema: A Media Type for Describing JSON Documents]; H. Andrews; 2018]
+ in the *Schema* at the end of this section.
 
 === Resources
 
@@ -304,71 +304,16 @@ Another example, running one task on each of four nodes.
 include::data/spec_14/example2.yaml[]
 ----
 
-=== Content Rules
+=== Schema
 
 A jobspec conforming to version 1 of the language definition SHALL
-adhere to the following ruleset, described using JSON Content Rules
-footnoteref:[contentrules]
- draft version 0.6.
+adhere to the following ruleset, described using JSON Schema
+footnoteref:[jsonschema]
 
+[source,json]
 ----
-# jcr-version 0.6
-
-{
-   "resources" : [ $vertex + ],
-   "tasks" : tasks,
-   "attributes" : { $system_attributes, $user_attributes },
-   "version" : 1
-}
-
-$slot_label := string
-
-$vertex_common = {
-    "count" : ( 1.. | $complex_range),
-    ?"exclusive" : boolean,
-    ?"with" : [ $vertex + ]
-}
-
-slot_vertex = {
-    "type"  : "slot",
-    "label" : $slot_label,
-    $vertex_common,
-}
-
-resource_vertex = {
-    "type" : ( :string, + @{reject} ("slot")),
-    $vertex_common
-    ?"id" : string,
-    ?"unit" : string,
-}
-
-vertex = ( $slot_vertex | $resource_vertex )
-
-$complex_range = {
-    "min" : 1..,
-    "max" : 1..,
-    "operator" : ( :"+" | :"*" | : "^" ),
-    "operand" : 1..,
-}
-
-$tasks = {
-    "command" : [ string + ],
-    "slot" : $slot_label,
-    "count" : { "per_slot" : 1.. | "total" : 1.. },
-    "distribution" : string,
-    ?"attributes" : { /.*/ : any },
-}
-
-$system_attributes = {
-    "duration" : string,
-    /.*/ : string
-}
-
-$user_attributes = { /.*/ : string }
-
+include::data/spec_14/schema.json[]
 ----
-
-
 
 == Basic Use Cases
 

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -370,6 +370,7 @@ runnable
 username
 ENODATA
 contentrules
+jsonschema
 footnoteref
 Herbein
 UTC


### PR DESCRIPTION
As discussed in #172, this PR
* Specifically calls out that system and user attributes can have any value type
* Replaces JCR specification with json-schema from flux-core, which now allows any type

Change the Makefile to generate html using asciidoctor and coderay, which makes a much prettier rendering, with inline source includes expanded and highlighted.

Sadly:  github rendering of includes doesn't even produce a clickable link anymore.  We really need to consider those other document publishing options, time permitting.