### PR TITLE
rfc21: Add priority-update event

### DIFF
--- a/spec_21.rst
+++ b/spec_21.rst
@@ -253,6 +253,21 @@ userid
    {"timestamp":1552593547.411336,"name":"urgency","context":{"urgency":0,"userid":5588}}
 
 
+Priority-Update Event
+^^^^^^^^^^^^^^^^^^^^^
+
+Job's priority has changed.
+
+The following keys are REQUIRED in the event context object:
+
+priority
+   (integer) Priority in the range of 0-4294967295.
+
+.. code:: json
+
+   {"timestamp":1552593547.411336,"name":"priority-update","context":{"priority":1001}}
+
+
 Alloc Event
 ^^^^^^^^^^^
 


### PR DESCRIPTION
Problem: There is no way to know if a job's priority has changed
after the PRIORITY state / after the "priority" event.

Solution: Add a new priority-update event, which can advertise that
the priority of a job has changed.