### PR TITLE
mergify: update config after migration to travis-ci.com

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,7 @@ pull_request_rules:
   - name: rebase and merge when passing all checks
     conditions:
       - base=master
-      - status-success=continuous-integration/travis-ci/pr
+      - status-success=Travis CI - Pull Request
       - label="merge-when-passing"
       - label!="work-in-progress"
       - "approved-reviews-by=@flux-framework/core"


### PR DESCRIPTION
Problem: The name of the travis-ci status check has changed with
the migration for travis-ci.org to travis-ci.com.

Update the name in the mergify config accordingly.