### PR TITLE
rename administrative priority to "urgency"

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Table of Contents
 - [26/Job Dependency Specification](spec_26.rst)
 - [27/Flux Resource Allocation Protocol Version 1](spec_27.rst)
 - [29/Hostlist Format](spec_29.rst)
+- [30/Job Urgency](spec_30.rst)
 
 Build Instructions
 ------------------

--- a/index.rst
+++ b/index.rst
@@ -205,6 +205,11 @@ Protocol implemented by the job manager and a compliant Flux scheduler.
 This specification describes the Flux implementation of the Hostlist Format
 -- a compressed representation of lists of hostnames.
 
+:doc:`30/Job Urgency <spec_30>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This specification describes the Flux job urgency parameter.
+
 .. Each file must appear in a toctree
 .. toctree::
    :hidden:
@@ -236,3 +241,4 @@ This specification describes the Flux implementation of the Hostlist Format
    spec_26
    spec_27
    spec_29
+   spec_30

--- a/spec_16.rst
+++ b/spec_16.rst
@@ -174,8 +174,8 @@ The *ingest agent* validates *J* and if accepted, populates the KVS with:
 
 The *ingest agent* logs one event to the eventlog:
 
-``submit`` ``userid=UID priority=N``
-   job was submitted, with authenticated userid and priority (0-31)
+``submit`` ``userid=UID urgency=N``
+   job was submitted, with authenticated userid and urgency (0-31)
 
 
 Content Consumed/Produced by Job Manager

--- a/spec_18.rst
+++ b/spec_18.rst
@@ -75,8 +75,8 @@ An example Flux Event Log:
 
 ::
 
-   {"timestamp":1552593348.073045,"name":"submit","context":{"priority":16,"userid":5588,"flags":0}}
-   {"timestamp":1552593547.411336,"name":"priority","context":{"priority":0,"userid":5588}}
+   {"timestamp":1552593348.073045,"name":"submit","context":{"urgency":16,"userid":5588,"flags":0}}
+   {"timestamp":1552593547.411336,"name":"urgency","context":{"urgency":0,"userid":5588}}
    {"timestamp":1552593348.088391,"name":"alloc",context:{"note":"rank0/core[0-1]"}}
    {"timestamp":1552593348.093541,"name":"free"}
    {"timestamp":1552593348.089787,"name":"start"}

--- a/spec_21.rst
+++ b/spec_21.rst
@@ -95,7 +95,7 @@ DEPEND
    The state transitions to PRIORITY.
 
 PRIORITY
-   The job is blocked waiting for a queue priority to be assigned by the job
+   The job is blocked waiting for a priority to be assigned by the job
    manager priority plugin.  Upon priority assignment, the job manager logs the
    ``priority`` event.  The state transitions to SCHED.
 
@@ -176,8 +176,8 @@ Job was submitted.
 
 The following keys are REQUIRED in the event context object:
 
-priority
-   (integer) Initial administrative priority in the range of 0-31.
+urgency
+   (integer) Initial urgency in the range of 0-31.
 
 userid
    (integer) Authenticated user ID of submitter.
@@ -189,7 +189,7 @@ Example:
 
 .. code:: json
 
-   {"timestamp":1552593348.073045,"name":"submit","context":{"priority":16,"userid":5588,"flags":0}}
+   {"timestamp":1552593348.073045,"name":"submit","context":{"urgency":16,"userid":5588,"flags":0}}
 
 
 Depend Event
@@ -209,12 +209,12 @@ Example:
 Priority Event
 ^^^^^^^^^^^^^^
 
-Job's queue priority has been assigned.
+Job's priority has been assigned.
 
 The following keys are REQUIRED in the event context object:
 
 priority
-   (integer) Queue priority in the range of 0-4294967295.
+   (integer) Priority in the range of 0-4294967295.
 
 .. code:: json
 
@@ -235,22 +235,22 @@ Example:
     {"timestamp":1605115080.0358412,"name":"flux-restart"}
 
 
-Admin-Priority Event
-^^^^^^^^^^^^^^^^^^^^
+Urgency Event
+^^^^^^^^^^^^^
 
-Job's administrative priority has changed.
+Job's urgency has changed.
 
 The following keys are REQUIRED in the event context object:
 
-priority
-   (integer) New administrative priority in the range of 0-31.
+urgency
+   (integer) New urgency in the range of 0-31.
 
 userid
    (integer) Authenticated user ID of requester.
 
 .. code:: json
 
-   {"timestamp":1552593547.411336,"name":"admin-priority","context":{"priority":0,"userid":5588}}
+   {"timestamp":1552593547.411336,"name":"urgency","context":{"urgency":0,"userid":5588}}
 
 
 Alloc Event

--- a/spec_27.rst
+++ b/spec_27.rst
@@ -151,7 +151,7 @@ id
   (integer) job ID
 
 priority
-  (integer) queue priority in the range of 0 through 4294967295
+  (integer) priority in the range of 0 through 4294967295
 
 userid
   (integer) job owner
@@ -234,7 +234,7 @@ id
   (integer) job ID
 
 priority
-  (integer) queue priority in the range of 0 through 4294967295
+  (integer) priority in the range of 0 through 4294967295
 
 userid
   (integer) job owner
@@ -483,7 +483,7 @@ Each tuple SHALL consist of a two element array, containing:
   (integer) job ID
 
 [1]
-  (integer) queue priority in the range of 0 through 4294967295
+  (integer) priority in the range of 0 through 4294967295
 
 Example:
 

--- a/spec_29.rst
+++ b/spec_29.rst
@@ -8,7 +8,7 @@
 This specification describes a compact form for expressing a list of
 hostnames which contain an optional numerical part.
 
--  Name: github.com/flux-framework/rfc/spec_22.rst
+-  Name: github.com/flux-framework/rfc/spec_29.rst
 
 -  Editor: Mark A. Grondona <mgrondona@llnl.gov>
 

--- a/spec_30.rst
+++ b/spec_30.rst
@@ -1,0 +1,70 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_30.html
+
+30/Job Urgency
+==============
+
+This specification describes the Flux job urgency parameter.
+
+-  Name: github.com/flux-framework/rfc/spec_30.rst
+
+-  Editor: Jim Garlick <garlick@llnl.gov>
+
+-  State: raw
+
+
+Language
+--------
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
+be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+
+Related Standards
+-----------------
+
+-  :doc:`21/Job States and Events <spec_21>`
+
+
+Background
+----------
+
+The Flux job *urgency* parameter reflects the job owner's idea of the job's
+importance relative to other work queued on the system.  It is one factor
+used by the job manager priority plugin to calculate the job *priority*,
+which determines queue listing order, and the order in which jobs are
+presented to the scheduler.
+
+The urgency MAY be provided by the job owner at job submission time.
+It MAY be adjusted by the job owner while the job is pending.
+
+
+Implementation
+--------------
+
+Job *urgency* SHALL be an integer with range of 0 through 31.
+
+A *guest user* MAY set or update the urgency of their own jobs to values in
+the range of 0-16.
+
+The *instance owner* MAY set or update the urgency of any job to any valid
+value.
+
+If the urgency is unspecified during job submission, a *default* initial
+value of 16 is assigned.
+
+A value of 0 indicates that the job should be *held*.  A held job is assigned
+the lowest possible priority, bypassing the job manager priority plugin.
+Although it remains in the queue while pending, a held job SHALL NOT be
+assigned resources.
+
+A value of 31 indicates that the job should be *expedited*.  An expedited job
+is assigned the highest possible priority, bypassing the job manager priority
+plugin.
+
+If the urgency is *updated*, the job manager priority plugin SHALL be notified
+so it can adjust the job's priority.
+
+The current urgency value SHALL persist across a Flux instance restart,
+therefore each change SHALL be recorded in the job's event log.


### PR DESCRIPTION
As discussed in flux-framework/flux-core#3377, the terms "queue priority" and "administrative priority" are a bit cumbersome/ambiguous.  This PR proposing changing the terms to "priority" and "urgency".

We had not written down the idea of urgency=0 for hold and urgency=31 for expedite so I went ahead and added a mini RFC about urgency and the meaning of these special values.  Hope that's not too much overkill.