### PR TITLE
rfc23: describe a common duration string format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ SOURCES = \
 	spec_19.adoc \
 	spec_20.adoc \
 	spec_21.adoc \
-	spec_22.adoc
+	spec_22.adoc \
+	spec_23.adoc
 
 HTML = $(SOURCES:.adoc=.html)
 

--- a/README.adoc
+++ b/README.adoc
@@ -117,6 +117,9 @@ link:spec_22{outfilesuffix}[22/Idset String Representation]::
 This specification describes a compact form for expressing a set of
 non-negative, integer ids.
 
+link:spec_23{outfilesuffix}[23/Flux Standard Duration]::
+This specification describes a standard form for time duration.
+
 == Change Process
 
 The change process is

--- a/spec_23.adoc
+++ b/spec_23.adoc
@@ -1,0 +1,41 @@
+ifdef::env-github[:outfilesuffix: .adoc]
+
+23/Flux Standard Duration
+=========================
+
+This specification describes a simple string format used to represent
+a duration of time.
+
+* Name: github.com/flux-framework/rfc/spec_23.adoc
+* Editor: Mark A. Grondona <mark.grondona@gmail.com>
+* State: raw
+
+== Language
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
+be interpreted as described in http://tools.ietf.org/html/rfc2119[RFC 2119].
+
+== Background
+
+Many Flux utilities and services may take a time _duration_ as input
+either via user-provided options, configuration input, or message payload
+contents.  To provide a consistent interface, and reduce the chance of
+incompatibility between Flux components, it is useful to standardize on
+a duration format that is human readable, easily parsed, and compact.
+
+Utilities and services that support the duration form described here are
+said to support "Flux Standard Duration."
+
+== Implementation
+
+A duration in Flux Standard Duration SHALL be of the form `N[SUFFIX]`
+where `SUFFIX` SHALL be optional and, if provided, MUST be a single character
+from the set `s,m,h,d`. The value `N` MUST be a positive, floating-point number,
+and SHALL be interpreted as:
+
+  * _seconds_ if `SUFFIX` is not provided, or is `s`.
+  * _minutes_ if `SUFFIX` is `m`.
+  * _hours_ if `SUFFIX` is `h`.
+  * _days_ if `SUFFIX` is `d`.
+


### PR DESCRIPTION
This PR adds a description of Flux Standard Duration:tm:, a common string duration format (as in GNU `sleep(1)`)