### PR TITLE
rfc6: drop group RPC section

### DIFF
--- a/spec_6.adoc
+++ b/spec_6.adoc
@@ -118,16 +118,6 @@ MAY be reused if a response containing the matchtag arrives with the
 FLUX_MSGFLAG_STREAMING message flag clear, or if the response contains
 a non-zero error number.
 
-=== Group RPC
-
-A group RPC is a request sent to multiple nodeids.
-
-The upper 12 bits of the matchtag field are designated as the group id
-portion of the matchtag.  If the group id is nonzero, the lower 20 bits
-SHALL be ignored in response matching and pass through to the group
-RPC implementation, which MAY use the lower 20 bits in an implementation
-dependent way;  for example, as a key to a lookup table.
-
 === Exceptional Conditions
 
 If a request cannot be delivered to the server, the broker MAY respond to


### PR DESCRIPTION
The mrpc class is deprecated in flux-framework/flux-core#2612,
so we no longer need group matchtag bits.  It was a hack anyway.