### PR TITLE
rfc21: add context to finish event

### DIFF
--- a/spec_21.adoc
+++ b/spec_21.adoc
@@ -197,8 +197,6 @@ Example:
 
 Resources have been released.
 
-Example:
-
 The following keys are REQUIRED in the event context object:
 
 ranks::
@@ -207,6 +205,8 @@ of resources that are being released.
 
 final::
 (boolean) True if all resources allocated to the job have been released.
+
+Example:
 
 ----
 1552593348.092830 release {"ranks":"all","final":true}

--- a/spec_21.adoc
+++ b/spec_21.adoc
@@ -216,14 +216,17 @@ Example:
 
 Job shells have terminated.
 
-The context SHALL be empty.
+The following keys are REQUIRED in the event context object:
 
-Future: context will contain or refer to global exit status.
+status::
+(integer) The largest of the job shell wait status codes, as
+defined by POSIX wait(2)
+footnote:[http://pubs.opengroup.org/onlinepubs/009604499/functions/wait.html[wait, waitpid - wait for a child process to stop or terminate]; The Open Group Base Specifications Issue 6; IEEE Std 1003.1, 2004 Edition]
 
 Example:
 
 ----
-1552593348.090927 finish
+1552593348.090927 finish {"status":0}
 ----
 
 ==== Clean Event

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -402,3 +402,5 @@ unutilized
 idset
 starttime
 oom
+waitpid
+IEEE


### PR DESCRIPTION
This PR adds a `status` value to the `finish` event context, tracking development in flux-framework/flux-core#2077.