### PR TITLE
rfc27: Clear annotations on job alloc failure

### DIFF
--- a/spec_27.rst
+++ b/spec_27.rst
@@ -377,7 +377,7 @@ Example:
 
 Annotations SHALL be considered *volatile* until a SUCCESS response is received
 to the ``sched.alloc`` request, as described in Alloc Success above.
-Annotations MAY be discarded by the job manager if the allocation fails.
+Annotations SHALL be discarded by the job manager if the allocation fails.
 
 Alloc Deny
 ^^^^^^^^^^


### PR DESCRIPTION
Per discussion flux-core issue #2608, when a job allocation
fails for any reason, the annotation shall be cleared.