### PR TITLE
rfc2: relax licensing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx-rtd-theme
+sphinx-rtd-theme>=0.5.2
 sphinxcontrib-spelling
 pyyaml
 jsonschema

--- a/spec_2.rst
+++ b/spec_2.rst
@@ -78,7 +78,7 @@ Collaboration Model for Flux Projects
 License for Flux Projects
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  Flux projects SHALL be licensed under the `GNU Lesser General Public License (LGPL) version 3 <https://www.gnu.org/licenses/lgpl-3.0.en.html>`__.
+-  Flux projects are RECOMMENDED to be licensed under the `GNU Lesser General Public License (LGPL) version 3 <https://www.gnu.org/licenses/lgpl-3.0.en.html>`__.
 
 -  Flux projects are RECOMMENDED to permit redistribution and/or modification
    under the project’s base license version, or any later version per


### PR DESCRIPTION
Per offline discussion about KubeFlux licensing needs, this relax the LGPL-3.0 REQUIRED language to RECOMMENDED for Flux framework projects.

Also, brought over a fix for rendering bullet lists on readthedocs from flux-docs, as I noticed they weren't rendering right here.