### PR TITLE
rfc14: clarify duration attribute range and meaning

### DIFF
--- a/spec_14.adoc
+++ b/spec_14.adoc
@@ -278,9 +278,11 @@ at all possible.
 Some common system attributes are:
 
  *duration*::
- The value of the `duration` attribute is a number representing time span
- in seconds. The scheduler will make an effort to allocate the requested
- resources for the number of seconds specified in `duration`.
+ The value of the `duration` attribute is a number greater than or equal
+ to zero representing time span in seconds. A `duration` of 0 SHALL be
+ interpreted as "unlimited" or "not set" by the system. The scheduler
+ will make an effort to allocate the requested resources for the number
+ of seconds specified in `duration`.
 
 === Example Jobspec
 


### PR DESCRIPTION
As mentioned in flux-framework/flux-core#2096, the `duration` system attribute should have a minimum of `0`, where `0` (zero) itself is reserved for a special meaning of either "not set" or "unlimited".

After I wrote that I though perhaps "not set" could be represented by literally not setting the `duration` attribute. Should I change the wording here to state that zero means "unlimited" duration? 