### PR TITLE
contributors: update some project practices

### DIFF
--- a/spec_1.rst
+++ b/spec_1.rst
@@ -123,6 +123,8 @@ Patch Requirements
 
 -  Where applicable, a commit message body SHOULD reference an Issue by number (e.g. Fixes #33").
 
+-  A commit message body SHOULD begin with ``Problem:`` and a short paragraph describing the problem solved by the commit.  Even commits that add features MAY include such a problem statement.
+
 -  A "Correct Patch" is one that satisfies the above requirements.
 
 

--- a/spec_1.rst
+++ b/spec_1.rst
@@ -82,7 +82,7 @@ Licensing and Ownership
 
 -  The copyrights in the project SHALL be owned collectively by all its Contributors.
 
--  Each Contributor SHALL be responsible for identifying themselves in the project Contributor list.
+-  The git commit history SHALL be considered the primary source of contributor identities.
 
 
 Patch Requirements

--- a/spec_1.rst
+++ b/spec_1.rst
@@ -26,6 +26,13 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
 be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
 
+Related Standards
+-----------------
+
+-  :doc:`2/Flux Licensing and Collaboration Guidelines <spec_2>`
+
+-  :doc:`7/Flux Coding Style Guide <spec_7>`
+
 
 Goals
 -----
@@ -74,7 +81,7 @@ Preliminaries
 Licensing and Ownership
 ~~~~~~~~~~~~~~~~~~~~~~~
 
--  The project SHALL use a share-alike license, such as the GPLv3 or a variant thereof (LGPL, AGPL), or the MPLv2.
+-  The project SHALL use a share-alike license, such as the GPLv3 or a variant thereof (LGPL, AGPL), or the MPLv2 for reasons outlined in :doc:`RFC 2 <spec_2>`.
 
 -  All contributions to the project source code ("patches") SHALL use the same license as the project.
 
@@ -92,7 +99,7 @@ Patch Requirements
 
 -  A patch SHOULD be a minimal and accurate answer to exactly one identified and agreed problem.
 
--  A patch MUST adhere to the code style guidelines of the project if these are defined.
+-  A patch MUST adhere to the code style guidelines of the project defined in :doc:`RFC 7 <spec_7>`.
 
 -  A patch MUST adhere to the "Evolution of Public Contracts" guidelines defined below.
 

--- a/spec_2.rst
+++ b/spec_2.rst
@@ -114,9 +114,6 @@ Copyright
 
 -  The SPDX license shorthand is RECOMMENDED [#f2]_.
 
--  New contributors MAY add themselves to the project’s AUTHORS file,
-   using the pull request process described in RFC 1.
-
 .. [#f1] `The Free-Libre / Open Source Software (FLOSS) License Slide <https://dwheeler.com/essays/floss-license-slide.html>`__, David A. Wheeler.
 
 .. [#f2] `The Software Package Data Exchange (SPDX) <https://spdx.org/>`__.


### PR DESCRIPTION
Some minor updates to RFC 1 and 2
* add forward references from RFC 1 to 2 and 7
* drop text about AUTHORS files we no longer use
* suggest the `Problem:` format for commit message bodies