### PR TITLE
Misspellings cause make error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,4 @@ $(SCHEMA_DIRS):
 	python ./validate.py --schema=$@/schema.json $@/*.yaml
 
 spelling:
-	@$(SPHINXBUILD) -b spelling "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -W -b spelling "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)


### PR DESCRIPTION
Thanks to @dhellmann (sphinx-contrib/spelling#52), we now get an error when there is a misspelling. 

This is part of a fix for flux-framework/flux-docs#43 