### PR TITLE
rfc21: add dependency-add/remove events

### DIFF
--- a/spec_21.rst
+++ b/spec_21.rst
@@ -89,10 +89,9 @@ NEW
    transitions the state to DEPEND.
 
 DEPEND
-   The job is blocked waiting for dependencies to be satisfied. The job manager
-   makes a request to the dependency service and receives a response once
-   the job’s dependencies are satisfied, then logs the ``depend`` event.
-   The state transitions to PRIORITY.
+   The job is blocked waiting for dependencies to be satisfied. Once all
+   dependencies have been satisfied the ``depend`` event is logged and
+   the state transitions to PRIORITY.
 
 PRIORITY
    The job is blocked waiting for a priority to be assigned by the job
@@ -190,6 +189,38 @@ Example:
 .. code:: json
 
    {"timestamp":1552593348.073045,"name":"submit","context":{"urgency":16,"userid":5588,"flags":0}}
+
+
+Dependency-add Event
+^^^^^^^^^^^^^^^^^^^^
+
+A dependency has been added to the job. This dependency must then be removed
+via a ``dependency-remove`` event.
+
+The following keys are REQUIRED in the event context object:
+
+description
+   (string) Name or description of this dependency.
+
+.. code:: json
+
+   {"timestamp":1552593348.073045,"name":"dependency-add","context":{"description":"begin-time=1552594348"}}
+
+
+Dependency-remove Event
+^^^^^^^^^^^^^^^^^^^^^^^
+
+A dependency has be removed from a job. The dependency description MUST
+match a previously added dependency from a ``dependency-add`` event.
+
+The following keys are REQUIRED in the event context object:
+
+description
+   (string) Name or description of the dependency to remove.
+
+.. code:: json
+
+   {"timestamp":1552594348.0,"name":"dependency-remove","context":{"description":"begin-time=1552594348"}}
 
 
 Depend Event


### PR DESCRIPTION
This simple addition to RFC21 allows management of dependencies via `dependency-add` and `dependency-remove` events. This enables some simple dependencies to be handled internally in the job manager, possibly via plugins. 

In the common case of no dependencies, there would be no change to existing behavior. If a job manager plugin wants to add a dependency to a job, it can issue the `dependency-add` event while in the depend state, e.g. via the `job.state.depend` callback. This will add a dependency reference to the job. When the job dependency is satisfied (e.g. at a future time, or when a job on which the job depends becomes inactive) the plugin can issue the `dependency-remove` event, the reference will be removed and the job manager will issue the `depend` event.

If a dependency service is being used instead, then a single reference can be issued for the dependency service and subsequently removed when RPC response from the service is received.

An additional benefit of issuing dependency-add/remove events to the eventlog is that outstanding dependencies can be gathered and listed by the `job-list` module. Also, it may be interesting to have dependencies logged for debugging and post-mortem analysis.

There is still some question as to how to handle these events on a job manager restart. 