### PR TITLE
rfc14: add constraints attribute to jobspec

### DIFF
--- a/data/spec_14/schema.json
+++ b/data/spec_14/schema.json
@@ -102,7 +102,8 @@
             "environment": { "type": "object" },
             "dependencies" : {
                 "$ref": "file:data/spec_26/schema.json"
-            }
+            },
+            "constraints" : { "type": "object" }
           }
         },
         "user": {

--- a/spec_14.rst
+++ b/spec_14.rst
@@ -345,6 +345,10 @@ Some common system attributes are:
    The value of the ``dependencies`` attribute SHALL be a
    list of dictionaries following the format specified in RFC 26.
 
+**constraints**
+   The value of the ``constraints`` attribute SHALL be a dictionary
+   expressing job constraints following the specification in RFC 31.
+
 **job**
    The ``job`` attribute is an optional dictionary containing job
    metadata. This metadata may be used for searching and filtering of


### PR DESCRIPTION
Problem: RFC 31 defines a format for specification of generic job
constraints, but RFC 14 does not define the location for a constraints
in jobspec.

Define attributes.system.constraints as the location in jobspec for
RFC 31 defined constraints.