### PR TITLE
rfc24: Allow data rank to be set to "all"

### DIFF
--- a/spec_24.adoc
+++ b/spec_24.adoc
@@ -105,8 +105,9 @@ stream::
 All valid stream names MUST appear as keys in the header `encoding` object.
 
 rank::
-(string) An idset string (RFC 22) representing the rank(s) that produced
-the output, or which will read the input.
+(string) A string representing the rank(s) that produced the output,
+or which will read the input.  The string may be an idset string (RFC
+22) or the string "all" to indicate all ranks in a job.
 
 The following keys are OPTIONAL in the event context object:
 


### PR DESCRIPTION
After some prototyping and some discussion in https://github.com/flux-framework/flux-core/issues/2257, I realized that there are a number of scenarios where "rank" should refer to all tasks in the job.  For example, stdin is typically broadcast to all ranks.

It can be inconvenient to calculate what all ranks in a job are b/c you have to get the jobspec, parse it, and calculate the idset string.

This PR allows the special case string "all" to indicate all ranks in the job.  Obviously we can debate if it should be wildcare (`*`) or another string instead.

Note that I only added "all" on data events and not redirect events.  I didn't see a use case in the latter case yet.