### PR TITLE
rfc24: update log event context

### DIFF
--- a/spec_24.adoc
+++ b/spec_24.adoc
@@ -174,12 +174,25 @@ Example:
 
 The log event supports error and debug logging from the Flux shells.
 
+The following keys are REQUIRED in the log event context object:
+
 rank::
 (integer) The shell rank.
 
-severity::
+level::
 (integer) An Internet RFC 5424 severity level in the range of 0 (LOG_EMERG)
 to 7 (LOG_DEBUG).
 
 message::
 (string) Textual log message, encoded with UTF-8.
+
+The following keys are OPTIONAL in the event context object:
+
+file::
+(string) Source file from which the log message was generated.
+
+line::
+(integer) Source line from which the log message was generated.
+
+component::
+(string) A shell component or plugin name which generated the log message.


### PR DESCRIPTION
This PR proposes a couple minor changes to the RFC 24 `log` event context.

Probably uncontroversial -- optional `file` `line` and `component` keys are added to the context. Addition of these members to log messages may aid in post mortem debugging.
(In case it isn't clear, the `component` would be used to indicate a facility or more likely plugin name which generated the log message)

Perhaps more controversial, I removed the reference to RFC 5424 severity levels and renamed the field to `level` instead of `severity`. The syslog severity system seems more tailored to system logs and not simple process logging, for which we'd like a more straightforward logging system that goes from "Fatal" errors to "Trace" logs. (For the shell my current implementation uses `0=Fatal, Error, Warning, Info, Debug, 6=Trace`.

