### PR TITLE
rfc26: extend canonical jobspec to support job dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ addons:
   apt:
     packages:
       - aspell-en
+      - python-jsonschema
+      - python-yaml
 
 script:
   - make check

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ SOURCES = \
 	spec_22.adoc \
 	spec_23.adoc \
 	spec_24.adoc \
-	spec_25.adoc
+	spec_25.adoc \
+	spec_26.adoc
 
 
 HTML = $(SOURCES:.adoc=.html)

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ HTML = $(SOURCES:.adoc=.html)
 # N.B. 'apt-get install codray' to enable inline source highlighting
 ADOC_FLAGS = --attribute=source-highlighter=coderay
 
+SCHEMA_DIRS=data/spec_26 data/spec_14
+
 all: html
 
 html: $(HTML)
@@ -42,6 +44,11 @@ html: $(HTML)
 clean:
 	rm -f $(HTML)
 
-check:
+check: $(SCHEMA_DIRS)
 	ASPELL=aspell ./spellcheck *.adoc
 	./indexcheck spec_*.adoc
+
+$(SCHEMA_DIRS):
+	python ./validate.py --schema=$@/schema.json $@/*.yaml
+
+.PHONY: all html clean check $(SCHEMA_DIRS)

--- a/README.adoc
+++ b/README.adoc
@@ -126,6 +126,10 @@ I/O streams in the Flux KVS.
 link:spec_25{outfilesuffix}[25/Job Specification Version 1]:: Version 1 of the
 domain specific job specification language canonically defined in RFC14.
 
+link:spec_26{outfilesuffix}[26/Job Dependency Specification]:: An extension to
+the canonical jobspec designed to express the dependencies between one or more
+programs submitted to a Flux instance for execution.
+
 == Change Process
 
 The change process is

--- a/data/spec_14/schema.json
+++ b/data/spec_14/schema.json
@@ -99,7 +99,10 @@
           "properties": {
             "duration": { "type": "number", "minimum": 0 },
             "cwd": { "type": "string" },
-            "environment": { "type": "object" }
+            "environment": { "type": "object" },
+            "dependencies" : {
+                "$ref": "file:data/spec_26/schema.json"
+            }
           }
         },
         "user": {

--- a/data/spec_14/use_case_2.8.yaml
+++ b/data/spec_14/use_case_2.8.yaml
@@ -1,0 +1,30 @@
+version: 999
+resources:
+  - type: slot
+    count: 1
+    label: default
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: [ "flux", "start" ]
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 3600.
+    cwd: "/home/flux"
+    dependencies:
+      - type: in
+        scope: user
+        scheme: fluid
+        value: hungry-hippo-white-elephant
+      - type: in
+        scope: user
+        scheme: string
+        value: foo
+      - type: out
+        scope: user
+        scheme: string
+        value: bar

--- a/data/spec_26/example_1.yaml
+++ b/data/spec_26/example_1.yaml
@@ -1,0 +1,4 @@
+- type: inout
+  scope: user
+  scheme: string
+  value: foo

--- a/data/spec_26/example_2.yaml
+++ b/data/spec_26/example_2.yaml
@@ -1,4 +1,4 @@
 - type: in
-  scope: system
+  scope: global
   scheme: fluid
   value: hungry-hippo-white-elephant

--- a/data/spec_26/example_2.yaml
+++ b/data/spec_26/example_2.yaml
@@ -1,0 +1,4 @@
+- type: in
+  scope: system
+  scheme: fluid
+  value: hungry-hippo-white-elephant

--- a/data/spec_26/example_3_A.yaml
+++ b/data/spec_26/example_3_A.yaml
@@ -1,0 +1,4 @@
+- type: out
+  scope: user
+  scheme: string
+  value: A

--- a/data/spec_26/example_3_B.yaml
+++ b/data/spec_26/example_3_B.yaml
@@ -1,0 +1,8 @@
+- type: in
+  scope: user
+  scheme: string
+  value: A
+- type: out
+  scope: user
+  scheme: string
+  value: B

--- a/data/spec_26/example_3_C.yaml
+++ b/data/spec_26/example_3_C.yaml
@@ -1,0 +1,4 @@
+- type: in
+  scope: user
+  scheme: string
+  value: B

--- a/data/spec_26/schema.json
+++ b/data/spec_26/schema.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "job-dependency",
+    "description":"Flux Job Dependency Definition",
+    "type": "array",
+    "minItems": 1,
+    "uniqueItems": true,
+    "items" : {
+        "type": "object",
+        "properties": {
+            "type" : {
+                "type": "string",
+                "enum": ["in", "out", "inout"]
+            },
+            "scope" : {
+                "type": "string",
+                "enum": ["user", "system"]
+            },
+            "scheme" : { "type": "string" },
+            "value" : { "type": "string" }
+        },
+        "required": ["type", "scope", "scheme", "value"],
+        "additionalProperties": false
+    }
+}

--- a/data/spec_26/schema.json
+++ b/data/spec_26/schema.json
@@ -14,7 +14,7 @@
             },
             "scope" : {
                 "type": "string",
-                "enum": ["user", "system"]
+                "enum": ["user", "global"]
             },
             "scheme" : { "type": "string" },
             "value" : { "type": "string" }

--- a/spec_14.adoc
+++ b/spec_14.adoc
@@ -25,6 +25,7 @@ be interpreted as described in http://tools.ietf.org/html/rfc2119[RFC 2119].
 * link:spec_4{outfilesuffix}[4/Flux Resource Model]
 * link:spec_8{outfilesuffix}[8/Flux Task and Program Execution Services]
 * link:spec_20{outfilesuffix}[20/Resource Set Specification Version 1]
+* link:spec_26{outfilesuffix}[26/Job Dependency Specification]
 
 == Goals
 
@@ -297,6 +298,9 @@ Some common system attributes are:
  *cwd*::
  The value of the `cwd` attribute is a string containing the absolute
  path to the current working directory to use when spawning the task.
+
+ *dependencies*:: The value of the `dependencies` attribute SHALL be a
+ list of dictionaries following the format specified in RFC 26.
 
  *job*::
  The `job` attribute is an optional dictionary containing job

--- a/spec_14.adoc
+++ b/spec_14.adoc
@@ -625,6 +625,23 @@ overridden environment (i.e., unset FOO and set BAR=2).
 Jobspec YAML::
 +
 [source,yaml]
+
 ----
 include::data/spec_14/use_case_2.7.yaml[]
+----
+
+'''
+Use Case 2.8:: Specify dependencies
++
+Specific Example:: Depend on two previously submitted jobs.  The first job's
+Flux ID (fluid) is known (`hungry-hippo-white-elephant`).  The second job's
+fluid is not known but its `out` dependency (`foo`) is known.  Also provide an
+`out` dependency (`bar`) that other jobs can depend on.
++
+Jobspec YAML::
++
+[source,yaml]
+
+----
+include::data/spec_14/use_case_2.8.yaml[]
 ----

--- a/spec_26.adoc
+++ b/spec_26.adoc
@@ -1,0 +1,171 @@
+ifdef::env-github[:outfilesuffix: .adoc]
+
+26/Job Dependency Specification
+==============================
+
+An extension to the canonical jobspec designed to express the dependencies
+between one or more programs submitted to a Flux instance for execution.
+
+* Name: github.com/flux-framework/rfc/spec_26.adoc
+* Editor: Stephen Herbein <herbein1@llnl.gov>
+* State: raw
+
+== Language
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
+be interpreted as described in http://tools.ietf.org/html/rfc2119[RFC 2119].
+
+== Related Standards
+
+* link:spec_14{outfilesuffix}[14/Canonical Job Specification]
+* link:spec_19{outfilesuffix}[19/Flux Locally Unique ID]
+* link:https://www.openmp.org/wp-content/uploads/OpenMP-API-Specification-5.0.pdf[OpenMP Specification]
+* link:https://tools.ietf.org/html/rfc3986[IETF RFC3986: Uniform Resource Identifier (URI)]
+
+== Goals
+
+* Express the dependencies between jobs to the dependency service.
+* Provide a mechanism for specifying dependencies as a directed acyclic graph
+  (DAG).
+* Provide a mechanism for specifying more advanced, runtime dependencies.
+
+== Job Dependency Definition
+
+A dependency SHALL be a dictionary containing the following keys (whose
+definitions are detailed in the sections below):
+
+* *type*
+* *scope*
+* *scheme*
+* *value*
+
+=== Type
+
+The value of the `type` key SHALL be one of the following (the semantics of
+which are inspired by the OpenMP specification):
+
+ * *out* This key only affects future submitted jobs. If the value of this key
+         is the same as the value in an `in` or `inout` dependency of a future
+         job within scope, then the future job will be a dependent job of the
+         current generated job.
+
+ * *in* If the value of this key is the same as the value in an `out` or `inout`
+        dependency of a previously submitted job within scope, then the
+        generated job will be a dependent job of that previous job.
+
+ * *inout* If the value of this key is the same as the value in an `out` or
+           `inout` dependency of a previously submitted job within scope, then
+           the generated job will be a dependent job of that previous job.
+
+Planned future values for `type` include `inoutset`, `runtime`, and `all`.
+
+=== Scope
+
+The value of the `scope` key SHALL be one of the following:
+
+ * *user* All jobs previously submitted by the user are contained within
+    this scope.  A user can create a dependency of any type within this scope.
+
+ * *system* All jobs previously submitted by the instance owner are contained
+    within this scope.  The instance owner can create a dependency of any type
+    within this scope. A non-instance owner can only create a dependency with
+    the type `in` within this scope.
+
+=== Scheme
+
+The value of the `scheme` key SHALL be a string.  Valid values MAY be but are
+not limited to the following:
+
+ * *string* The `value` is to be interpreted as a string literal.
+
+ * *fluid* The `value` is to be interpreted as a Flux Locally Unique ID.  A
+    dependency of this `scheme` with a `type` of `out` SHALL be generated
+    automatically for every job by the job dependency system.
+
+=== Value
+
+The value of the `value` key SHALL be a string, whose semantics are
+determined by the `scheme`.
+
+== Shorthand
+
+For convenience at the command line, dependencies MAY be formatted as a
+link:https://tools.ietf.org/html/rfc3986[Uniform Resource Identifier (URI)] and
+then expanded into the dictionary format described above. It is left up to each
+implementation as to which URIs to support, the URIs' semantics, default values,
+and what to do when an unsupported URI is encountered.  Some example URIs
+include:
+
+ * `string:foo`
+ * `string:foo?type=out`
+ * `fluid:hungry-hippos-white-elephant`
+
+== Examples
+
+Under the description above, the following are examples of fully compliant
+dependency declarations.
+
+'''
+Example 1:: Submitting a chain of jobs using `inout`
+
+Submitting multiple jobs with the following dependency definition will result in
+the jobs running one after another.
+
+[source,yaml]
+----
+include::data/spec_26/example_1.yaml[]
+----
+
+'''
+Example 2:: Submitting job that depends on a system job
+
+Submitting a job with the following dependency will result in the job running
+after the completion of the system job with the FLUID of
+`hungry-hippo-white-elephant`. One common use-case of this example is the case
+of a large system dedicated access time (DAT).  A DAT typically preempts any
+running jobs.  Users that do not want their jobs preempted will need to submit
+their jobs with a dependency on the system DAT job.
+
+[source,yaml]
+----
+include::data/spec_26/example_2.yaml[]
+----
+
+'''
+Example 3:: Submitting a fan-out of jobs
+
+A typical sub-component of a workflow DAG is a fan-out of jobs, consisting of a
+single pre-processing job, many tasks, and a single post-processing job. These jobs
+are represented as A, B, and C respectively in the DAG visualization below.
+
+....
+   A
+  /|\
+ B B B
+  \|/
+   C
+....
+
+The dependency definitions for each of the job types (i.e., A, B, C) in the
+above DAG are provided below.
+
+// Force asciidoc to render source-code blocks within tables using cols="a,a,a"
+// Source: https://stackoverflow.com/questions/55488370/create-a-table-with-highlighted-source-code-in-asciidoc
+[cols="a,a,a"]
+|===
+|Job A |Job(s) B |Job C
+
+|[source,yaml]
+----
+include::data/spec_26/example_3_A.yaml[]
+----
+|[source,yaml]
+----
+include::data/spec_26/example_3_B.yaml[]
+----
+|[source,yaml]
+----
+include::data/spec_26/example_3_C.yaml[]
+----
+|===

--- a/spec_26.adoc
+++ b/spec_26.adoc
@@ -67,10 +67,10 @@ The value of the `scope` key SHALL be one of the following:
  * *user* All jobs previously submitted by the user are contained within
     this scope.  A user can create a dependency of any type within this scope.
 
- * *system* All jobs previously submitted by the instance owner are contained
-    within this scope.  The instance owner can create a dependency of any type
-    within this scope. A non-instance owner can only create a dependency with
-    the type `in` within this scope.
+ * *global* All jobs previously submitted are contained within this scope,
+    subject to policy constraints.  The instance owner can create a dependency
+    of any type within this scope. A non-instance owner can only create a
+    dependency with the type `in` within this scope.
 
 === Scheme
 

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -423,3 +423,8 @@ unsetting
 CPUs
 GPUs
 gpus
+OpenMP
+URIs
+inout
+inoutset
+asciidoc

--- a/validate.py
+++ b/validate.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+
+# Usage: validate.py --schema=jobspec.json data.json [data.json ...]
+# Usage: cat data.json | validate.py --schema=jobspec.json
+
+import sys
+import argparse
+import json
+import yaml
+import jsonschema
+
+
+def validate_input(jobspec_stream, schema, label=""):
+    errors = 0
+    try:
+        data = yaml.safe_load(jobspec_stream)
+        jsonschema.validate(data, schema)
+    except (yaml.YAMLError) as e:
+        print("{}: {}".format(label, e.problem))
+        errors = errors + 1
+    except (Exception) as e:
+        print("{}: {}".format(label, str(e)))
+        errors = errors + 1
+    except:
+        print("{}: unknown error".format(label))
+        errors = errors + 1
+    else:
+        print("{}: ok".format(label))
+    return errors
+
+
+def validate_inputfile(infile, schema):
+    errors = 0
+    try:
+        with open(infile) as fd:
+            errors += validate_input(fd, schema, label=infile)
+    except (OSError, IOError) as e:
+        print("{}: {}".format(infile, e.strerror))
+        errors = errors + 1
+    return errors
+
+
+# parse command line args
+parser = argparse.ArgumentParser()
+parser.add_argument("--schema", "-s", type=str, required=True)
+parser.add_argument("jobspecs", nargs="*")
+args = parser.parse_args()
+
+# Parse json-schema file (JSON format)
+try:
+    schema = json.load(open(args.schema))
+except (OSError, IOError) as e:
+    sys.exit("{}: {}".format(args.schema, e.strerror))
+except Exception as e:
+    sys.exit("{}: unknown error: {}".format(args.schema, e))
+
+# Validate each file on command line
+errors = 0
+if args.jobspecs:
+    for infile in args.jobspecs:
+        errors += validate_inputfile(infile, schema)
+else:
+    errors += validate_input(sys.stdin, schema, label="stdin")
+
+sys.exit(errors)


### PR DESCRIPTION
Adds the OpenMP-inspired `in`, `out`, and `inout` keys as valid
dependency types.

Based on discussion in
https://github.com/flux-framework/flux-core/issues/1698

Closes #209