### PR TITLE
rfc27: Add queue name as special case annotation

### DIFF
--- a/spec_27.rst
+++ b/spec_27.rst
@@ -367,6 +367,9 @@ sched.reason_pending
 sched.resource_summary
   (string) human readable overview of assigned resources
 
+sched.queue
+  (string) human readable identification of job queue
+
 user
   (dictionary) dictionary object containing user specific annotations
 


### PR DESCRIPTION
i think `queue` name is common enough we can go ahead and define it as a known special case