### PR TITLE
rfc14: Update commands to always be a list

### DIFF
--- a/data/spec_14/example1.yaml
+++ b/data/spec_14/example1.yaml
@@ -10,7 +10,7 @@ resources:
           - type: core
             count: 2
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/data/spec_14/example2.yaml
+++ b/data/spec_14/example2.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: hostname
+  - command: [ "hostname" ]
     slot: default
     count:
       per_slot: 1

--- a/data/spec_14/schema.json
+++ b/data/spec_14/schema.json
@@ -116,7 +116,7 @@
         "required": ["command", "slot", "count" ],
         "properties": {
           "command": {
-            "type": ["string", "array"],
+            "type": "array",
             "minItems": 1,
             "items": { "type": "string" }
           },

--- a/data/spec_14/use_case_2.1.yaml
+++ b/data/spec_14/use_case_2.1.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: hostname
+  - command: [ "hostname" ]
     slot: default
     count:
       per_slot: 5

--- a/data/spec_14/use_case_2.2.yaml
+++ b/data/spec_14/use_case_2.2.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: hostname
+  - command: [ "hostname" ]
     slot: myslot
     count:
       total: 5

--- a/data/spec_14/use_case_2.3.yaml
+++ b/data/spec_14/use_case_2.3.yaml
@@ -7,7 +7,7 @@ resources:
       - type: core
         count: 2
 tasks:
-  - command: myapp
+  - command: [ "myapp" ]
     slot: default
     count:
       per_slot: 1

--- a/data/spec_14/use_case_2.4.yaml
+++ b/data/spec_14/use_case_2.4.yaml
@@ -22,11 +22,11 @@ resources:
             count: 24
             unit: GB
 tasks:
-  - command: read-db
+  - command: [ "read-db" ]
     slot: read-db
     count:
       per_slot: 1
-  - command: db
+  - command: [ "db" ]
     slot: db
     count:
       per_slot: 1

--- a/data/spec_14/use_case_2.5.yaml
+++ b/data/spec_14/use_case_2.5.yaml
@@ -11,7 +11,7 @@ resources:
     - type: core
       count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/data/spec_14/use_case_2.6.yaml
+++ b/data/spec_14/use_case_2.6.yaml
@@ -12,7 +12,7 @@ resources:
             min: 4
           unit: GB
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: 4GB-node
     count:
       total: 10

--- a/data/spec_25/example1.yaml
+++ b/data/spec_25/example1.yaml
@@ -10,7 +10,7 @@ resources:
           - type: core
             count: 2
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/data/spec_25/use_case_2.1.yaml
+++ b/data/spec_25/use_case_2.1.yaml
@@ -10,7 +10,7 @@ resources:
           - type: core
             count: 1
 tasks:
-  - command: hostname
+  - command: [ "hostname" ]
     slot: myslot
     count:
       total: 5

--- a/data/spec_25/use_case_2.2.yaml
+++ b/data/spec_25/use_case_2.2.yaml
@@ -7,7 +7,7 @@ resources:
       - type: core
         count: 2
 tasks:
-  - command: myapp
+  - command: [ "myapp" ]
     slot: default
     count:
       per_slot: 1

--- a/spec_14.adoc
+++ b/spec_14.adoc
@@ -209,8 +209,8 @@ representing a task or tasks to run as part of the program. A task
 descriptor SHALL contain the following keys:
 
  *command*::
- The value of the `command` key SHALL be a string OR list representing
- an executable and its arguments.
+ The value of the `command` key SHALL be a list representing an
+ executable and its arguments.
 
  *slot*::
  The value of the `slot` key SHALL match a `label` of a resource vertex


### PR DESCRIPTION
Per discussion offline and in issue #213, update commands to always be a list, instead of possibly a list or string.

Update schema and examples accordingly.
