### PR TITLE
rfc18: establish some basic eventlog update rules

### DIFF
--- a/spec_18.adoc
+++ b/spec_18.adoc
@@ -36,6 +36,10 @@ A Flux KVS Event Log SHALL consist of events separated by newlines.
 Each event SHALL be an independent JSON object, serialized without
 embedded newlines.  The Event Log as a whole is not valid JSON.
 
+An Event Log SHALL only be written by appending one or more whole event
+objects.  It SHALL NOT be created empty, and it SHALL NOT be rewritten
+or truncated.  It MAY be removed when it is no longer needed.
+
 The following keys are REQUIRED in an event object:
 
 timestamp::


### PR DESCRIPTION
It came up in flux-framework/flux-core#2374 that some basic rules of engagement for eventlogs had not been documented.  So this adds a little bit of clarification.