### PR TITLE
rfc14: make duration attribute a number of seconds

### DIFF
--- a/data/spec_14/example1.yaml
+++ b/data/spec_14/example1.yaml
@@ -16,4 +16,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.

--- a/data/spec_14/example2.yaml
+++ b/data/spec_14/example2.yaml
@@ -13,4 +13,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.

--- a/data/spec_14/use_case_1.1.yaml
+++ b/data/spec_14/use_case_1.1.yaml
@@ -13,4 +13,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.

--- a/data/spec_14/use_case_1.2.yaml
+++ b/data/spec_14/use_case_1.2.yaml
@@ -17,4 +17,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.

--- a/data/spec_14/use_case_1.3.yaml
+++ b/data/spec_14/use_case_1.3.yaml
@@ -22,4 +22,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.

--- a/data/spec_14/use_case_1.4.yaml
+++ b/data/spec_14/use_case_1.4.yaml
@@ -19,4 +19,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.

--- a/data/spec_14/use_case_1.5.yaml
+++ b/data/spec_14/use_case_1.5.yaml
@@ -38,4 +38,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 4 hours
+    duration: 14400.

--- a/data/spec_14/use_case_1.6.yaml
+++ b/data/spec_14/use_case_1.6.yaml
@@ -22,4 +22,4 @@ tasks:
         count: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.

--- a/data/spec_14/use_case_1.7.yaml
+++ b/data/spec_14/use_case_1.7.yaml
@@ -22,4 +22,4 @@ tasks:
         count: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.

--- a/data/spec_14/use_case_2.1.yaml
+++ b/data/spec_14/use_case_2.1.yaml
@@ -13,4 +13,4 @@ tasks:
       per_slot: 5
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.

--- a/data/spec_14/use_case_2.2.yaml
+++ b/data/spec_14/use_case_2.2.yaml
@@ -13,4 +13,4 @@ tasks:
       total: 5
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.

--- a/data/spec_14/use_case_2.3.yaml
+++ b/data/spec_14/use_case_2.3.yaml
@@ -13,4 +13,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.

--- a/data/spec_14/use_case_2.4.yaml
+++ b/data/spec_14/use_case_2.4.yaml
@@ -32,4 +32,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.

--- a/data/spec_14/use_case_2.5.yaml
+++ b/data/spec_14/use_case_2.5.yaml
@@ -17,4 +17,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.

--- a/data/spec_14/use_case_2.6.yaml
+++ b/data/spec_14/use_case_2.6.yaml
@@ -18,4 +18,4 @@ tasks:
       total: 10
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.

--- a/spec_14.adoc
+++ b/spec_14.adoc
@@ -278,9 +278,9 @@ at all possible.
 Some common system attributes are:
 
  *duration*::
- The value of the `duration` attribute is a string representing time span.
- The scheduler will make an effort to allocate the requested resources
- for the time specified in `duration`.
+ The value of the `duration` attribute is a number representing time span
+ in seconds. The scheduler will make an effort to allocate the requested
+ resources for the number of seconds specified in `duration`.
 
 === Example Jobspec
 


### PR DESCRIPTION
Problem: RFC 14 specifies that the system attribute "duration" is
a "string representing a time span", but does not specify how that
string is to be interpreted.

Since this RFC describes a canonical jobspec format, specifically
state that the duration is a number of seconds, leaving no question
as to how it should be interpreted.

Update all use case examples that used arbitrary strings for duration.

Fixes #175