### PR TITLE
remove outdated terminology, update keepalive description in RFC5

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Table of Contents
 
 - [1/C4.1 - Collective Code Construction Contract](spec_1.rst)
 - [2/Flux Licensing and Collaboration Guidelines](spec_2.rst)
-- [3/CMB1 - Flux Message Broker Protocol](spec_3.rst)
+- [3/Flux Message Protocol](spec_3.rst)
 - [4/Flux Resource Model](spec_4.rst)
 - [5/Flux Broker Modules](spec_5.rst)
 - [6/Flux Remote Procedure Call Protocol](spec_6.rst)

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Table of Contents
 
 - [1/C4.1 - Collective Code Construction Contract](spec_1.rst)
 - [2/Flux Licensing and Collaboration Guidelines](spec_2.rst)
-- [3/CMB1 - Flux Comms Message Broker Protocol](spec_3.rst)
+- [3/CMB1 - Flux Message Broker Protocol](spec_3.rst)
 - [4/Flux Resource Model](spec_4.rst)
-- [5/Flux Comms Modules](spec_5.rst)
+- [5/Flux Broker Modules](spec_5.rst)
 - [6/Flux Remote Procedure Call Protocol](spec_6.rst)
 - [7/Flux Coding Style Guide](spec_7.rst)
 - [8/Flux Task and Program Execution Services](spec_8.rst)

--- a/index.rst
+++ b/index.rst
@@ -33,11 +33,10 @@ site-customized resource management systems for High Performance
 Computing (HPC) data centers. This document specifies licensing and
 collaboration guidelines for Flux projects.
 
-:doc:`3/CMB1 - Flux Message Broker Protocol <spec_3>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`3/Flux Message Protocol <spec_3>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This specification describes the format of communications message
-broker messages, Version 1, also referred to as CMB1.
+This specification describes the format of Flux messages, Version 1.
 
 :doc:`4/Flux Resource Model <spec_4>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -55,7 +54,7 @@ implement Flux services.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This specification describes how Flux Remote Procedure Call (RPC) is
-built on top of CMB1 request and response messages.
+built on top of Flux request and response messages.
 
 :doc:`7/Flux Coding Style Guide <spec_7>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/index.rst
+++ b/index.rst
@@ -33,8 +33,8 @@ site-customized resource management systems for High Performance
 Computing (HPC) data centers. This document specifies licensing and
 collaboration guidelines for Flux projects.
 
-:doc:`3/CMB1 - Flux Comms Message Broker Protocol <spec_3>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`3/CMB1 - Flux Message Broker Protocol <spec_3>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This specification describes the format of communications message
 broker messages, Version 1, also referred to as CMB1.
@@ -45,8 +45,8 @@ broker messages, Version 1, also referred to as CMB1.
 The Flux Resource Model describes the conceptual model used for
 resources within the Flux framework.
 
-:doc:`5/Flux Comms Modules <spec_5>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`5/Flux Broker Modules <spec_5>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This specification describes the broker extension modules used to
 implement Flux services.

--- a/spec_10.rst
+++ b/spec_10.rst
@@ -26,7 +26,7 @@ be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__
 Related Standards
 -----------------
 
--  :doc:`3/CMB1 - Flux Message Broker Protocol <spec_3>`
+-  :doc:`3/Flux Message Protocol <spec_3>`
 
 
 Goals
@@ -107,10 +107,10 @@ Note: "blobref" was shamelessly borrowed from Camlistore
 Store
 ~~~~~
 
-A store request SHALL be encoded as a CMB1 request message with the blob
+A store request SHALL be encoded as a Flux request message with the blob
 as raw payload (blob length > 0), or no payload (blob length = 0).
 
-A store response SHALL be encoded as a CMB1 response message with
+A store response SHALL be encoded as a Flux response message with
 NULL-terminated blobref string as raw payload, or an error response.
 
 A request to store content that exceeds the maximum size SHALL
@@ -123,10 +123,10 @@ accessible from any rank in the instance.
 Load
 ~~~~
 
-A load request SHALL be encoded as a CMB1 request message with
+A load request SHALL be encoded as a Flux request message with
 NULL-terminated blobref string as raw payload.
 
