### PR TITLE
add non-infinite and non-NaN conditions to fsd

### DIFF
--- a/spec_23.adoc
+++ b/spec_23.adoc
@@ -29,10 +29,10 @@ said to support "Flux Standard Duration."
 
 == Implementation
 
-A duration in Flux Standard Duration SHALL be of the form `N[SUFFIX]`
-where `SUFFIX` SHALL be optional and, if provided, MUST be a single character
-from the set `s,m,h,d`. The value `N` MUST be a positive, floating-point number,
-and SHALL be interpreted as:
+A duration in Flux Standard Duration SHALL be of the form `N[SUFFIX]` where
+`SUFFIX` SHALL be optional and, if provided, MUST be a single character from the
+set `s,m,h,d`. The value `N` MUST be a positive, non-infinite, floating-point
+number excluding `NaN`, and SHALL be interpreted as:
 
   * _seconds_ if `SUFFIX` is not provided, or is `s`.
   * _minutes_ if `SUFFIX` is `m`.

--- a/spec_23.adoc
+++ b/spec_23.adoc
@@ -31,8 +31,11 @@ said to support "Flux Standard Duration."
 
 A duration in Flux Standard Duration SHALL be of the form `N[SUFFIX]` where
 `SUFFIX` SHALL be optional and, if provided, MUST be a single character from the
-set `s,m,h,d`. The value `N` MUST be a positive, non-infinite, floating-point
-number excluding `NaN`, and SHALL be interpreted as:
+set `s,m,h,d`. The value `N` MUST be a non-negative, non-infinite,
+floating-point number excluding `NaN`. The value `N` SHALL be in one of the
+forms allowed by C99 footnote:[link:https://www.iso.org/standard/29237.html[C99
+- ISO/IEC 9899:1999 standard] section 7.20.1.3: The strtod, strtof, and strtold
+functions] `strtof` or `strtod` and SHALL be interpreted as:
 
   * _seconds_ if `SUFFIX` is not provided, or is `s`.
   * _minutes_ if `SUFFIX` is `m`.

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -405,3 +405,7 @@ oom
 waitpid
 IEEE
 NaN
+IEC
+strtod
+strtof
+strtold

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -404,3 +404,4 @@ starttime
 oom
 waitpid
 IEEE
+NaN


### PR DESCRIPTION
Clarify allowed fsd floats to correspond to changes in flux-framework/flux-core#2216.