### PR TITLE
fix all broken links and a couple typos in RFC 21

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-on: [ pull_request ]
+on: [ pull_request, push ]
 jobs:
   check-pr:
     name: validate commits
@@ -27,3 +27,20 @@ jobs:
     - name: make check
       run: |
         make check
+
+  make-linkcheck:
+    name: make linkcheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.6
+    - name: install dependencies
+      run: |
+        pip3 install --upgrade -r ./requirements.txt
+    - name: make linkcheck
+      run: |
+        make linkcheck

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,6 +4,7 @@ queue_rules:
       - base=master
       - status-success="validate commits"
       - status-success="make check"
+      - status-success="make linkcheck"
       - label="merge-when-passing"
       - label!="work-in-progress"
       - "approved-reviews-by=@flux-framework/core"

--- a/spec_1.rst
+++ b/spec_1.rst
@@ -6,7 +6,7 @@
 ==============================================
 
 The Collective Code Construction Contract (C4.1) is an evolution of the
-github.com `Fork + Pull Model <http://help.github.com/send-pull-requests/>`__,
+github.com `Fork + Pull Model <https://help.github.com/en/pull-requests/>`__,
 aimed at providing an optimal collaboration model for free software
 projects.
 
@@ -24,7 +24,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 Related Standards
 -----------------
@@ -181,7 +181,7 @@ Release Process
 -  Releases SHALL be tagged with git annotated tags.
 
 -  Release names SHALL employ version numbers that follow the
