### PR TITLE
Index readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is the Flux RFC project.
 We collect specifications for APIs, file formats, wire protocols, and
 processes.
 
+The full RFC specs can be found on [readthedocs](https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest).
 Details about each of the active RFC documents can be found [in the index](index.rst)
 
 Table of Contents

--- a/README.md
+++ b/README.md
@@ -6,158 +6,51 @@ This is the Flux RFC project.
 We collect specifications for APIs, file formats, wire protocols, and
 processes.
 
-Active RFC Documents
---------------------
+Details about each of the active RFC documents can be found [in the index](index.rst)
 
-#### [1/C4.1 - Collective Code Construction Contract](spec_1.rst)
+Table of Contents
+-----------------
 
-The Collective Code Construction Contract (C4.1) is an evolution of
-the github.com Fork + Pull Model, aimed at providing an optimal
-collaboration model for free software projects.
+- [1/C4.1 - Collective Code Construction Contract](spec_1.rst)
+- [2/Flux Licensing and Collaboration Guidelines](spec_2.rst)
+- [3/CMB1 - Flux Comms Message Broker Protocol](spec_3.rst)
+- [4/Flux Resource Model](spec_4.rst)
+- [5/Flux Comms Modules](spec_5.rst)
+- [6/Flux Remote Procedure Call Protocol](spec_6.rst)
+- [7/Flux Coding Style Guide](spec_7.rst)
+- [8/Flux Task and Program Execution Services](spec_8.rst)
+- [9/Distributed Communication and Synchronization Best Practices](spec_9.rst)
+- [10/Content Storage](spec_10.rst)
+- [11/Key Value Store Tree Object Format v1](spec_11.rst)
+- [12/Flux Security Architecture](spec_12.rst)
+- [13/Simple Process Manager Interface v1](spec_13.rst)
+- [14/Canonical Job Specification](spec_14.rst)
+- [15/Independent Minister of Privilege for Flux: The Security IMP](spec_15.rst)
+- [16/KVS Job Schema](spec_16.rst)
+- [18/KVS Event Log Format](spec_18.rst)
+- [19/Flux Locally Unique ID (FLUID)](spec_19.rst)
+- [20/Resource Set Specification](spec_20.rst)
+- [21/Job States and Events](spec_21.rst)
+- [22/Idset String Representation](spec_22.rst)
+- [23/Flux Standard Duration](spec_23.rst)
+- [24/Flux Job Standard I/O Version 1](spec_24.rst)
+- [25/Job Specification Version 1](spec_25.rst)
+- [26/Job Dependency Specification](spec_26.rst)
 
-#### [2/Flux Licensing and Collaboration Guidelines](spec_2.rst)
+Build Instructions
+------------------
 
-The Flux framework is a family of projects used to build
-site-customized resource management systems for High Performance
-Computing (HPC) data centers. This document specifies licensing and
-collaboration guidelines for Flux projects.
+To build with python virtual environments:
 
-#### [3/CMB1 - Flux Comms Message Broker Protocol](spec_3.rst)
+```bash
+virtualenv -p python3 sphinx-rtd
+source sphinx-rtd/bin/activate
+git clone git@github.com:flux-framework/rfc
+cd rfc
+pip install -r requirements.txt
+make html
+```
 
