### PR TITLE
rfc24: log event context updates

### DIFF
--- a/spec_24.adoc
+++ b/spec_24.adoc
@@ -177,9 +177,6 @@ The log event supports error and debug logging from the Flux shells.
 
 The following keys are REQUIRED in the log event context object:
 
-rank::
-(integer) The shell rank.
-
 level::
 (integer) An Internet RFC 5424 severity level in the range of 0 (LOG_EMERG)
 to 7 (LOG_DEBUG).
@@ -188,6 +185,9 @@ message::
 (string) Textual log message, encoded with UTF-8.
 
 The following keys are OPTIONAL in the event context object:
+
+rank::
+(integer) The shell rank. If not present then the shell rank is unknown.
 
 file::
 (string) Source file from which the log message was generated.

--- a/spec_24.adoc
+++ b/spec_24.adoc
@@ -189,6 +189,10 @@ The following keys are OPTIONAL in the event context object:
 rank::
 (integer) The shell rank. If not present then the shell rank is unknown.
 
+program::
+(string) Program name that generated the log message. If not present,
+the program default is `flux-shell`.
+
 file::
 (string) Source file from which the log message was generated.
 


### PR DESCRIPTION
As discussed in flux-framework/flux-core#2477, change the `rank` key in RFC 24 log event context from REQUIRED to OPTIONAL. If  the `rank` key is missing it is assumed the shell rank is unknown at the time of the log message.

This PR also adds another optional key: `program`, which is assumed to be `flux-shell` when not present, but could be used in the future if outside entities write log messages to a job output event log. It is assumed the that `program` value will be used as the prefix for log messages in display programs like `flux-job attach`.