### PR TITLE
RFCs 14 & 25: Jobspec Version 1 + ENV and CWD attributes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,9 @@ SOURCES = \
 	spec_21.adoc \
 	spec_22.adoc \
 	spec_23.adoc \
-	spec_24.adoc
+	spec_24.adoc \
+	spec_25.adoc
+
 
 HTML = $(SOURCES:.adoc=.html)
 

--- a/README.adoc
+++ b/README.adoc
@@ -123,6 +123,9 @@ link:spec_24{outfilesuffix}[24/Flux Job Standard I/O Version 1]::
 This specification describes the format used to represent standard
 I/O streams in the Flux KVS.
 
+link:spec_25{outfilesuffix}[25/Job Specification Version 1]:: Version 1 of the
+domain specific job specification language canonically defined in RFC14.
+
 == Change Process
 
 The change process is

--- a/data/spec_14/example1.yaml
+++ b/data/spec_14/example1.yaml
@@ -17,3 +17,6 @@ tasks:
 attributes:
   system:
     duration: 3600.
+    cwd: "/home/flux"
+    environment:
+      HOME: "/home/flux"

--- a/data/spec_14/example2.yaml
+++ b/data/spec_14/example2.yaml
@@ -14,3 +14,6 @@ tasks:
 attributes:
   system:
     duration: 3600.
+    cwd: "/home/flux"
+    environment:
+      HOME: "/home/flux"

