### PR TITLE
Rendering of Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-rfc
-===
+RFC Index
+=========
 
 This is the Flux RFC project.
 

--- a/index.rst
+++ b/index.rst
@@ -7,8 +7,7 @@ Flux RFC Index
 ==============
 
 .. toctree::
-   :maxdepth: 1
-   :caption: RFC Listing
+   :hidden:
 
    README
    spec_1


### PR DESCRIPTION
This PR changes the title at the of README so that it will look better in the RTD website. 

The index.rst file is used by sphinx to make sure each page appears somewhere. We make the TOC tree hidden since we’ll use the README to list each sub-page for this repo.