### PR TITLE
rfc20: replace R_lite "node" key with execution.nodelist

### DIFF
--- a/spec_20.rst
+++ b/spec_20.rst
@@ -125,9 +125,9 @@ the format version.
 Execution
 ~~~~~~~~~
 
-The value of the ``execution`` key SHALL contain at least the single key
-``R_lite``, with optional keys ``starttime`` and ``expiration`` and other keys
-reserved for future extensions.
+The value of the ``execution`` key SHALL contain at least the keys
+``R_lite``, and ``nodelist``, with optional keys ``starttime`` and
+``expiration``. Other keys are reserved for future extensions.
 
 ``R_lite`` is a strict list of dictionaries each of which SHALL contain
 at least the following two keys:
@@ -152,14 +152,14 @@ at least the following two keys:
       The OPTIONAL ``gpu`` key SHALL contain a logical GPU IDs string
       in RFC 22 **idset format**.
 
-An ``R_lite`` dictionary entry MAY also contain any of the following optional
-keys:
 
-**node**
-   The value of the ``node`` key, if present, SHALL be the string
-   hostname of the target compute node.
+The ``nodelist`` key SHALL be an array of hostnames which correspond to
+the ``rank`` entries of the ``R_lite`` dictionary, and serves as a mapping
+of ``R_lite`` ``rank`` entries to hostname. Each hostname entry in ``nodelist`` MAY contain an embedded idset, expandable by ``idset_format_map(3)``, e.g.
+``"host[0-16]``.
 
-The ``execution`` key MAY contain any of the following optional keys:
+
+The ``execution`` key MAY also contain any of the following optional keys:
 
 **starttime**
    The value of the ``starttime`` key, if present, SHALL

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -303,6 +303,7 @@ ruleset
 yaml
 vertices
 hostname
+hostnames
 InfiniBand
 Infiniband
 bicore


### PR DESCRIPTION
Currently we're working on adding support for carrying along hostnames instead of/in addition to ranks in flux-core. I started with adding the `"node"` key to `R_lite` object in `R`, but this will make every `R` on a normal system explode in size, since every rank entry in `R_lite` will now need to be separated.

This experimental addition to RFC 20 adds an alternative -- a `nodelist` key in the `execution` section of `R` version 1. If present, this key is a list of hostnames which directly correspond to the rank entries in the `R_lite` array. E.g. on a system where `fluke[0-16]` correspond to broker ranks `[0-16]`, and we have the `R`

```json
{"version":1,"execution":{"R_lite":[{"rank":"0,2-3","children":{"core":"0-3"}}]}},
```

Then `nodelist` would be `["fluke0","fluke2","fluke3"]`, i.e. the first rank in `R_lite` corresponds to `fluke0` the second to `fluke2`, and so on.

Besides allowing better natural compression, this scheme would allow the host list to be tacked on as a post-processing step (possibly simplifying changes in code now that will need to be replaced when Rv2 is implemented).

Another benefit is that this scheme will make it simpler for `job-info` and other users of `R` to pick off the nodelist from an `R` object. Instead of iterating all `R_lite` entries, the `nodelist` key can simply be read. (Perhaps that is not a strong argument since `job-info` already must iterate `R_lite` to get the rank list)

Finally, separating the hostnames from the rank information might make a better (i.e. more easily written) initial "config file" syntax (if we decide to go that route)

Anyway, just throwing this out there to see what people think. I have the per-R_lite-nodename implemented so no big deal if this is not acceptable.