-This specification describes the format of communications message
-broker messages, Version 1, also referred to as CMB1.
-
-#### [4/Flux Resource Model](spec_4.rst)
-
-The Flux Resource Model describes the conceptual model used for
-resources within the Flux framework.
-
-#### [5/Flux Comms Modules](spec_5.rst)
-
-This specification describes the broker extension modules used to
-implement Flux services.
-
-#### [6/Flux Remote Procedure Call Protocol](spec_6.rst)
-
-This specification describes how Flux Remote Procedure Call (RPC) is
-built on top of CMB1 request and response messages.
-
-#### [7/Flux Coding Style Guide](spec_7.rst)
-
-This specification presents the recommended standards when
-contributing C code to the Flux code base.
-
-#### [8/Flux Task and Program Execution Services](spec_8.rst)
-
-A core service of Flux is to launch, monitor, and handle I/O for
-distributed sets of tasks in order to execute a parallel workload. A
-Flux workload can include further instances of Flux, to arbitrary
-recursive depth. The goal of this RFC is to specify in detail the
-services required to execute a Flux workload.
-
-#### [9/Distributed Communication and Synchronization Best Practices](spec_9.rst)
-
-Establishes best practices, preferred patterns and anti-patterns for
-distributed services in the flux framework.
-
-#### [10/Content Storage](spec_10.rst)
-
-This specification describes the Flux content storage service and
-the messages used to access it.
-
-#### [11/Key Value Store Tree Object Format v1](spec_11.rst)
-
-The Flux Key Value Store (KVS) implements hierarchical key
-namespaces layered atop the content storage service described in
-RFC 10. Namespaces are organized as hash trees of content-addressed
-tree objects and values. This specification defines the version 1
-format of key value store tree objects.
-
-#### [12/Flux Security Architecture](spec_12.rst)
-
-This document describes the mechanisms used to secure Flux instances
-against unauthorized access and prevent privilege escalation and
-other attacks, while ensuring programs run with appropriate user
-credentials and are contained within their set of allocated
-resources.
-
-#### [13/Simple Process Manager Interface v1](spec_13.rst)
-
-The MPI process manager interface (PMI) version 1 is a de-facto
-standard API and wire protocol for communication between MPI
-runtimes and resource managers. It was added to the MPICH2 MPI-2
-reference implementation in late 2001, and has since been widely
-implemented, but was not officially standardized by the MPI Forum
-and has been only lightly documented. This RFC is an attempt to
-document PMI-1 to guide developers of resource managers that must
-support current and legacy MPI implementations.
-
-#### [14/Canonical Job Specification](spec_14.rst)
-
-A domain specific language based on YAML is defined to express the
-resource requirements and other attributes of one or more programs
-submitted to a Flux instance for execution. This RFC describes the
-canonical form of the jobspec language, which represents a request
-to run exactly one program.
-
-#### [15/Independent Minister of Privilege for Flux: The Security IMP](spec_15.rst)
-
-This specification describes Flux Security IMP, a privileged service
-used by multi-user Flux instances to launch, monitor, and control
-processes running as users other than the instance owner.
-
-#### [16/KVS Job Schema](spec_16.rst)
-
-This specification describes the format of data stored in the KVS
-for Flux jobs.
-
-#### [18/KVS Event Log Format](spec_18.rst)
-
-A log format is defined that can be used to log job state
-transitions and other date-stamped events.
-
-#### [19/Flux Locally Unique ID (FLUID)](spec_19.rst)
-
-This specification describes a scheme for a distributed,
-uncoordinated *flux locally unique ID* service that generates 64 bit
-k-ordered, unique identifiers that are a combination of timestamp
-since some epoch, generator id, and sequence number. The scheme is
-used to generate Flux job IDs.
-
-#### [20/Resource Set Specification](spec_20.rst)
-
-This specification defines the version 1 format of the resource-set
-representation or *R* in short.
-
-#### [21/Job States and Events](spec_21.rst)
-
-This specification describes Flux job states and the events that
-trigger job state transitions.
-
-#### [22/Idset String Representation](spec_22.rst)
-
-This specification describes a compact form for expressing a set of
-non-negative, integer ids.
-
-#### [23/Flux Standard Duration](spec_23.rst)
-
-This specification describes a standard form for time duration.
-
-#### [24/Flux Job Standard I/O Version 1](spec_24.rst)
-
-This specification describes the format used to represent standard
-I/O streams in the Flux KVS.
-
-#### [25/Job Specification Version 1](spec_25.rst)
-
-Version 1 of the domain specific job specification language
-canonically defined in RFC14.
-
-#### [26/Job Dependency Specification](spec_26.rst)
-
-An extension to the canonical jobspec designed to express the
-dependencies between one or more programs submitted to a Flux instance
-for execution.
 
 Change Process
 --------------

