### PR TITLE
rfc24: add log event

### DIFF
--- a/spec_24.adoc
+++ b/spec_24.adoc
@@ -36,7 +36,7 @@ be interpreted as described in http://tools.ietf.org/html/rfc2119[RFC 2119].
 * Input and output should be labeled with a timestamp.
 * Each stream may independently indicate end-of-stream.
 * Support standard UNIX I/O streams: `stdin`, `stdout`, `stderr`.
-* Support an additional output stream called `stdlog`.
+* Support shell error and debug logging.
 
 == Implementation
 
@@ -56,8 +56,8 @@ version::
 (integer) Version of this format.  This RFC describes version 1.
 
 encoding::
-(object) A dictionary mapping stream names (e.g. `stdin`, `stdout`, `stderr`,
-`stdlog`) to encoding type (e.g. `base64`, `UTF-8`).
+(object) A dictionary mapping stream names (e.g. `stdin`, `stdout`, `stderr`)
+to encoding type (e.g. `base64`, `UTF-8`).
 
 options::
 (object) A dictionary mapping option names to values.
@@ -75,7 +75,6 @@ Example:
     "encoding":{
       "stdout":"base64",
       "stderr":"UTF-8",
-      "stdlog":"UTF-8",
     },
     "options":{
     }
@@ -94,7 +93,7 @@ The output event encapsulates a blob of input or output data.
 The following keys are REQUIRED in the event context object:
 
 stream::
-(string) The stream name (e.g. `stdin`, `stdout`, `stderr`, `stdlog`).
+(string) The stream name (e.g. `stdin`, `stdout`, `stderr`).
 All valid stream names MUST appear as keys in the header `encoding` object.
 
 rank::
@@ -126,3 +125,17 @@ Example:
   }
 }
 ----
+
+=== Log Event
+
+The log event supports error and debug logging from the Flux shells.
+
+rank::
+(integer) The shell rank.
+
+severity::
+(integer) An Internet RFC 5424 severity level in the range of 0 (LOG_EMERG)
+to 7 (LOG_DEBUG).
+
+message::
+(string) Textual log message, encoded with UTF-8.

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -415,3 +415,4 @@ UTF
 bcast
 eof
 bWVlcAo
+EMERG


### PR DESCRIPTION
This is a do over on PR #196 which I managed to let mergify merge with a fixup commit pending

Restorative actions:
* temporarily removed restriction on force push to master
* force pushed master back to its earlier state
* restored restriction on force push to master
* resubmitted this PR with fixup squashed

Sorry about that!