### PR TITLE
rfc27: support mode=limited in sched.ready

### DIFF
--- a/spec_27.rst
+++ b/spec_27.rst
@@ -214,7 +214,10 @@ Example:
 
    {"mode":"limited","limit":42}
 
-The response payload SHALL be empty.
+The response payload is a JSON object with the following REQUIRED keys:
+
+count
+  (integer) current queue depth
 
 After responding to the ``job-manager.sched-ready`` request, the job manager
 MAY immediately begin sending ``sched.alloc`` and ``sched.free`` requests.

--- a/spec_27.rst
+++ b/spec_27.rst
@@ -194,20 +194,25 @@ mode
 
 The mode string SHALL be one of the following:
 
-single
-  The job manager SHALL send a ``sched.alloc`` request only when there are
-  no outstanding ``sched.alloc`` requests.  This mode is only useful for simple
-  schedulers that run jobs strictly in the job manager queue order.
-
 unlimited
   The job manager SHALL send a ``sched.alloc`` request for all jobs in SCHED
   state, with no limit on concurrency.
+
+limited
+  The job manager SHALL limit the number of concurrent ``sched.alloc``
+  requests to value specified by the ``limit`` key (described below).
+
+The following key is REQUIRED for ``limited`` mode only:
+
+limit
+  (integer) The number of concurrent ``sched.alloc`` requests that can
+  be sent.  ``limit`` can be in the range of 1 to 2147483647.
 
 Example:
 
 .. code:: json
 
-   {"mode":"unlimited"}
+   {"mode":"limited","limit":42}
 
 The response payload SHALL be empty.
 


### PR DESCRIPTION
Per issue https://github.com/flux-framework/flux-core/issues/2070, support mode=N in the `job-manager`.  Update RFC27 to allow a `mode=N` in the `sched.ready` protocol.

Not 100% if this is the best way to go about things, but thought I'd setup this PR for discussion / consideration of this change:

- should "mode" be an integer instead of a "string"?  We treat "unlimited" to mean 0 and obviously "single" is just numeral 1.  Seems silly to keep it a string.

  - But we may want to keep as a string for future flexibility.  IMO, this is a good reason to keep it.
  - Changing it to a numeral we'd have to break ABI in `libschedutil` in `flux-core`

- Another possibility, do we want to set `N` via an option?  So instead of `mode=2`, we could do `mode=N=2`.  Perhaps in the future we might want to do, `mode=N=1000,someflag` or `mode=foo=bar,N=1000`.  We could keep the "flags", `single` and `unlimited` as special case flags meaning `N=1` and `N=0`.

- If we keep `N` a string, should we define a cap on N in RFC27?  I'm assuming `int` range is reasonable?  Or `unsigned int` range?  Or something much smaller to be reasonable?