-   Semantic Versioning 2.0.0 standard, (C.f. http://semver.org).
+   Semantic Versioning 2.0.0 standard, (C.f. https://semver.org).
 
 -  Release materials for projects that use GNU Autotools SHOULD include
    "dist tarballs"; that is, a source distribution with pre-generated
@@ -239,7 +239,7 @@ Project Administration
 Further Reading
 ---------------
 
--  `ZeroMQ - The Guide, Chapter 6: The ZeroMQ Community <http://zguide.zeromq.org/page:all#Chapter-The-MQ-Community>`__
+-  `ZeroMQ - The Guide, Chapter 6: The ZeroMQ Community <https://zguide.zeromq.org/docs/chapter6/#the-community>`__
 
 -  `Argyris' Models 1 and 2 <http://en.wikipedia.org/wiki/Chris_Argyris>`__ - the goals of C4.1 are consistent with Argyris' Model 2.
 
@@ -251,6 +251,4 @@ Implementations
 
 -  The `ZeroMQ community <http://zeromq.org>`__ uses the C4.1 process for many projects.
 
--  `OSSEC <http://www.ossec.net/>`__ `uses the C4.1 process <http://ossec-docs.readthedocs.org/en/latest/oRFC/orfc-1.html>`__.
-
--  The `ZeroVM <http://zerovm.org>`__ community uses `a C4.1 fork for their work <https://github.com/zerovm/zvm-community/blob/master/process/c4_1.md>`__.
+-  `OSSEC <http://www.ossec.net/>`__ `uses the C4.1 process <https://ossec-docs.readthedocs.io/en/latest/docs/development/oRFC/orfc-1.html>`__.

--- a/spec_10.rst
+++ b/spec_10.rst
@@ -20,7 +20,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Related Standards

--- a/spec_11.rst
+++ b/spec_11.rst
@@ -23,7 +23,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Related Standards

--- a/spec_12.rst
+++ b/spec_12.rst
@@ -22,7 +22,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Related Standards
@@ -235,17 +235,17 @@ authenticity, and integrity such as "CURVE" or "GSSAPI".
 
 ZeroMQ security is documented in:
 
--  `ZeroMQ RFC 23 ZMTP ZeroMQ Message Transport Protocol <http://rfc.zeromq.org/spec:23>`__
+-  `ZeroMQ RFC 23 ZMTP ZeroMQ Message Transport Protocol <https://rfc.zeromq.org/spec:23>`__
 
--  `ZeroMQ RFC 24 ZMTP PLAIN <http://rfc.zeromq.org/spec:24>`__
+-  `ZeroMQ RFC 24 ZMTP PLAIN <https://rfc.zeromq.org/spec:24>`__
 
--  `ZeroMQ RFC 25 ZMTP CURVE <http://rfc.zeromq.org/spec:25>`__
+-  `ZeroMQ RFC 25 ZMTP CURVE <https://rfc.zeromq.org/spec:25>`__
 
--  `ZeroMQ RFC 26 CurveZMQ <http://rfc.zeromq.org/spec:26>`__
+-  `ZeroMQ RFC 26 CurveZMQ <https://rfc.zeromq.org/spec:26>`__
 
--  `ZeroMQ RFC 27 ZAP ZeroMQ Authentication Protocol <http://rfc.zeromq.org/spec:27>`__
+-  `ZeroMQ RFC 27 ZAP ZeroMQ Authentication Protocol <https://rfc.zeromq.org/spec:27>`__
 
--  `ZeroMQ RFC 38 ZMTP GSSAPI <http://rfc.zeromq.org/spec:38>`__
+-  `ZeroMQ RFC 38 ZMTP GSSAPI <https://rfc.zeromq.org/spec:38>`__
 
 The default ZeroMQ security plugin SHALL be "CURVE", which requires
 minimal security infrastructure to operate.

--- a/spec_13.rst
+++ b/spec_13.rst
@@ -25,7 +25,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Related Standards
@@ -285,7 +285,7 @@ Notes:
    'PMI_Get_name_length_max()'.
 
 -  'PMI_Get_id_length_max()' was dropped from pmi.h [#f3]_ on 2011-01-28 in
-   `commit f17423ef <http://git.mpich.org/mpich.git/commit/f17423ef535f562bcacf981a9f7e379838962c6e>`__.
+   `commit f17423ef <https://github.com/pmodels/mpich/commit/f17423ef535f562bcacf981a9f7e379838962c6e>`__.
 
 .. code:: c
 
@@ -403,7 +403,7 @@ Notes:
    'PMI_Get_clique_size()'.
 
 -  This function was dropped from pmi.h [#f3]_ on 2011-01-28 in
-   `commit f17423ef <http://git.mpich.org/mpich.git/commit/f17423ef535f562bcacf981a9f7e379838962c6e>`__
+   `commit f17423ef <https://github.com/pmodels/mpich/commit/f17423ef535f562bcacf981a9f7e379838962c6e>`__
 
 -  The implementation should fetch the "PMI_process_mapping" value from the KVS
    and calculate the clique ranks (see below).
@@ -424,7 +424,7 @@ Errors:
 Notes:
 
 -  This function was dropped from pmi.h [#f3]_ on 2011-01-28 in
-   `commit f17423ef <http://git.mpich.org/mpich.git/commit/f17423ef535f562bcacf981a9f7e379838962c6e>`__
+   `commit f17423ef <https://github.com/pmodels/mpich/commit/f17423ef535f562bcacf981a9f7e379838962c6e>`__
 
 -  The implementation should fetch the "PMI_process_mapping" value from the KVS
    and calculate the clique ranks (see below).
@@ -542,7 +542,7 @@ Notes:
    an alias for 'PMI_KVS_Get_my_name()'.
 
 -  'PMI_Get_kvs_domain_id()' and 'PMI_Get_id()' were dropped from pmi.h [#f3]_
-   on 2011-01-28 in `commit f17423ef <http://git.mpich.org/mpich.git/commit/f17423ef535f562bcacf981a9f7e379838962c6e>`__.
+   on 2011-01-28 in `commit f17423ef <https://github.com/pmodels/mpich/commit/f17423ef535f562bcacf981a9f7e379838962c6e>`__.
 
 .. code:: c
 
@@ -579,7 +579,7 @@ Notes:
 -  These functions are OPTIONAL.
 
 -  Dropped from pmi.h [#f3]_ on 2011-01-28 in
-   `commit f17423ef <http://git.mpich.org/mpich.git/commit/f17423ef535f562bcacf981a9f7e379838962c6e>`__,
+   `commit f17423ef <https://github.com/pmodels/mpich/commit/f17423ef535f562bcacf981a9f7e379838962c6e>`__,
 
 
 Dynamic Process Management
@@ -668,7 +668,7 @@ Notes:
 -  These functions are OPTIONAL.
 
 -  These functions were dropped from pmi.h [#f3]_ on 2009-05-01 in
-   `commit 52c462d <http://git.mpich.org/mpich.git/commit/52c462d2be6a8d0720788d36e1e096e991dcff38>`__
+   `commit 52c462d <https://github.com/pmodels/mpich/commit/52c462d2be6a8d0720788d36e1e096e991dcff38>`__
 
 
 Wire Protocol
@@ -913,10 +913,10 @@ References
 
 .. [#f2] `MPI-2: Extensions to the Message-Passing Interface <https://www.mpi-forum.org/docs/mpi-2.0/mpi-20-html/mpi2-report.html>`__
 
-.. [#f3] `MPICH canonical pmi.h header <http://git.mpich.org/mpich.git/blob/HEAD:/src/include/pmi.h>`__
+.. [#f3] `MPICH canonical pmi.h header <https://github.com/pmodels/mpich/blob/94b1cd6f060cafbf68d6d83ea551a8bcc8fcecd4/src/pmi/include/pmi.h>`__
 
-.. [#f4] `MPICH simple PMI implementation <http://git.mpich.org/mpich.git/tree/HEAD:/src/pmi/simple>`__
+.. [#f4] `MPICH simple PMI implementation <https://github.com/pmodels/mpich/tree/94b1cd6f060cafbf68d6d83ea551a8bcc8fcecd4/src/pmi/simple>`__
 
-.. [#f5] `SLURM PMI-1 implementation <https://github.com/SchedMD/slurm/blob/master/src/api/pmi.c>`__
+.. [#f5] `SLURM PMI-1 implementation <https://github.com/SchedMD/slurm/blob/ba603812b947f14c1aba7adb220258feb7960001/src/api/slurm_pmi.c>`__
 
-.. [#f6] `PMI: A Scalable Parallel Process-Management Interface for Extreme-Scale Systems <http://www.mcs.anl.gov/papers/P1760.pdf>`__, P. Balaji et al, EuroMPI Proceedings, 2010.
+.. [#f6] `PMI: A Scalable Parallel Process-Management Interface for Extreme-Scale Systems <https://www.mcs.anl.gov/papers/P1760.pdf>`__, P. Balaji et al, EuroMPI Proceedings, 2010.

--- a/spec_14.rst
+++ b/spec_14.rst
@@ -23,7 +23,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Related Standards

--- a/spec_15.rst
+++ b/spec_15.rst
@@ -21,7 +21,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Related Standards

--- a/spec_16.rst
+++ b/spec_16.rst
@@ -20,7 +20,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Related Standards

--- a/spec_18.rst
+++ b/spec_18.rst
@@ -19,7 +19,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Related Standards

--- a/spec_19.rst
+++ b/spec_19.rst
@@ -23,7 +23,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Background

--- a/spec_2.rst
+++ b/spec_2.rst
@@ -22,7 +22,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Goals

--- a/spec_21.rst
+++ b/spec_21.rst
@@ -533,7 +533,7 @@ Example:
 
 .. code:: json
 
-  {"timestamp":1637723184.3725791,"name":"memo","context":{"key":"value"})
+  {"timestamp":1637723184.3725791,"name":"memo","context":{"key":"value"}}
 
 Debug Event
 ^^^^^^^^^^^

--- a/spec_21.rst
+++ b/spec_21.rst
@@ -371,7 +371,7 @@ description
    {"timestamp":1552593348.073045,"name":"epilog-start","context":{"description":"/usr/sbin/job-epilog.sh"}}
 
 
-Prolog-finish Event
+Epilog-finish Event
 ^^^^^^^^^^^^^^^^^^^
 
 A epilog action for the job has completed. The epilog description SHOULD

--- a/spec_21.rst
+++ b/spec_21.rst
@@ -20,7 +20,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Related Standards

--- a/spec_22.rst
+++ b/spec_22.rst
@@ -20,7 +20,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Background

--- a/spec_23.rst
+++ b/spec_23.rst
@@ -20,7 +20,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Background

--- a/spec_24.rst
+++ b/spec_24.rst
@@ -20,7 +20,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Related Standards

--- a/spec_25.rst
+++ b/spec_25.rst
@@ -24,7 +24,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Related Standards

--- a/spec_26.rst
+++ b/spec_26.rst
@@ -17,7 +17,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 Related Standards
 -----------------

--- a/spec_27.rst
+++ b/spec_27.rst
@@ -20,7 +20,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Related Standards

--- a/spec_28.rst
+++ b/spec_28.rst
@@ -21,7 +21,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Related Standards

--- a/spec_29.rst
+++ b/spec_29.rst
@@ -20,7 +20,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Background

--- a/spec_3.rst
+++ b/spec_3.rst
@@ -9,7 +9,7 @@ This specification describes the format of Flux message broker
 messages, Version 1.
 
 The Flux message protocol is encapsulated in the
-`ZeroMQ Message Transfer Protocol (ZMTP) <http://rfc.zeromq.org/spec:23/ZMTP>`__.
+`ZeroMQ Message Transfer Protocol (ZMTP) <https://rfc.zeromq.org/spec:23/ZMTP>`__.
 
 -  Name: github.com/flux-framework/rfc/spec_3.rst
 
@@ -23,7 +23,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Goals
@@ -309,6 +309,6 @@ ABNF grammar [#f2]_
    ; unused 4-byte field
    unused          = %x00.00.00.00
 
-.. [#f1] `RFC 7159: The JavaScript Object Notation (JSON) Data Interchange Format <http://www.rfc-editor.org/rfc/rfc7159.txt>`__, T. Bray, Google, Inc, March 2014.
+.. [#f1] `RFC 7159: The JavaScript Object Notation (JSON) Data Interchange Format <https://www.rfc-editor.org/rfc/rfc7159.txt>`__, T. Bray, Google, Inc, March 2014.
 
 .. [#f2] For convenience: the ``C:request``, ``S:response``, ``S:event``, and ``C:keepalive`` ABNF non-terminals refer to ZeroMQ messages, sent by client or server, and built from ordered ZeroMQ message parts (frames). Other non-terminals are built from concatenated ABNF terminals per usual. Thus it is meaningful for ``delimiter``, a message frame, to have zero length, since a zero-length message frame is valid ZMTP.

--- a/spec_30.rst
+++ b/spec_30.rst
@@ -19,7 +19,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 Related Standards
 -----------------

--- a/spec_4.rst
+++ b/spec_4.rst
@@ -20,7 +20,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Related Standards

--- a/spec_5.rst
+++ b/spec_5.rst
@@ -20,7 +20,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Related Standards

--- a/spec_6.rst
+++ b/spec_6.rst
@@ -20,7 +20,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Related Standards

--- a/spec_7.rst
+++ b/spec_7.rst
@@ -21,7 +21,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Related Standards
@@ -205,4 +205,4 @@ In emacs, add this to your custom-set-variables defs to highlight whitespace err
 Python coding style
 -------------------
 
--  Python code SHALL be formatted with the `Black code style <https://black.readthedocs.io/en/stable/the_black_code_style.html>`__.
+-  Python code SHALL be formatted with the `Black code style <https://black.readthedocs.io/en/stable/the_black_code_style/index.html>`__.

--- a/spec_8.rst
+++ b/spec_8.rst
@@ -17,7 +17,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Goals

--- a/spec_9.rst
+++ b/spec_9.rst
@@ -17,7 +17,7 @@ Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <http://tools.ietf.org/html/rfc2119>`__.
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
 Goals


### PR DESCRIPTION
I found a couple typos in RFC 21. At the same time I regretfully ran `make linkcheck` and then was duty bound to fix all the broken links.

I added all the link fixes in one big commit (sorry)

Finally, added `make linkcheck` to ci. (So this will need to be merged manually).