### PR TITLE
GitHub comment for viewing ReST files

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -3,6 +3,10 @@
 
    SPDX-License-Identifier: (LGPL-3.0)
 
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/index.html
+
 Flux RFC Index
 ==============
 

--- a/spec_1.rst
+++ b/spec_1.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_1.html
 
 1/C4.1 - Collective Code Construction Contract
 ==============================================

--- a/spec_10.rst
+++ b/spec_10.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_10.html
 
 10/Content Storage Service
 ==========================

--- a/spec_11.rst
+++ b/spec_11.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_11.html
 
 11/Key Value Store Tree Object Format v1
 ========================================

--- a/spec_12.rst
+++ b/spec_12.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_12.html
 
 12/Flux Security Architecture
 =============================

--- a/spec_13.rst
+++ b/spec_13.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_13.html
 
 13/Simple Process Manager Interface v1
 ======================================

--- a/spec_14.rst
+++ b/spec_14.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_14.html
 
 14/Canonical Job Specification
 ==============================

--- a/spec_15.rst
+++ b/spec_15.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_15.html
 
 15/Independent Minister of Privilege for Flux: The Security IMP
 ===============================================================

--- a/spec_16.rst
+++ b/spec_16.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_16.html
 
 16/KVS Job Schema
 =================

--- a/spec_18.rst
+++ b/spec_18.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_18.html
 
 18/KVS Event Log Format
 =======================

--- a/spec_19.rst
+++ b/spec_19.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_19.html
 
 19/Flux Locally Unique ID (FLUID)
 =================================

--- a/spec_2.rst
+++ b/spec_2.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_2.html
 
 2/Flux Licensing and Collaboration Guidelines
 =============================================

--- a/spec_20.rst
+++ b/spec_20.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_20.html
 
 20/Resource Set Specification Version 1
 =======================================

--- a/spec_21.rst
+++ b/spec_21.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_21.html
 
 21/Job States and Events
 ========================

--- a/spec_22.rst
+++ b/spec_22.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_22.html
 
 22/Idset String Representation
 ==============================

--- a/spec_23.rst
+++ b/spec_23.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_23.html
 
 23/Flux Standard Duration
 =========================

--- a/spec_24.rst
+++ b/spec_24.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_24.html
 
 24/Flux Job Standard I/O Version 1
 ==================================

--- a/spec_25.rst
+++ b/spec_25.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_25.html
 
 25/Job Specification Version 1
 ==============================

--- a/spec_26.rst
+++ b/spec_26.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_26.html
 
 26/Job Dependency Specification
 ===============================

--- a/spec_3.rst
+++ b/spec_3.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_3.html
 
 3/CMB1 - Flux Comms Message Broker Protocol
 ===========================================

--- a/spec_4.rst
+++ b/spec_4.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_4.html
 
 4/Flux Resource Model
 =====================

--- a/spec_5.rst
+++ b/spec_5.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_5.html
 
 5/Flux Comms Modules
 ====================

--- a/spec_6.rst
+++ b/spec_6.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_6.html
 
 6/Flux Remote Procedure Call Protocol
 =====================================

--- a/spec_7.rst
+++ b/spec_7.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_7.html
 
 7/Flux Coding Style Guide
 =========================

--- a/spec_8.rst
+++ b/spec_8.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_8.html
 
 8/Flux Task and Program Execution Services
 ==========================================

--- a/spec_9.rst
+++ b/spec_9.rst
@@ -1,3 +1,6 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_9.html
 
 9/Distributed Communication and Synchronization Best Practices
 ==============================================================


### PR DESCRIPTION
This PR adds a github-visible comment which directs readers to view the rendered file on the readthedocs site.

Fixes #247 