--- a/conf.py
+++ b/conf.py
@@ -45,7 +45,6 @@ release = '0.13.0'
 extensions = [
     'sphinx.ext.intersphinx',
     'sphinxcontrib.spelling',
-    'recommonmark',
 ]
 
 # sphinxcontrib.spelling settings
@@ -59,13 +58,10 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README.md']
 
 master_doc = 'index'
-source_suffix = {
-    '.rst' : 'restructuredtext',
-    '.md' : 'markdown',
-} 
+source_suffix = '.rst'
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -85,14 +81,3 @@ html_static_path = [
 
 man_pages = [
 ]
-
-
-# -- Options for recommonmark -----------------------------------------------
-def on_missing_reference(app, env, node, contnode):
-        if node['reftype'] == 'any':
-                return contnode
-        else:
-                return None
-
-def setup(app):
-        app.connect('missing-reference', on_missing_reference)

--- a/index.rst
+++ b/index.rst
@@ -6,10 +6,193 @@
 Flux RFC Index
 ==============
 
+This is the Flux RFC project.
+
+We collect specifications for APIs, file formats, wire protocols, and
+processes.
+
+Active RFC Documents
+--------------------
+
+:doc:`1/C4.1 - Collective Code Construction Contract <spec_1>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Collective Code Construction Contract (C4.1) is an evolution of
+the github.com Fork + Pull Model, aimed at providing an optimal
+collaboration model for free software projects.
+
+:doc:`2/Flux Licensing and Collaboration Guidelines <spec_2>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Flux framework is a family of projects used to build
+site-customized resource management systems for High Performance
+Computing (HPC) data centers. This document specifies licensing and
+collaboration guidelines for Flux projects.
+
+:doc:`3/CMB1 - Flux Comms Message Broker Protocol <spec_3>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This specification describes the format of communications message
+broker messages, Version 1, also referred to as CMB1.
+
+:doc:`4/Flux Resource Model <spec_4>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Flux Resource Model describes the conceptual model used for
+resources within the Flux framework.
+
+:doc:`5/Flux Comms Modules <spec_5>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This specification describes the broker extension modules used to
+implement Flux services.
+
+:doc:`6/Flux Remote Procedure Call Protocol <spec_6>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This specification describes how Flux Remote Procedure Call (RPC) is
+built on top of CMB1 request and response messages.
+
+:doc:`7/Flux Coding Style Guide <spec_7>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This specification presents the recommended standards when
+contributing C code to the Flux code base.
+
+:doc:`8/Flux Task and Program Execution Services <spec_8>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A core service of Flux is to launch, monitor, and handle I/O for
+distributed sets of tasks in order to execute a parallel workload. A
+Flux workload can include further instances of Flux, to arbitrary
+recursive depth. The goal of this RFC is to specify in detail the
+services required to execute a Flux workload.
+
+:doc:`9/Distributed Communication and Synchronization Best Practices <spec_9>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Establishes best practices, preferred patterns and anti-patterns for
+distributed services in the flux framework.
+
+:doc:`10/Content Storage <spec_10>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This specification describes the Flux content storage service and
+the messages used to access it.
+
+:doc:`11/Key Value Store Tree Object Format v1 <spec_11>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Flux Key Value Store (KVS) implements hierarchical key
+namespaces layered atop the content storage service described in
+RFC 10. Namespaces are organized as hash trees of content-addressed
+tree objects and values. This specification defines the version 1
+format of key value store tree objects.
+
+:doc:`12/Flux Security Architecture <spec_12>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This document describes the mechanisms used to secure Flux instances
+against unauthorized access and prevent privilege escalation and
+other attacks, while ensuring programs run with appropriate user
+credentials and are contained within their set of allocated
+resources.
+
+:doc:`13/Simple Process Manager Interface v1 <spec_13>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The MPI process manager interface (PMI) version 1 is a de-facto
+standard API and wire protocol for communication between MPI
+runtimes and resource managers. It was added to the MPICH2 MPI-2
+reference implementation in late 2001, and has since been widely
+implemented, but was not officially standardized by the MPI Forum
+and has been only lightly documented. This RFC is an attempt to
+document PMI-1 to guide developers of resource managers that must
+support current and legacy MPI implementations.
+
+:doc:`14/Canonical Job Specification <spec_14>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A domain specific language based on YAML is defined to express the
+resource requirements and other attributes of one or more programs
+submitted to a Flux instance for execution. This RFC describes the
+canonical form of the jobspec language, which represents a request
+to run exactly one program.
+
+:doc:`15/Independent Minister of Privilege for Flux: The Security IMP <spec_15>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This specification describes Flux Security IMP, a privileged service
+used by multi-user Flux instances to launch, monitor, and control
+processes running as users other than the instance owner.
+
+:doc:`16/KVS Job Schema <spec_16>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This specification describes the format of data stored in the KVS
+for Flux jobs.
+
+:doc:`18/KVS Event Log Format <spec_18>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A log format is defined that can be used to log job state
+transitions and other date-stamped events.
+
+:doc:`19/Flux Locally Unique ID (FLUID) <spec_19>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This specification describes a scheme for a distributed,
+uncoordinated *flux locally unique ID* service that generates 64 bit
+k-ordered, unique identifiers that are a combination of timestamp
+since some epoch, generator id, and sequence number. The scheme is
+used to generate Flux job IDs.
+
+:doc:`20/Resource Set Specification <spec_20>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This specification defines the version 1 format of the resource-set
+representation or *R* in short.
+
+:doc:`21/Job States and Events <spec_21>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This specification describes Flux job states and the events that
+trigger job state transitions.
+
+:doc:`22/Idset String Representation <spec_22>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This specification describes a compact form for expressing a set of
+non-negative, integer ids.
+
+:doc:`23/Flux Standard Duration <spec_23>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This specification describes a standard form for time duration.
+
+:doc:`24/Flux Job Standard I/O Version 1 <spec_24>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This specification describes the format used to represent standard
+I/O streams in the Flux KVS.
+
+:doc:`25/Job Specification Version 1 <spec_25>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Version 1 of the domain specific job specification language
+canonically defined in RFC14.
+
+:doc:`26/Job Dependency Specification <spec_26>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+An extension to the canonical jobspec designed to express the
+dependencies between one or more programs submitted to a Flux instance
+for execution.
+
+.. Each file must appear in a toctree
 .. toctree::
    :hidden:
 
-   README
    spec_1
    spec_2
    spec_3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 sphinx
 sphinx-rtd-theme
 sphinxcontrib-spelling
-recommonmark
 pyyaml
 jsonschema

--- a/spec_6.rst
+++ b/spec_6.rst
@@ -184,7 +184,7 @@ A service MAY implement a method which allows pending requests on its
 other methods to be canceled.  If implemented, the cancellation method
 SHOULD accept a JSON object payload containing a "matchtag" key with integer
 value.  The sender of the cancellation request and the matchtag from its
-payload MAY be used by the service to uniquely idenitfy a single request
+payload MAY be used by the service to uniquely identify a single request
 to be canceled.
 
 The client SHALL set the FLUX_MSGFLAG_NORESPONSE message flag in the


### PR DESCRIPTION
This PR move the detailed RFC listing to the index file, which will appear as the top level page for RFC on readthedocs. This is entry page for users.

The README file is removed from sphinx processing. The README is now only used for indexing directly to source files on GitHub and providing information for developers.

This is a major change to the README, so I’d like a few people to review it before merging.

Closes #242 and Closes #234 