--- a/data/spec_14/schema.json
+++ b/data/spec_14/schema.json
@@ -98,7 +98,9 @@
         "system": {
           "type": "object",
           "properties": {
-            "duration": { "type": "string" }
+            "duration": { "type": "number", "minimum": 0 },
+            "cwd": { "type": "string" },
+            "environment": { "type": "object" }
           }
         },
         "user": {

--- a/data/spec_14/schema.json
+++ b/data/spec_14/schema.json
@@ -1,9 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://github.com/flux-framework/rfc/tree/master/data/spec_14/schema.json",
-  "title": "jobspec-01",
+  "title": "canonical-jobspec",
 
-  "description":         "Flux jobspec version 1",
+  "description":         "Flux canonical jobspec",
 
   "definitions": {
     "complex_range": {

--- a/data/spec_14/schema.json
+++ b/data/spec_14/schema.json
@@ -82,8 +82,7 @@
   "properties": {
     "version": {
       "description": "the jobspec version",
-      "type": "integer",
-      "enum": [1]
+      "type": "integer"
     },
     "resources": {
       "description": "requested resources",
@@ -132,7 +131,10 @@
           "distribution": { "type": "string" },
           "attributes": {
             "type": "object",
-	    "additionalProperties": { "type": "string" }
+            "properties": {
+              "environment": { "type" : "object"}
+            },
+	        "additionalProperties": { "type": "string" }
           }
         },
 	"additionalProperties": false

--- a/data/spec_14/use_case_1.1.yaml
+++ b/data/spec_14/use_case_1.1.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 999
 resources:
   - type: slot
     count: 4

--- a/data/spec_14/use_case_1.2.yaml
+++ b/data/spec_14/use_case_1.2.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 999
 resources:
   - type: slot
     count:

--- a/data/spec_14/use_case_1.2.yaml
+++ b/data/spec_14/use_case_1.2.yaml
@@ -18,3 +18,6 @@ tasks:
 attributes:
   system:
     duration: 3600.
+    cwd: "/home/flux"
+    environment:
+      HOME: "/home/flux"

--- a/data/spec_14/use_case_1.3.yaml
+++ b/data/spec_14/use_case_1.3.yaml
@@ -23,3 +23,6 @@ tasks:
 attributes:
   system:
     duration: 3600.
+    cwd: "/home/flux"
+    environment:
+      HOME: "/home/flux"

--- a/data/spec_14/use_case_1.3.yaml
+++ b/data/spec_14/use_case_1.3.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 999
 resources:
   - type: slot
     count: 4

--- a/data/spec_14/use_case_1.4.yaml
+++ b/data/spec_14/use_case_1.4.yaml
@@ -20,3 +20,6 @@ tasks:
 attributes:
   system:
     duration: 3600.
+    cwd: "/home/flux"
+    environment:
+      HOME: "/home/flux"

--- a/data/spec_14/use_case_1.4.yaml
+++ b/data/spec_14/use_case_1.4.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 999
 resources:
   - type: slot
     count: 4

--- a/data/spec_14/use_case_1.5.yaml
+++ b/data/spec_14/use_case_1.5.yaml
@@ -39,3 +39,6 @@ tasks:
 attributes:
   system:
     duration: 14400.
+    cwd: "/home/flux"
+    environment:
+      HOME: "/home/flux"

--- a/data/spec_14/use_case_1.5.yaml
+++ b/data/spec_14/use_case_1.5.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 999
 resources:
   - type: cluster
     count: 1

--- a/data/spec_14/use_case_1.6.yaml
+++ b/data/spec_14/use_case_1.6.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 999
 resources:
     - type: cluster
       count: 2

--- a/data/spec_14/use_case_1.6.yaml
+++ b/data/spec_14/use_case_1.6.yaml
@@ -23,3 +23,6 @@ tasks:
 attributes:
   system:
     duration: 3600.
+    cwd: "/home/flux"
+    environment:
+      HOME: "/home/flux"

--- a/data/spec_14/use_case_1.7.yaml
+++ b/data/spec_14/use_case_1.7.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 999
 resources:
   - type: switch
     count: 3

--- a/data/spec_14/use_case_1.7.yaml
+++ b/data/spec_14/use_case_1.7.yaml
@@ -23,3 +23,6 @@ tasks:
 attributes:
   system:
     duration: 3600.
+    cwd: "/home/flux"
+    environment:
+      HOME: "/home/flux"

--- a/data/spec_14/use_case_2.1.yaml
+++ b/data/spec_14/use_case_2.1.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 999
 resources:
   - type: slot
     label: default

--- a/data/spec_14/use_case_2.1.yaml
+++ b/data/spec_14/use_case_2.1.yaml
@@ -14,3 +14,6 @@ tasks:
 attributes:
   system:
     duration: 3600.
+    cwd: "/home/flux"
+    environment:
+      HOME: "/home/flux"

--- a/data/spec_14/use_case_2.2.yaml
+++ b/data/spec_14/use_case_2.2.yaml
@@ -14,3 +14,6 @@ tasks:
 attributes:
   system:
     duration: 3600.
+    cwd: "/home/flux"
+    environment:
+      HOME: "/home/flux"

--- a/data/spec_14/use_case_2.2.yaml
+++ b/data/spec_14/use_case_2.2.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 999
 resources:
   - type: slot
     count: 4

--- a/data/spec_14/use_case_2.3.yaml
+++ b/data/spec_14/use_case_2.3.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 999
 resources:
   - type: slot
     label: default

--- a/data/spec_14/use_case_2.3.yaml
+++ b/data/spec_14/use_case_2.3.yaml
@@ -14,3 +14,6 @@ tasks:
 attributes:
   system:
     duration: 3600.
+    cwd: "/home/flux"
+    environment:
+      HOME: "/home/flux"

--- a/data/spec_14/use_case_2.4.yaml
+++ b/data/spec_14/use_case_2.4.yaml
@@ -33,3 +33,6 @@ tasks:
 attributes:
   system:
     duration: 3600.
+    cwd: "/home/flux"
+    environment:
+      HOME: "/home/flux"

--- a/data/spec_14/use_case_2.4.yaml
+++ b/data/spec_14/use_case_2.4.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 999
 resources:
   - type: node
     count: 1

--- a/data/spec_14/use_case_2.5.yaml
+++ b/data/spec_14/use_case_2.5.yaml
@@ -18,3 +18,6 @@ tasks:
 attributes:
   system:
     duration: 3600.
+    cwd: "/home/flux"
+    environment:
+      HOME: "/home/flux"

--- a/data/spec_14/use_case_2.5.yaml
+++ b/data/spec_14/use_case_2.5.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 999
 resources:
   - type: slot
     label: default

--- a/data/spec_14/use_case_2.6.yaml
+++ b/data/spec_14/use_case_2.6.yaml
@@ -19,3 +19,6 @@ tasks:
 attributes:
   system:
     duration: 3600.
+    cwd: "/home/flux"
+    environment:
+      HOME: "/home/flux"

--- a/data/spec_14/use_case_2.6.yaml
+++ b/data/spec_14/use_case_2.6.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 999
 resources:
   - type: slot
     label: 4GB-node

--- a/data/spec_14/use_case_2.7.yaml
+++ b/data/spec_14/use_case_2.7.yaml
@@ -7,11 +7,11 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: [ "flux" "start" ]
+  - command: [ "flux", "start" ]
     slot: default
     count:
       per_slot: 1
-  - command: [ "flux" "start" ]
+  - command: [ "flux", "start" ]
     slot: default
     count:
       per_slot: 1

--- a/data/spec_14/use_case_2.7.yaml
+++ b/data/spec_14/use_case_2.7.yaml
@@ -1,19 +1,28 @@
 version: 999
 resources:
   - type: slot
-    count: 4
+    count: 1
     label: default
     with:
       - type: node
         count: 1
 tasks:
-  - command: [ "flux", "start" ]
+  - command: [ "flux" "start" ]
     slot: default
     count:
       per_slot: 1
+  - command: [ "flux" "start" ]
+    slot: default
+    count:
+      per_slot: 1
+    attributes:
+      environment:
+        FOO: null
+        BAR: "2"
 attributes:
   system:
     duration: 3600.
     cwd: "/home/flux"
     environment:
-      HOME: "/home/flux"
+      FOO: "/tmp"
+      BAR: "1"

--- a/data/spec_25/example1.yaml
+++ b/data/spec_25/example1.yaml
@@ -1,0 +1,22 @@
+version: 1
+resources:
+  - type: node
+    count: 4
+    with:
+      - type: slot
+        count: 1
+        label: default
+        with:
+          - type: core
+            count: 2
+tasks:
+  - command: app
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 3600.
+    cwd: "/home/flux"
+    environment:
+      HOME: "/home/flux"

--- a/data/spec_25/schema.json
+++ b/data/spec_25/schema.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://github.com/flux-framework/rfc/tree/master/data/spec_24/schema.json",
+  "title": "jobspec-01",
+
+  "description":         "Flux jobspec version 1",
+
+  "definitions": {
+    "intranode_resource_vertex": {
+      "description": "schema for resource vertices within a node, cannot have child vertices",
+      "type": "object",
+      "required": ["type", "count"],
+      "properties": {
+        "type": { "enum": ["core", "gpu"]},
+        "count": { "type": "integer", "minimum" : 1 },
+        "unit": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "node_vertex": {
+      "description": "schema for the node resource vertex",
+      "type": "object",
+      "required": ["type", "count", "with"],
+      "properties": {
+        "type": { "enum" : ["node"] },
+        "count": { "type": "integer", "minimum" : 1 },
+        "unit": { "type": "string" },
+        "with": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1,
+          "items": {
+            "oneOf": [
+              {"$ref": "#/definitions/slot_vertex"}
+            ]
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "slot_vertex": {
+      "description": "special slot resource type - label assigns to task slot",
+      "type": "object",
+      "required": ["type", "count", "with", "label"],
+      "properties": {
+        "type": { "enum" : ["slot"] },
+        "count": { "type": "integer", "minimum" : 1 },
+        "unit": { "type": "string" },
+        "label": { "type": "string" },
+        "exclusive": { "type": "boolean" },
+        "with": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 2,
+          "items": {
+            "oneOf": [
+              {"$ref": "#/definitions/intranode_resource_vertex"}
+            ]
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "required": ["version", "resources", "attributes", "tasks"],
+  "properties": {
+    "version": {
+      "description": "the jobspec version",
+      "type": "integer",
+      "enum": [1]
+    },
+    "resources": {
+      "description": "requested resources",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1,
+      "items": {
+        "oneOf": [
+          { "$ref": "#/definitions/node_vertex" },
+          { "$ref": "#/definitions/slot_vertex" }
+        ]
+      }
+    },
+    "attributes": {
+      "description": "system and user attributes",
+      "type": ["object", "null"],
+      "properties": {
+        "system": {
+          "type": "object",
+          "properties": {
+            "duration": { "type": "number", "minimum": 0 },
+            "cwd": { "type": "string" },
+            "environment": { "type": "object" }
+          }
+        },
+        "user": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    "tasks": {
+      "description": "task configuration",
+      "type": "array",
+      "maxItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["command", "slot", "count" ],
+        "properties": {
+          "command": {
+            "type": ["string", "array"],
+            "minItems": 1,
+            "items": { "type": "string" }
+          },
+          "slot": { "type": "string" },
+          "count": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "per_slot": { "type": "integer", "minimum" : 1 },
+              "total": { "type": "integer", "minimum" : 1 }
+            }
+          }
+        },
+	    "additionalProperties": false
+      }
+    }
+  }
+}

--- a/data/spec_25/use_case_1.1.yaml
+++ b/data/spec_25/use_case_1.1.yaml
@@ -1,0 +1,22 @@
+version: 1
+resources:
+  - type: node
+    count: 4
+    with:
+    - type: slot
+      count: 1
+      label: default
+      with:
+        - type: core
+          count: 1
+tasks:
+  - command: [ "flux", "start" ]
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 3600.
+    cwd: "/home/flux"
+    environment:
+      HOME: "/home/flux"

--- a/data/spec_25/use_case_2.1.yaml
+++ b/data/spec_25/use_case_2.1.yaml
@@ -1,0 +1,22 @@
+version: 1
+resources:
+  - type: node
+    count: 4
+    with:
+      - type: slot
+        count: 1
+        label: myslot
+        with:
+          - type: core
+            count: 1
+tasks:
+  - command: hostname
+    slot: myslot
+    count:
+      total: 5
+attributes:
+  system:
+    duration: 3600.
+    cwd: "/home/flux"
+    environment:
+      HOME: "/home/flux"

--- a/data/spec_25/use_case_2.2.yaml
+++ b/data/spec_25/use_case_2.2.yaml
@@ -1,0 +1,19 @@
+version: 1
+resources:
+  - type: slot
+    label: default
+    count: 10
+    with:
+      - type: core
+        count: 2
+tasks:
+  - command: myapp
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 3600.
+    cwd: "/home/flux"
+    environment:
+      HOME: "/home/flux"

--- a/data/spec_25/use_case_2.3.yaml
+++ b/data/spec_25/use_case_2.3.yaml
@@ -1,0 +1,21 @@
+version: 1
+resources:
+  - type: slot
+    count: 10
+    label: default
+    with:
+      - type: core
+        count: 2
+      - type: gpu
+        count: 1
+tasks:
+  - command: [ "myapp" ]
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 3600.
+    cwd: "/home/flux"
+    environment:
+      HOME: "/home/flux"

--- a/data/spec_25/use_case_2.4.yaml
+++ b/data/spec_25/use_case_2.4.yaml
@@ -1,0 +1,24 @@
+version: 1
+resources:
+  - type: node
+    count: 4
+    with:
+    - type: slot
+      count: 4
+      label: default
+      with:
+        - type: core
+          count: 1
+        - type: gpu
+          count: 1
+tasks:
+  - command: [ "myapp" ]
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 3600.
+    cwd: "/home/flux"
+    environment:
+      HOME: "/home/flux"

--- a/spec_14.adoc
+++ b/spec_14.adoc
@@ -287,7 +287,7 @@ Some common system attributes are:
 === Example Jobspec
 
 Under the description above, the following is an example of a fully compliant
-version 1 jobspec. The example below declares a request for 4 "nodes"
+canonical jobspec. The example below declares a request for 4 "nodes"
 each of which with 1 task slot consisting of 2 cores each, for a total
 of 4 task slots. A single copy of the command `app` will be run on each
 task slot for a total of 4 tasks.
@@ -306,7 +306,7 @@ include::data/spec_14/example2.yaml[]
 
 === Schema
 
-A jobspec conforming to version 1 of the language definition SHALL
+A jobspec conforming to the canonical language definition SHALL
 adhere to the following ruleset, described using JSON Schema
 footnote:[https://json-schema.org/latest/json-schema-core.html[JSON Schema: A Media Type for Describing JSON Documents]; H. Andrews; 2018].
 

--- a/spec_14.adoc
+++ b/spec_14.adoc
@@ -260,7 +260,7 @@ which, if present, must have values.  Values MAY have any valid YAML type.
 
  *user*::
  Attributes in the `user` dictionary are unrestricted, and may be used
- as the application demands.  Flux may provide addition tools that can
+ as the application demands.  Flux may provide additional tools that can
  identify jobs based on `user` attributes.
 
  *system*::

--- a/spec_14.adoc
+++ b/spec_14.adoc
@@ -291,7 +291,7 @@ Some common system attributes are:
  representing the environment variable name and the `value` is a string
  representing the environment variable value to set.  A `null` `value`
  represents unsetting the environment variable given by `key`.  The values
- provided here can be overriden per-rak by providing the
+ provided here can be overridden per-rank by providing the
  `attributes.environment` dictionary under the target task.
 
  *cwd*::

--- a/spec_14.adoc
+++ b/spec_14.adoc
@@ -284,6 +284,20 @@ Some common system attributes are:
  will make an effort to allocate the requested resources for the number
  of seconds specified in `duration`.
 
+ *environment*::
+ The value of the `environment` attribute is a dictionary containing the names
+ and values of environment variables that should be set (or unset) when spawning
+ tasks.  For each entry in the `environment` dictionary, the `key` is a string
+ representing the environment variable name and the `value` is a string
+ representing the environment variable value to set.  A `null` `value`
+ represents unsetting the environment variable given by `key`.  The values
+ provided here can be overriden per-rak by providing the
+ `attributes.environment` dictionary under the target task.
+
+ *cwd*::
+ The value of the `cwd` attribute is a string containing the absolute
+ path to the current working directory to use when spawning the task.
+
 === Example Jobspec
 
 Under the description above, the following is an example of a fully compliant
@@ -572,4 +586,18 @@ Jobspec YAML::
 [source,yaml]
 ----
 include::data/spec_14/use_case_2.6.yaml[]
+----
+
+'''
+Use Case 2.7:: Override the global environment
++
+Specific Example::
+Run two different tasks, one with the global environment and one with an
+overridden environment (i.e., unset FOO and set BAR=2).
++
+Jobspec YAML::
++
+[source,yaml]
+----
+include::data/spec_14/use_case_2.7.yaml[]
 ----

--- a/spec_14.adoc
+++ b/spec_14.adoc
@@ -278,11 +278,11 @@ at all possible.
 Some common system attributes are:
 
  *duration*::
- The value of the `duration` attribute is a number greater than or equal
- to zero representing time span in seconds. A `duration` of 0 SHALL be
- interpreted as "unlimited" or "not set" by the system. The scheduler
- will make an effort to allocate the requested resources for the number
- of seconds specified in `duration`.
+ The value of the `duration` attribute is a floating-point number greater than
+ or equal to zero representing time span in seconds. A `duration` of 0 SHALL be
+ interpreted as "unlimited" or "not set" by the system. The scheduler will make
+ an effort to allocate the requested resources for the number of seconds
+ specified in `duration`.
 
  *environment*::
  The value of the `environment` attribute is a dictionary containing the names

--- a/spec_25.adoc
+++ b/spec_25.adoc
@@ -1,0 +1,267 @@
+ifdef::env-github[:outfilesuffix: .adoc]
+25/Job Specification Version 1
+==============================
+
+A domain specific language based on YAML is defined to express the resource
+requirements and other attributes of one or more programs submitted to a Flux
+instance for execution.  This RFC describes the version 1 of jobspec, which
+represents a request to run exactly one program.  This version is a simplified
+version of the canonical jobspec format described in
+link:spec_14{outfilesuffix}[RFC 14].
+
+
+* Name: github.com/flux-framework/rfc/spec_25.adoc
+* Editor: Stephen Herbein <herbein1@llnl.gov>
+* State: raw
+
+== Language
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
+be interpreted as described in http://tools.ietf.org/html/rfc2119[RFC 2119].
+
+== Related Standards
+
+* link:spec_4{outfilesuffix}[4/Flux Resource Model]
+* link:spec_8{outfilesuffix}[8/Flux Task and Program Execution Services]
+* link:spec_14{outfilesuffix}[14/Canonical Job Specification]
+* link:spec_20{outfilesuffix}[20/Resource Set Specification Version 1]
+
+== Goals
+
+* Express the resource requirements of a program to the scheduler.
+* Allow resource requirements to be expressed simply in terms of Nodes, CPUs,
+and GPUs.
+* Express program attributes such as arguments, run time, and
+task layout, to be considered by the program execution service (RFC 12)
+
+== Overview
+
+This RFC describes the version 1 form of "jobspec", a domain specific language
+based on YAML footnote:[http://yaml.org/spec/1.1/current.html[YAML Ain't Markup
+Language (YAML) Version 1.1], O. Ben-Kiki, C. Evans, B. Ingerson, 2004.]
+. The version 1 of jobspec SHALL consist of
+a single YAML document representing a reusable request to run
+exactly one program.  Hereafter, "jobspec" refers to the version 1
+form, and "non-canonical jobspec" refers to the non-canonical form.
+
+== Jobspec Language Definition
+
+A jobspec V1 YAML document SHALL consist of a dictionary
+defining the resources, tasks and other attributes of a single
+program. The dictionary MUST contain the keys `resources`, `tasks`,
+`attributes`, and `version`.
+
+Each of the listed jobspec keys SHALL meet the form and requirements
+listed in detail in the sections below. For reference, a ruleset for
+compliant jobspec V1 is provided in the *Schema* section below.
+
+=== Resources
+
+The value of the `resources` key SHALL be a strict list which MUST define either
+`node` or `slot` as the first and only resource. Each list element SHALL represent a
+*resource vertex* (described below).
+
+A resource vertex SHALL contain only the following keys:
+
+ * type
+ * count
+ * unit
+ * with
+ * label
+
+The definitions of `unit`, `with`, and `label` SHALL match
+those found in RFC14.  The others are redefined and simplified to mean the
+following:
+
+ *type*::
+ The `type` key for a resource SHALL indicate the type of resource to be
+ matched. In V1, only four resource types are valid: [`node`, `slot`, `core`,
+ and `gpu`]. `slot` types are described in the *Reserved Resource Types* section
+ below.
+
+ *count*:: The `count` key SHALL indicate the desired number of
+ resources matching the current vertex. The `count` SHALL be a single integer
+ value representing a fixed count
+
+==== V1-Specific Resource Graph Restrictions
+
+In V1, the `resources` list MUST contain exactly one element, which MUST be
+either `node` or `slot`.  Additionally, the resource graph MUST contain the
+`core` type.
+
+In V1, there are also restrictions on which resources can have `out` edges to
+other resources. Specifically, a `node` can have an out edge to a `slot`, and a
+`slot` can have an `out` edge to a `core`.  If a `slot` has an `out` edge to a
+`core`, it can also, optionally, have an `out` edge to a `gpu` as
+well. Therefore, the complete enumeration of valid resource graphs in V1 is:
+
+* `slot>core`
+* `node>slot>core`
+* `slot>(core,gpu)`
+* `node>slot>(core,gpu)`
+
+---
+
+=== Tasks
+
+The value of the `tasks` key SHALL be a strict list which MUST define exactly
+one task. The list element SHALL be a dictionary representing a task to run as
+part of the program. A task descriptor SHALL contain the following keys, whose
+definitions SHALL match those provided in RFC14:
+
+ * command
+ * slot
+ * count
+ ** per_slot
+ ** total
+
+---
+
+=== Attributes
+
+The `attributes` key SHALL be a dictionary of
+dictionaries.  The `attributes` dictionary MUST contain `system` key and MAY
+contain the `user` key.  Common `system` keys are listed below, and their
+definitions can be found in RFC14.  Values MAY have any valid YAML type.
+
+ * user
+ * system
+ ** duration
+ ** environment
+ ** cwd
+
+Most system attributes are optional, but the `duration` attribute is required in
+jobspec V1.
+
+---
+
+=== Example Jobspec
+
+Under the description above, the following is an example of a fully compliant
+version 1 jobspec. The example below declares a request for 4 "nodes"
+each of which with 1 task slot consisting of 2 cores each, for a total
+of 4 task slots. A single copy of the command `app` will be run on each
+task slot for a total of 4 tasks.
+
+[source,yaml]
+----
+include::data/spec_25/example1.yaml[]
+----
+
+== Basic Use Cases
+
+To implement basic resource manager functionality, the following use
+cases SHALL be supported by the jobspec:
+
+=== Section 1: Node-level Requests
+
+The following "node-level" requests are all requests to start an instance,
+i.e. run a single copy of `flux start` per allocated node. Many of these
+requests are similar to existing resource manager batch job submission or
+allocation requests, i.e. equivalent to `oarsub`, `qsub`, and `salloc`.
+
+'''
+Use Case 1.1:: Request nodes outside of a slot
++
+Specific Example:: Request 4 nodes, each with 1 slot
++
+Existing Equivalents::
++
+|===
+| Slurm | `salloc -N4`
+| PBS | `qsub -l nodes=4`
+|===
++
+Jobspec YAML::
++
+[source,yaml]
+----
+include::data/spec_25/use_case_1.1.yaml[]
+----
+
+=== Section 2: General Requests
+
+The following use cases are more general and include more complex slot placement
+and task counts.
+
+'''
+Use Case 2.1:: Run N tasks across M nodes, unequal distribution
++
+Specific Example:: Run 5 copies of `hostname` across 4 nodes,
+default distribution
++
+Existing Equivalents::
++
+|===
+| Slurm | `srun -n5 -N4 hostname`
+|===
++
+Jobspec YAML::
++
+[source,yaml]
+----
+include::data/spec_25/use_case_2.1.yaml[]
+----
+
+'''
+Use Case 2.2:: Run N tasks, Require M cores per task
++
+Specific Example:: Run 10 copies of `myapp`, require 2 cores per copy,
+for a total of 20 cores
++
+Existing Equivalents::
++
+|===
+| Slurm | `srun -n10 -c 2 myapp`
+|===
++
+Jobspec YAML::
++
+[source,yaml]
+----
+include::data/spec_25/use_case_2.2.yaml[]
+----
+
+'''
+Use Case 2.3:: Run N tasks, Require M cores and J gpus per task
++
+Specific Example:: Run 10 copies of `myapp`, require 2 cores and 1 gpu per copy,
+for a total of 20 cores and 10 gpus
++
+Jobspec YAML::
++
+[source,yaml]
+----
+include::data/spec_25/use_case_2.3.yaml[]
+----
+
+'''
+Use Case 2.4:: Run N tasks across M nodes, each task with 1 core and 1 gpu
++
+Specific Example:: Run 16 copies of `myapp` across 4 nodes, each copy with
+1 core and 1 gpu
++
+Existing Equivalents::
++
+|===
+| Slurm | `srun -n16 -N4 --gpus-per-task=1 myapp`
+|===
++
+Jobspec YAML::
++
+[source,yaml]
+----
+include::data/spec_25/use_case_2.4.yaml[]
+----
+
+=== Schema
+
+A jobspec conforming to version 1 of the language definition SHALL
+adhere to the following ruleset, described using JSON Schema
+footnote:[https://json-schema.org/latest/json-schema-core.html[JSON Schema: A Media Type for Describing JSON Documents]; H. Andrews; 2018].
+
+[source,json]
+----
+include::data/spec_25/schema.json[]
+----

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -418,3 +418,5 @@ bWVlcAo
 EMERG
 rusage
 getrusage
+cwd
+unsetting

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -422,3 +422,4 @@ cwd
 unsetting
 CPUs
 GPUs
+gpus

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -420,3 +420,5 @@ rusage
 getrusage
 cwd
 unsetting
+CPUs
+GPUs


### PR DESCRIPTION
Still TODO:

- [x] resolve the discussion in #2214 and integrate any changes
- [x] validate the rfc25 examples against the V1 jobspec schema
- [x] add missing `.` back into `data/spec_14/use_case_1.3.yaml`
- [x] make RFC 2% a "delta" of 14 (rather than a complete copy)
- [x] Per https://github.com/flux-framework/flux-sched/pull/502, make `exclusive: false` under a `slot` invalid
- [x] Nix the exclusive option
- [ ] ~~Integrate lessons learned and requirements from `flux run` design~~
- [ ] ~~Add `slot>node` as a valid configuration (`node>slot` is not)~~
- [ ] ~~Add examples and jsonschema for `per_resource`~~
- [ ] ~~Discussion about warning that should be emitted (task vs slot vs execution target counts)~~

I'm happy to split the environment and cwd changes out into a separate PR if desirable.

Closes #100
Closes #188 
Closes #149 