### PR TITLE
rfc26: after:JOBID jobs should start after start event

### DIFF
--- a/spec_26.rst
+++ b/spec_26.rst
@@ -144,9 +144,10 @@ after
 ``value`` SHALL be interpreted as the antecedent jobid, in any valid
 FLUID encoding from RFC 19.
 
-The dependency SHALL be satisfied once the antecedent job enters RUN state.
-If the antecedent job reaches INACTIVE state without entering RUN state,
-a fatal exception SHOULD be raised on the dependent job.
+The dependency SHALL be satisfied once the antecedent job enters RUN state
+and posts a ``start`` event. If the antecedent job reaches INACTIVE state
+without entering RUN state and posting a ``start`` event, a fatal exception
+SHOULD be raised on the dependent job.
 
 
 afterany


### PR DESCRIPTION
Problem: RFC 26 specifies that after:JOBID jobs start after the
antecedent enters the RUN state. However, it is more practical and useful
if dependent jobs are not started until the dependency also posts a
'start' event.

Update the language to indicate that dependent jobs with the 'after'
scheme are not started until the antecedent enters the RUN state *and*
a "start" event is posted.