### PR TITLE
rfc27: add sched.prioritize RPC

### DIFF
--- a/spec_27.rst
+++ b/spec_27.rst
@@ -151,13 +151,10 @@ id
   (integer) job ID
 
 priority
-  (integer) job priority in the range of 0 through 31
+  (integer) queue priority in the range of 0 through 4294967295
 
 userid
   (integer) job owner
-
-t_submit
-  (double) job submit time in seconds since the UNIX epoch
 
 Example:
 
@@ -167,15 +164,13 @@ Example:
      "alloc": [
        {
          "id": 1552593348,
-         "priority": 20,
+         "priority": 43444,
          "userid": 5588,
-         "t_submit": 593011542.2359374
        },
        {
          "id": 1552599944,
-         "priority": 20,
+         "priority": 222,
          "userid": 5588,
-         "t_submit": 593069342.2334354
        }
      ]
    }
@@ -239,13 +234,10 @@ id
   (integer) job ID
 
 priority
-  (integer) job priority in the range of 0 through 31
+  (integer) queue priority in the range of 0 through 4294967295
 
 userid
   (integer) job owner
-
-t_submit
-  (double) job submit time in seconds since the UNIX epoch
 
 Example:
 
@@ -253,9 +245,8 @@ Example:
 
    {
      "id": 1552593348,
-     "priority": 20,
+     "priority": 53444,
      "userid": 5588,
-     "t_submit": 593011542.2359374
    }
 
 Upon receipt of the ``alloc`` request, the scheduler SHALL look up *jobspec*

--- a/spec_27.rst
+++ b/spec_27.rst
@@ -462,7 +462,52 @@ as described above.  If the specified job does not have a pending
 Note that receipt of a ``sched.cancel`` does not necessarily indicate
 that the *job* is canceled. For example, the job manager may cancel all
 outstanding ``sched.alloc`` requests in response to the queue being
-administratively disabled.
+administratively disabled, or to make room for higher priority jobs
+in ``single`` mode.
+
+
+Prioritize
+~~~~~~~~~~
+
+When jobs with outstanding ``sched.alloc`` requests are re-prioritized,
+the job manager notifies the scheduler by sending a ``sched.prioritize``
+request.  The request payload consists of a JSON object with the following
+REQUIRED key:
+
+jobs
+  (array) list of [id, priority] tuples
+
+Each tuple SHALL consist of a two element array, containing:
+
+[0]
+  (integer) job ID
+
+[1]
+  (integer) queue priority in the range of 0 through 4294967295
+
+Example:
+
+.. code:: json
+
+   {
+     "jobs":[
+       [49056579584, 444],
+       [57428410368, 298],
+       [63988301824, 343205],
+       [69675778048, 99]
+     ]
+   }
+
+
+Job IDs which cannot be correlated to a pending ``sched.alloc`` request
+may be safely ignored.
+
+No response is sent to the ``sched.prioritize`` request.
+
+.. note::
+    A job manager priority plugin MAY initiate a priority update of many
+    jobs at once.  The job manager captures these updates in a single
+    ``sched.prioritize`` request.
 
 
 Free


### PR DESCRIPTION
Add an RPC that allows the job manager to inform the scheduler of new priorities assigned to job(s) that have outstanding alloc requests.  It should be possible for the job manager to send _one_ of these requests to the scheduler after the fair share priority plugin finishes a batch of priority updates, so the scheduler receives the total order in one go.

This request would not be used in `single` mode.  In that case, if the single outstanding alloc request is no longer the highest priority job, the job manager must cancel its alloc request and let the top job take its place.

Also, the alloc request is modified to drop `t_submit` and redefine `priority` from the administrative priority to the queue priority.  (This assumes that the scheduler would no longer need the submit time because it will now be reflected in the queue priority)