### PR TITLE
rfc14,25: add example and references for constraints, dependencies

### DIFF
--- a/data/spec_14/use_case_2.9.yaml
+++ b/data/spec_14/use_case_2.9.yaml
@@ -1,0 +1,20 @@
+version: 999
+resources:
+  - type: slot
+    count: 1
+    label: default
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: [ "flux", "start" ]
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 3600.
+    cwd: "/home/flux"
+    constraints:
+      properties:
+        - amd-mi50

--- a/spec_14.rst
+++ b/spec_14.rst
@@ -37,6 +37,8 @@ Related Standards
 
 -  :doc:`26/Job Dependency Specification <spec_26>`
 
+-  :doc:`31/Job Constraints Specification <spec_31>`
+
 
 Goals
 -----
@@ -653,6 +655,17 @@ Specific Example
 Jobspec YAML
    .. literalinclude:: data/spec_14/use_case_2.8.yaml
       :language: yaml
+
+Use Case 2.9
+   Specify constraints based on properties
+
+Specific Example
+   Require that allocated resources have the ``amd-mi50`` property
+
+Jobspec YAML
+   .. literalinclude:: data/spec_14/use_case_2.9.yaml
+      :language: yaml
+
 
 .. [#f1] `YAML Ain’t Markup Language (YAML) Version 1.1 <http://yaml.org/spec/1.1/current.html>`__, O. Ben-Kiki, C. Evans, B. Ingerson, 2004.
 

--- a/spec_25.rst
+++ b/spec_25.rst
@@ -38,6 +38,9 @@ Related Standards
 
 -  :doc:`20/Resource Set Specification Version 1 <spec_20>`
 
+-  :doc:`26/Job Dependency Specification <spec_26>`
+
+-  :doc:`31/Job Constraints Specification <spec_31>`
 
 Goals
 -----
@@ -171,6 +174,10 @@ definitions can be found in RFC14. Values MAY have any valid YAML type.
    -  environment
 
    -  cwd
+
+   -  dependencies
+
+   -  constraints
 
 Most system attributes are optional, but the ``duration`` attribute is required in
 jobspec V1.


### PR DESCRIPTION
As described in #319, the lack of an example and references for the `constraints` key makes searching the RFC for this support challenging. Also references for `constraints` and `dependencies` is missing from RFC 25 (Jobspec v1 definition).

This PR addresses these concerns.

Fixes #319