-A load response SHALL be encoded as a CMB1 response message with blob
+A load response SHALL be encoded as a Flux response message with blob
 as raw payload (blob length > 0), no payload (blob length = 0),
 or an error response.
 
@@ -181,7 +181,7 @@ content SHALL be destroyed when the instance terminates.
 Message Definitions
 ~~~~~~~~~~~~~~~~~~~
 
-Content service messages SHALL follow the CMB1 rules described
+Content service messages SHALL follow the Flux rules described
 in RFC 3 for requests and responses, and are described in detail by
 the following ABNF grammar:
 

--- a/spec_10.rst
+++ b/spec_10.rst
@@ -26,7 +26,7 @@ be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__
 Related Standards
 -----------------
 
--  :doc:`3/CMB1 - Flux Comms Message Broker Protocol <spec_3>`
+-  :doc:`3/CMB1 - Flux Message Broker Protocol <spec_3>`
 
 
 Goals

--- a/spec_12.rst
+++ b/spec_12.rst
@@ -28,7 +28,7 @@ be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__
 Related Standards
 -----------------
 
--  :doc:`3/CMB1 - Flux Message Broker Protocol <spec_3>`
+-  :doc:`3/Flux Message Protocol <spec_3>`
 
 
 Goals

--- a/spec_12.rst
+++ b/spec_12.rst
@@ -28,7 +28,7 @@ be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__
 Related Standards
 -----------------
 
--  :doc:`3/CMB1 - Flux Comms Message Broker Protocol <spec_3>`
+-  :doc:`3/CMB1 - Flux Message Broker Protocol <spec_3>`
 
 
 Goals

--- a/spec_3.rst
+++ b/spec_3.rst
@@ -2,13 +2,13 @@
    GitHub is NOT the preferred viewer for this file. Please visit
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_3.html
 
-3/CMB1 - Flux Message Broker Protocol
-=====================================
+3/Flux Message Protocol
+=======================
 
 This specification describes the format of Flux message broker
-messages, Version 1, also referred to as CMB1.
+messages, Version 1.
 
-CMB1 is encapsulated in the
+The Flux message protocol is encapsulated in the
 `ZeroMQ Message Transfer Protocol (ZMTP) <http://rfc.zeromq.org/spec:23/ZMTP>`__.
 
 -  Name: github.com/flux-framework/rfc/spec_3.rst
@@ -29,8 +29,8 @@ be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__
 Goals
 -----
 
-The CMB1 protocol provides a way for Flux utilities and services to
-communicate with one another within the context of a job. CMB1 has
+The Flux message protocol v1 provides a way for Flux utilities and services to
+communicate with one another within the context of a job. It has
 the following specific goals:
 
 -  Endpoint-count scalability (e.g. to 100K nodes) through multi-hop
@@ -99,7 +99,7 @@ The rank FLUX_NODEID_ANY (2:sup:`32` - 1) SHALL be reserved to indicate
 The rank FLUX_NODEID_UPSTREAM (2:sup:`32` - 2) SHALL be reserved to indicate
 *any rank* that is upstream of the sender in request addressing.
 This value is reserved for the convenience of API implementations
-and SHALL NOT appear in the nodeid slot of an encoded CMB1 message.
+and SHALL NOT appear in the nodeid slot of an encoded message.
 
 A node’s rank SHALL be assigned at broker startup and SHALL NOT change
 for the node’s lifetime.
@@ -217,30 +217,30 @@ established for common payload types:
 General Message Format
 ~~~~~~~~~~~~~~~~~~~~~~
 
-CMB1 messages are multi-part ZeroMQ messages.
+Flux messages are multi-part ZeroMQ messages.
 
-CMB1 messages MUST include a PROTO message part, positioned last for fast
+Flux messages MUST include a PROTO message part, positioned last for fast
 access. The PROTO part includes flags that indicate the presence of
 additional message parts.
 
-CMB1 messages MAY include a stack of message identity parts comprising
+Flux messages MAY include a stack of message identity parts comprising
 a source address route, positioned first for compatibility with ZeroMQ
 DEALER-ROUTER sockets. If message identity parts are present, a zero-size
 route delimiter frame MUST be present and positioned next.
 
