### PR TITLE
spec_26: fixup inter-doc links

### DIFF
--- a/spec_26.rst
+++ b/spec_26.rst
@@ -19,8 +19,8 @@ be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__
 Related Standards
 -----------------
 
--  `14/Canonical Job Specification <spec_14.rst>`__
--  `19/Flux Locally Unique ID <spec_19.rst>`__
+-  :doc:`14/Canonical Job Specification <spec_14>`
+-  :doc:`19/Flux Locally Unique ID <spec_19>`
 -  `OpenMP Specification <https://www.openmp.org/wp-content/uploads/OpenMP-API-Specification-5.0.pdf>`__
 -  `IETF RFC3986: Uniform Resource Identifier (URI) <https://tools.ietf.org/html/rfc3986>`__
 


### PR DESCRIPTION
Needed proper RST format to link to other spec files.