### PR TITLE
WIP: rfc21: add hold/release-request events

### DIFF
--- a/spec_21.rst
+++ b/spec_21.rst
@@ -317,6 +317,53 @@ Example:
    {"timestamp":1552593348.088391,"name":"alloc","context":{"annotations":{"sched.resource_summary":"rank0/core[0-1]"}}}
 
 
+Hold-request Event
+^^^^^^^^^^^^^^^^^^
+
+A hold has been placed on one or more requests that will be made by the job
+manager. The job manager will not perform the named request which is the
+target of the hold until the hold has been released by a ``release-request``
+event. If multiple holds are made for a request, then the request SHALL not
+be issued until all holds are released.
+
+The following key is REQUIRED in the context object:
+
+names:
+  (array of string) array of request names to hold
+
+The current list of job manager requests which may be held include:
+
+start
+  The request made by the job manager to the execution system to start
+  the job shells.
+
+free
+  The request made by the job manager to the scheduler to free some or
+  all of the resources associated with a job.
+
+Example:
+
+.. code:: json
+
+   {"timestamp":1552593348.088391,"name":"hold-request","context":{"names":["start"]}}
+
+
+Release-request Event
+^^^^^^^^^^^^^^^^^^^^^
+A hold placed on a job manager request has been released.
+
+The following key is REQUIRED in the context object:
+
+names:
+  (array of string) array of request names to release
+
+Example:
+
+.. code:: json
+
+   {"timestamp":1552593349.048682,"name":"release-request","context":{"names":["start"]}}
+
+
 Free Event
 ^^^^^^^^^^
 


### PR DESCRIPTION
Opening this PR for discussion.

We have a use case that requires blocking a job from starting execution after resources have been allocated and before the job starts execution (e.g. between the `alloc` event and the start request sent to the `job-exec` module).

Similarly, it would be useful to block freeing of resources after a job has finished (after the `finish` event and before the free request is sent to the scheduler)

In general, this could allow optional global per-job initialization and teardown when necessary. 

This PR proposes an additional pair of events which will allow plugins to request a hold on the `start` and `free` requests (not to be confused with the `start` and `free` events) which should work for the use cases we have in mind.

Implementation will be very simple:
Internally, each job will have a `start` and `free` reference counter which will be incremented by hold and decremented by release. The requests will not be sent until the refcount is zero, allowing a plugin to block a job arbitrarily before execution or after finish but before resources are freed.

I'm not really crazy about the naming here, any suggestions appreciated. 