### PR TITLE
rfc3,6: add FLUX_MSGFLAG_NORESPONSE

### DIFF
--- a/spec_3.rst
+++ b/spec_3.rst
@@ -251,13 +251,13 @@ ABNF grammar [#f2]_
    ; Protocol frame
    PROTO       = request / response / event / keepalive
 
-   request     = signature version %x01 flags userid rolemask nodeid   matchtag
-   response    = signature version %x02 flags userid rolemask errnum   matchtag
-   event       = signature version %x04 flags userid rolemask sequence unused
-   keepalive   = signature version %x08 flags userid rolemask errnum   status
+   request     = magic version %x01 flags userid rolemask nodeid   matchtag
+   response    = magic version %x02 flags userid rolemask errnum   matchtag
+   event       = magic version %x04 flags userid rolemask sequence unused
+   keepalive   = magic version %x08 flags userid rolemask errnum   status
 
    ; Constants
-   signature   = %x8E          ; magic cookie
+   magic       = %x8E          ; magic cookie
    version     = %x01          ; version for CMB1
 
    ; Flags: a bitmask of flag- values below

--- a/spec_3.rst
+++ b/spec_3.rst
@@ -142,11 +142,12 @@ first match in the following sequence:
 
 If the message is received by a comms module, but the remaining words of the
 topic string do not match a method it implements, the comms module SHALL
-respond with error number 38, "Function not implemented".
+respond with error number 38, "Function not implemented", unless suppressed
+as described below.
 
 If the message reaches the root node, but none of the above conditions
 are met, the root broker SHALL respond with error number 38,
-"Function not implemented".
+"Function not implemented", unless suppressed as described below.
 
 A service may send a request *upstream* on the tree based overlay network
 by placing the sending nodeid in the message and setting the
@@ -166,14 +167,23 @@ Such messages SHALL be routed to the target broker rank, then as follows:
 
 If the message is received by a comms module, but the remaining words of the
 topic string do not match a method it implements, the comms module SHALL
-respond with error number 38, "Function not implemented".
+respond with error number 38, "Function not implemented", unless suppressed
+as described below.
 
 If the message reaches the target node, but none of the above conditions
 are met, the broker SHALL respond with error number 38,
-"Function not implemented".
+"Function not implemented", unless suppressed as described below.
 
 If the message cannot be routed to the target node, the broker making
-this determination SHALL respond with error number 113, "No route to host".
+this determination SHALL respond with error number 113, "No route to host",
+unless suppressed as described below.
+
+
+Suppression of Responses
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+If a request message includes the FLUX_MSGFLAG_NORESPONSE (4) flag,
+the broker or other responding entity SHALL NOT send a response message.
 
 
 Event Routing
@@ -264,6 +274,7 @@ ABNF grammar [#f2]_
    flags           = OCTET
    flag-topic      = %x01          ; message has topic string frame
    flag-payload    = %x02          ; message has payload frame
+   flag-noresponse = %x04          ; request message should receive no response
    flag-route      = %x08          ; message has route delimiter frame
    flag-upstream   = %x10          ; request should be routed upstream
                                    ;   of nodeid sender

--- a/spec_3.rst
+++ b/spec_3.rst
@@ -227,73 +227,73 @@ ABNF grammar [#f2]_
 
 ::
 
-   CMB1        = C:request *S:response
-           / S:event
-           / C:keepalive
+   CMB1            = C:request *S:response
+                   / S:event
+                   / C:keepalive
 
    ; Multi-part ZeroMQ messages
-   C:request   = [routing] topic [payload] PROTO
-   S:response  = [routing] topic [payload] PROTO
-   S:event     = [routing] topic [payload] PROTO
-   C:keepalive = PROTO
+   C:request       = [routing] topic [payload] PROTO
+   S:response      = [routing] topic [payload] PROTO
+   S:event         = [routing] topic [payload] PROTO
+   C:keepalive     = PROTO
 
    ; Route frame stack, ZeroMQ DEALER-ROUTER format
-   routing     = *identity delimiter
-   identity    = 1*OCTET       ; socket identity ZeroMQ frame
-   delimiter   = 0OCTET        ; empty delimiter ZeroMQ frame
+   routing         = *identity delimiter
+   identity        = 1*OCTET       ; socket identity ZeroMQ frame
+   delimiter       = 0OCTET        ; empty delimiter ZeroMQ frame
 
    ; Topic string frame, ZeroMQ PUB-SUB format
-   topic       = 1*(ALPHA / DIGIT / ".")
+   topic           = 1*(ALPHA / DIGIT / ".")
 
    ; Payload frame
-   payload     = *OCTET        ; payload ZeroMQ frame
+   payload         = *OCTET        ; payload ZeroMQ frame
 
    ; Protocol frame
-   PROTO       = request / response / event / keepalive
+   PROTO           = request / response / event / keepalive
 
-   request     = magic version %x01 flags userid rolemask nodeid   matchtag
-   response    = magic version %x02 flags userid rolemask errnum   matchtag
-   event       = magic version %x04 flags userid rolemask sequence unused
-   keepalive   = magic version %x08 flags userid rolemask errnum   status
+   request         = magic version %x01 flags userid rolemask nodeid   matchtag
+   response        = magic version %x02 flags userid rolemask errnum   matchtag
+   event           = magic version %x04 flags userid rolemask sequence unused
+   keepalive       = magic version %x08 flags userid rolemask errnum   status
 
    ; Constants
-   magic       = %x8E          ; magic cookie
-   version     = %x01          ; version for CMB1
+   magic           = %x8E          ; magic cookie
+   version         = %x01          ; version for CMB1
 
    ; Flags: a bitmask of flag- values below
-   flags       = OCTET
-   flag-topic  = %x01          ; message has topic string frame
+   flags           = OCTET
+   flag-topic      = %x01          ; message has topic string frame
    flag-payload    = %x02          ; message has payload frame
-   flag-route  = %x08          ; message has route delimiter frame
-   flag-upstream   = %x10                  ; request should be routed upstream
-                       ;   of nodeid sender
+   flag-route      = %x08          ; message has route delimiter frame
+   flag-upstream   = %x10          ; request should be routed upstream
+                                   ;   of nodeid sender
    flag-private    = %x20          ; event message is requested to be
-                       ;   private to sender, instance owner
+                                   ;   private to sender, instance owner
    flag-streaming  = %x40          ; request/response is part of streaming RPC
 
    ; Userid assigned by connector at message ingress
-   userid      = 4OCTET / userid-unknown
+   userid          = 4OCTET / userid-unknown
    userid-unknown  = 0xFF.FF.FF.FF
 
    ; Role bitmask assigned by connector at message ingress
-   rolemask    = 4OCTET
+   rolemask        = 4OCTET
 
    ; Matchtag to correlate request/response
-   matchtag    = 4OCTET / matchtag-none
+   matchtag        = 4OCTET / matchtag-none
    matchtag-none   = %x00.00.00.00
 
    ; Target node ID in network byte order
-   nodeid      = 4OCTET / nodeid-any
-   nodeid-any  = %xFF.FF.FF.FF
+   nodeid          = 4OCTET / nodeid-any
+   nodeid-any      = %xFF.FF.FF.FF
 
    ; UNIX errno in network byte order
-   errnum      = 4OCTET
+   errnum          = 4OCTET
 
    ; Monotonic sequence number in network byte order
-   sequence    = 4OCTET
+   sequence        = 4OCTET
 
    ; unused 4-byte field
-   unused      = %x00.00.00.00
+   unused          = %x00.00.00.00
 
 .. [#f1] `RFC 7159: The JavaScript Object Notation (JSON) Data Interchange Format <http://www.rfc-editor.org/rfc/rfc7159.txt>`__, T. Bray, Google, Inc, March 2014.
 

--- a/spec_6.rst
+++ b/spec_6.rst
@@ -175,3 +175,20 @@ the disconnect request, by reading the first source-address routing identity
 frame (closest to routing delimiter frame) from the request message.
 Servers which maintain per-request state SHOULD index it by sender identity
 so that it can be removed upon receipt of the disconnect request.
+
+
+Cancellation
+~~~~~~~~~~~~
+
+A service MAY implement a method which allows pending requests on its
+other methods to be canceled.  If implemented, the cancellation method
+SHOULD accept a JSON object payload containing a "matchtag" key with integer
+value.  The sender of the cancellation request and the matchtag from its
+payload MAY be used by the service to uniquely idenitfy a single request
+to be canceled.
+
+The client SHALL set the FLUX_MSGFLAG_NORESPONSE message flag in the
+cancellation request and the server SHALL NOT respond to it.
+
+If the canceled request did not set the FLUX_MSGFLAG_NORESPONSE message flag,
+the server SHOULD respond to it with error number 125 (operation canceled).

--- a/spec_6.rst
+++ b/spec_6.rst
@@ -158,11 +158,11 @@ implement any timeouts or other mitigation to handle missing or delayed
 responses.
 
 
-Cancellation
-~~~~~~~~~~~~
+Disconnection
+~~~~~~~~~~~~~
 
-If a client wishes to give up on an in-progress RPC, it MAY send a request
-to the server with a topic string of "*service*.disconnect".
+If a client aborts with an RPC in progress, it or its proxy SHOULD send a
+request to the server with a topic string of "*service*.disconnect".
 The FLUX_MSGFLAG_NORESPONSE message flag SHOULD be set in this request.
 
 It is optional for the server to implement the disconnect method.
@@ -170,8 +170,8 @@ It is optional for the server to implement the disconnect method.
 If the server implements the disconnect method, it SHALL cancel any
 pending RPC requests from the sender, without responding to them.
 
-The server MAY determine the sender identity for any request
-by reading the first source-address routing identity frame (closest to
-routing delimiter frame) from the request message. Servers which
-respond to requests out of order SHOULD retain state for pending
-requests, allowing them to be canceled by sender id as described above.
+The server MAY determine the sender identity for any request, including
+the disconnect request, by reading the first source-address routing identity
+frame (closest to routing delimiter frame) from the request message.
+Servers which maintain per-request state SHOULD index it by sender identity
+so that it can be removed upon receipt of the disconnect request.

--- a/spec_6.rst
+++ b/spec_6.rst
@@ -75,22 +75,25 @@ The request message MAY include a service-defined payload.
 Requests to services that send multiple responses SHALL set the
 FLUX_MSGFLAG_STREAMING message flag.
 
+A request MAY indicate that the response should be suppressed by
+setting the FLUX_MSGFLAG_NORESPONSE message flag.
+
 
 Response Messages
 ~~~~~~~~~~~~~~~~~
 
 The server SHALL send zero or more responses to each request, as
 established by prior agreement between client and server (e.g. defined
-in their protocol specification).
+in their protocol specification) and determined by message flags.
 
 Responses SHALL contain topic string and matchtag values copied from
 the request, to facilitate client response matching.
 
-If the request succeeds, the server SHALL set errnum in the response
-to zero and MAY include a service-defined payload.
+If the request succeeds and a response is to be sent, the server SHALL
+set errnum in the response to zero and MAY include a service-defined payload.
 
-If the request fails, the server SHALL set errnum in the response to
-a nonzero value conforming to
+If the request fails and a response is to be sent, the server SHALL set
+errnum in the response to a nonzero value conforming to
 `POSIX.1 errno encoding <http://man7.org/linux/man-pages/man3/errno.3.html>`__
 and MAY include an error string payload. The error string, if included
 SHALL consist of a brief, human readable message. It is RECOMMENDED that
@@ -160,16 +163,12 @@ Cancellation
 
 If a client wishes to give up on an in-progress RPC, it MAY send a request
 to the server with a topic string of "*service*.disconnect".
+The FLUX_MSGFLAG_NORESPONSE message flag SHOULD be set in this request.
 
 It is optional for the server to implement the disconnect method.
-As usual, if the method is unimplemented, the server SHALL respond with
-error number 38, "Function not implemented".
 
 If the server implements the disconnect method, it SHALL cancel any
-pending RPC requests from the sender, without responding to them,
-and respond to the disconnect request with success, no payload.
-Upon receipt of a successful disconnect response, the client
-MAY reuse the canceled messages' matchtags, if any.
+pending RPC requests from the sender, without responding to them.
 
 The server MAY determine the sender identity for any request
 by reading the first source-address routing identity frame (closest to


### PR DESCRIPTION
flux-framework/flux-core#2913 introduced a new message flag.  This PR updates RFC 3 and 6 with the new flag.

It also updates the "cancellation" section in RFC 6 and creates a new section on "disconnection", to sync up with how the disconnect RPC changed in flux-framework/flux-core#2913, and to describe the emerging practice for RPC cancellation.