### PR TITLE
pip requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+sphinx
+sphinx-rtd-theme
+sphinxcontrib-spelling
+recommonmark
+pyyaml
+jsonschema


### PR DESCRIPTION
This is needed to setup readthedocs. We could name the file something else (maybe `.requirements.txt` or `.github/requirements.txt` if we want to keep the top-level for the repo from having too many files. 