### PR TITLE
rfc25: add optional exclusive key to node resource vertex

### DIFF
--- a/spec_25.rst
+++ b/spec_25.rst
@@ -93,7 +93,11 @@ A resource vertex SHALL contain only the following keys:
 
 -  label
 
-The definitions of ``unit``, ``with``, and ``label`` SHALL match
+a ``node`` type resource vertex MAY also contain the following optional keys:
+
+- exclusive
+
+The definitions of ``unit``, ``with``, ``exclusive`` and ``label`` SHALL match
 those found in RFC14. The others are redefined and simplified to mean the
 following:
 


### PR DESCRIPTION
As discussed in flux-framework/flux-core#4228, we should have limited support for the `exclusive` flag on `node` resources in jobspec v1.

This PR simply adds that as a first step.

The next step will be to add a method to set this flag in the `Jobspec` class of Python and a new flag in `flux mini` tools to set it explicitly, and finally setting it implicitly when only `-N` is used. I guess we'd also want to add support for this flag in `libjobspec1` and the various jobspec C parsers in flux-core.

At first, `sched-simple` will just reject jobs when this flag is set. We're actually in a pretty good place since `-N` without `-n` was an error before, we are guaranteed to not break any tests. So kudos to @garlick and @trws for suggesting this behavior at first, since it will save a lot of pain now.
