### PR TITLE
rfc21: add job memo event

### DIFF
--- a/spec_21.rst
+++ b/spec_21.rst
@@ -520,6 +520,14 @@ start
 free
    A problem occurred while releasing resources to the scheduler.
 
+Memo Event
+^^^^^^^^^^
+
+A brief data record has been associated with the job.
+
+The context object SHALL be considered the data to associate with
+the job.  Any data attached to the job via a previous "memo"
+event SHALL be updated, i.e. existing keys SHALL be replaced.
 
 Debug Event
 ^^^^^^^^^^^


### PR DESCRIPTION
This PR introduces a `memo` event for posting user data to the job eventlog as an augmentation of the current annotations system. The intent is to have a way to associate data with a job and have it persist across job-manager restart.

The specific use case is a mechanism to allow a child job of a Flux instance to publish its remote-uri in a place with easier access than the job's kvs, without losing the uri if the instance is restarted.