-CMB1 messages MAY include a topic string part, positioned after route
+Flux messages MAY include a topic string part, positioned after route
 delimiter, if any. When the topic string part is first, it is compatible
 with ZeroMQ PUB-SUB sockets.
 
-Finally, CMB1 messages MAY include a payload part, positioned before
+Finally, Flux messages MAY include a payload part, positioned before
 the PROTO part. Payloads MAY consist of any byte sequence.
 
-CMB1 messages are specified in terms of ZeroMQ messages by the following
+Flux messages are specified in terms of ZeroMQ messages by the following
 ABNF grammar [#f2]_
 
 ::
 
-   CMB1            = C:request *S:response
+   message       = C:request *S:response
                    / S:event
                    / C:keepalive
 
@@ -271,7 +271,7 @@ ABNF grammar [#f2]_
 
    ; Constants
    magic           = %x8E          ; magic cookie
-   version         = %x01          ; version for CMB1
+   version         = %x01          ; Flux message version
 
    ; Flags: a bitmask of flag- values below
    flags           = OCTET

--- a/spec_3.rst
+++ b/spec_3.rst
@@ -2,10 +2,10 @@
    GitHub is NOT the preferred viewer for this file. Please visit
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_3.html
 
-3/CMB1 - Flux Comms Message Broker Protocol
-===========================================
+3/CMB1 - Flux Message Broker Protocol
+=====================================
 
-This specification describes the format of communications message broker
+This specification describes the format of Flux message broker
 messages, Version 1, also referred to as CMB1.
 
 CMB1 is encapsulated in the
@@ -56,7 +56,7 @@ Background
 ----------
 
 ``flux-broker`` is a message broker daemon for the Flux resource manager
-framework. A *comms session* is a set of interconnected ``flux-broker`` tasks
+framework. A Flux *instance* is a set of interconnected ``flux-broker`` tasks
 that together provide a shared communications substrate for distributed
 resource manager services within a job. Services and utilities communicate
 by passing messages through the session brokers. There are four
@@ -64,7 +64,7 @@ types of messages: events, requests, responses, and keepalives, which
 share a common structure described herein.
 
 Event messages are published such that they are available to subscribers
-throughout the comms session. Events are published with a *topic string*
+throughout the instance. Events are published with a *topic string*
 attached. Subscribers register a list of topic string prefixes
 to filter the set of messages they receive.
 
@@ -88,8 +88,8 @@ Implementation
 Rank Assignment
 ~~~~~~~~~~~~~~~
 
-A *node* is defined as a ``flux-broker`` task. Each node in a comms
-session of size N SHALL be assigned a rank in the range of 0 to N - 1.
+A *node* is defined as a ``flux-broker`` task. Each node in a Flux
+instance of size N SHALL be assigned a rank in the range of 0 to N - 1.
 Ranks SHALL be represented by a 32 bit unsigned integer, with the highest
 value of (2:sup:`32` - 3).
 
@@ -104,18 +104,18 @@ and SHALL NOT appear in the nodeid slot of an encoded CMB1 message.
 A node’s rank SHALL be assigned at broker startup and SHALL NOT change
 for the node’s lifetime.
 
-The size of the comms session SHALL be determined at startup and SHALL
-not change for the life of the comms session. [Dynamic resize will
+The size of the Flux instance SHALL be determined at startup and SHALL
+not change for the life of the Flux instance. [Dynamic resize will
 be covered in a future version of this specification.]
 
 
 Overlay Networks
 ~~~~~~~~~~~~~~~~
 
-The nodes of a comms session SHALL at minimum be interconnected in
+The nodes of a Flux instance SHALL at minimum be interconnected in
 tree based overlay network with rank 0 at the root of the tree.
 
-The nodes of a comms session MAY be interconnected in additional
+The nodes of a Flux instance MAY be interconnected in additional
 overlay networks to improve efficiency or fault tolerance.
 
 
@@ -135,16 +135,16 @@ Request messages MAY be addressed to *any rank* (FLUX_NODEID_ANY).
 Such messages SHALL be routed to the local broker, then to the
 first match in the following sequence:
 
-1. If topic string begins with a word matching a local comms module
-   and the sender is not the same comms module attached to the same rank
-   broker, the message SHALL be routed to the comms module.
+1. If topic string begins with a word matching a local broker module
+   and the sender is not the same module attached to the same rank
+   broker, the message SHALL be routed to the broker module.
 
 2. If the broker is not the root node of the tree based overlay network,
    the message SHALL be routed to a parent node in the tree based overlay
    network, which SHALL re-apply this routing algorithm.
 
-If the message is received by a comms module, but the remaining words of the
-topic string do not match a method it implements, the comms module SHALL
+If the message is received by a broker module, but the remaining words of the
+topic string do not match a method it implements, the module SHALL
 respond with error number 38, "Function not implemented", unless suppressed
 as described below.
 
@@ -165,11 +165,11 @@ Rank Request Routing
 Request messages MAY be addressed to a specific rank.
 Such messages SHALL be routed to the target broker rank, then as follows:
 
-1. If topic string begins with a word matching a local comms module,
-   the message SHALL be routed to the comms module.
+1. If topic string begins with a word matching a local broker module,
+   the message SHALL be routed to the module.
 
-If the message is received by a comms module, but the remaining words of the
-topic string do not match a method it implements, the comms module SHALL
+If the message is received by a broker module, but the remaining words of the
+topic string do not match a method it implements, the module SHALL
 respond with error number 38, "Function not implemented", unless suppressed
 as described below.
 

--- a/spec_5.rst
+++ b/spec_5.rst
@@ -26,7 +26,7 @@ be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__
 Related Standards
 -----------------
 
--  :doc:`3/CMB1 - Flux Message Broker Protocol <spec_3>`
+-  :doc:`3/Flux Message Protocol <spec_3>`
 
 
 Background
@@ -188,7 +188,7 @@ the following events:
 Module Management Message Definitions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Module management messages SHALL follow the CMB1 rules described
+Module management messages SHALL follow the Flux message rules described
 in RFC 3 for requests and responses with JSON payloads.
 
 The broker module loader SHALL implement the ``broker.insmod``,

--- a/spec_5.rst
+++ b/spec_5.rst
@@ -2,8 +2,8 @@
    GitHub is NOT the preferred viewer for this file. Please visit
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_5.html
 
-5/Flux Comms Modules
-====================
+5/Flux Broker Modules
+=====================
 
 This specification describes the broker extension modules
 used to implement Flux services.
@@ -26,48 +26,48 @@ be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__
 Related Standards
 -----------------
 
--  :doc:`3/CMB1 - Flux Comms Message Broker Protocol <spec_3>`
+-  :doc:`3/CMB1 - Flux Message Broker Protocol <spec_3>`
 
 
 Background
 ----------
 
-Flux services are implemented as dynamically loaded plugins called
-"comms modules". They are "actors" in the sense that they have
+Flux services are implemented as dynamically loaded broker plugins called
+"broker modules". They are "actors" in the sense that they have
 their own thread of control, and interact with the broker and the rest
 of Flux exclusively via messages.
 
-The ``flux-module`` front-end utility loads, unloads, and lists comms modules
+The ``flux-module`` front-end utility loads, unloads, and lists broker modules
 by exchanging RPC messages with a module management component of the broker.
 
-A comms module exports two symbols: a ``mod_main()`` function, and
+A broker module exports two symbols: a ``mod_main()`` function, and
 a ``mod_name`` NULL-terminated string.
 
-The broker starts a comms module by calling its ``mod_main()`` function in
+The broker starts a module by calling its ``mod_main()`` function in
 a new thread. The broker provides a broker handle and argv vector
 style arguments to the via ``mod_main()`` arguments. The arguments originate
 on the ``flux-module load`` command line.
 
 Prior to calling ``mod_main()``, the broker registers a service for the
-comms module based on the value of ``mod_name``. Request messages with
+module based on the value of ``mod_name``. Request messages with
 topic strings starting with this service name are diverted by the broker
-to the comms module as described in RFC 3. The portion of the topic string
-following the service name is called a "service method". A comms module
+to the module as described in RFC 3. The portion of the topic string
+following the service name is called a "service method". A module
 may register many service methods.
 
-The broker also pre-registers handlers for service methods that all comms
+The broker also pre-registers handlers for service methods that all
 modules are expected to provide, such as "ping" and "shutdown". These
-handlers may be overridden by the comms module if desired.
+handlers may be overridden by the module if desired.
 
-The comms module implementing a new service is expected to register
+The broker module implementing a new service is expected to register
 message handlers for its methods, then run the flux reactor. It should
 use event driven (reactive) programming techniques to remain responsive
 while juggling work from multiple clients.
 
 Keepalive messages are sent by pre-registered reactor watchers to the broker,
-to indicate when the comms module is initializing, waiting for reactor events,
+to indicate when the module is initializing, waiting for reactor events,
 busy doing work, finalizing, or exited. This provides synchronization to
-the comms module loader, as well as useful runtime debug information that
+the broker module loader, as well as useful runtime debug information that
 can be reported by ``flux module list``.
 
 
@@ -78,7 +78,7 @@ Implementation
 Well known Symbols
 ~~~~~~~~~~~~~~~~~~
 
-A comms module SHALL export the following global symbols:
+A broker module SHALL export the following global symbols:
 
 ``const char \*mod_name;``
    A null-terminated C string defining the module name.
@@ -93,7 +93,7 @@ A comms module SHALL export the following global symbols:
 Keepalive Values
 ~~~~~~~~~~~~~~~~
 
-A comms module SHALL send RFC 3 keepalive messages containing status
+A broker module SHALL send RFC 3 keepalive messages containing status
 integers to the broker over its broker handle. Status integers are
 enumerated as follows:
 
@@ -114,16 +114,16 @@ when ``mod_main()`` returns a value of -1 indicating failure and state
 transitions to FLUX_MODSTATE_EXITED. In this case ``errnum`` SHALL be set
 to the value of POSIX ``errno`` set by ``mod_main()`` before returning.
 
-The broker MAY track the number of session heartbeats since an
-comms module last sent a message and report this as "idle time"
-for the comms module.
+The broker MAY track the number of session heartbeats since a
+module last sent a message and report this as "idle time"
+for the module.
 
 
 Load Sequence
 ~~~~~~~~~~~~~
 
-The broker module loader SHALL launch the comms module’s ``mod_main()`` in a
-new thread. The ``cmb.insmod`` response is deferred until the comms module
+The broker module loader SHALL launch the module’s ``mod_main()`` in a
+new thread. The ``broker.insmod`` response is deferred until the module
 state transitions out of FLUX_MODSTATE_INIT. If it transitions immediately to
 FLUX_MODSTATE_EXITED, and the ``errnum`` value is nonzero, an error response
 SHALL be returned as described in RFC 3.
@@ -133,9 +133,9 @@ Unload Sequence
 ~~~~~~~~~~~~~~~
 
 The broker module loader SHALL send a ``<service>.shutdown`` request to the
-comms module when the module loader receives a ``cmb.rmmod`` request for the
-module. In response, the comms module SHALL exit ``mod_main()``, send a
-keepalive transition to FLUX_MODSTATE_EXITED state, and exit the comms
+module when the module loader receives a ``broker.rmmod`` request for the
+module. In response, the broker module SHALL exit ``mod_main()``, send a
+keepalive transition to FLUX_MODSTATE_EXITED state, and exit the
 module’s thread or process. This final state transition indicates to
 the broker that it MAY clean up the module thread.
 
@@ -143,11 +143,11 @@ the broker that it MAY clean up the module thread.
 Built-in Request Handlers
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-All comms modules receive default handlers for the following methods:
+All broker modules receive default handlers for the following methods:
 
 ``<service>.shutdown``
    The default handler immediately stops the reactor. This handler may
-   be overridden if a comms module requires a more complex shutdown sequence.
+   be overridden if a broker module requires a more complex shutdown sequence.
 
 ``<service>.stats.get``
    The default handler returns a JSON object containing message counts.
@@ -176,7 +176,7 @@ All comms modules receive default handlers for the following methods:
 Built-in Event Handlers
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-In addition, all comms modules subscribe to and register a handler for
+In addition, all broker modules subscribe to and register a handler for
 the following events:
 
 ``<service>.stats.clear``
@@ -191,8 +191,8 @@ Module Management Message Definitions
 Module management messages SHALL follow the CMB1 rules described
 in RFC 3 for requests and responses with JSON payloads.
 
-The broker comms module loader SHALL implement the ``cmb.insmod``,
-``cmb.rmmod``, and ``cmb.lsmod`` methods.
+The broker module loader SHALL implement the ``broker.insmod``,
+``broker.rmmod``, and ``broker.lsmod`` methods.
 
 Module management messages are described in detail by the following
 ABNF grammar:
@@ -214,9 +214,9 @@ ABNF grammar:
    S:lsmod-rep     = [routing] lsmod-topic lsmod-json PROTO   ; see below for JSON
 
    ; topic strings are optional service + module operation
-   insmod-topic    = "cmb.insmod"
-   rmmod-topic     = "cmb.rmmod"
-   lsmod-topic     = "cmb.lsmod"
+   insmod-topic    = "broker.insmod"
+   rmmod-topic     = "broker.rmmod"
+   lsmod-topic     = "broker.lsmod"
 
    ; PROTO and [routing] are as defined in RFC 3.
 
@@ -239,7 +239,7 @@ Content Rules <https://tools.ietf.org/html/draft-newton-json-content-rules-05>`_
        "name"     : string           ; module name
        "size"     : integer 0..      ; module file size
        "digest"   : string           ; SHA1 digest of module file
-       "idle"     : integer 0..      ; comms idle time in heartbeats
+       "idle"     : integer 0..      ; idle time in heartbeats
        "status"   : integer 0..      ; module state (enumerated above)
    }
 

--- a/spec_6.rst
+++ b/spec_6.rst
@@ -26,7 +26,7 @@ be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__
 Related Standards
 -----------------
 
--  :doc:`3/CMB1 - Flux Message Broker Protocol <spec_3>`
+-  :doc:`3/Flux Message Protocol <spec_3>`
 
 
 Goals

--- a/spec_6.rst
+++ b/spec_6.rst
@@ -26,15 +26,15 @@ be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__
 Related Standards
 -----------------
 
--  :doc:`3/CMB1 - Flux Comms Message Broker Protocol <spec_3>`
+-  :doc:`3/CMB1 - Flux Message Broker Protocol <spec_3>`
 
 
 Goals
 -----
 
-Flux RPC protocol enables comms modules, utilities, or other software
-communicating with a Flux comms session to call the methods implemented
-by comms modules. Flux RPC has the following goals:
+Flux RPC protocol enables broker modules, utilities, or other software
+communicating with a Flux instance to call the methods implemented
+by broker modules. Flux RPC has the following goals:
 
 -  Support location-neutral service addressing, without a location broker.
 
@@ -52,7 +52,7 @@ Implementation
 A remote procedure call SHALL consist of one request message
 sent from a client to a server, and zero or more response messages sent
 from a server to a client. The client and server roles are not
-mutually-exclusive—​comms modules often act in both roles.
+mutually-exclusive—​ broker modules often act in both roles.
 
 ::
 

--- a/spec_8.rst
+++ b/spec_8.rst
@@ -57,7 +57,7 @@ Terminology
    where a program MAY store persistent state.
 
 -  **instance** A set of Flux framework services running within a single
-   Flux *comms session* [RFC 3], that includes a capability to launch
+   communication domain  [RFC 3], that includes a capability to launch
    programs. A Flux instance is such a *program*.
 
 -  **enclosing instance** The instance in which a program is running.

--- a/spec_9.rst
+++ b/spec_9.rst
@@ -25,7 +25,7 @@ Goals
 
 To establish best practices, preferred patterns and anti-patterns for
 distributed services in the flux framework. Several of the core services of
-flux, including comms, RPCs, and the KVS, provide services for distributed
+Flux, including messages, RPCs, and the KVS, provide services for distributed
 notification and synchronization, but not all of them are suitable for all
 cases. For now, this is a listing of some common patterns and anti-patterns,
 but may shape into a more comprehensive guide as the most effective patterns

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -8,8 +8,6 @@ tarball
 tarballs
 adoc
 api
-cmb
-comms
 env
 github
 hpc


### PR DESCRIPTION
This PR does two things, I'm fine breaking it up into separate PRs if desired.

 1. Update outdated terminology similar to flux-framework/flux-core#3456
 2. reword keepalive passages in RFC5 to de-emphasize running/sleeping transition keepalive messages