### PR TITLE
rfc28: add property-add, property-remove keys

### DIFF
--- a/spec_28.rst
+++ b/spec_28.rst
@@ -150,6 +150,20 @@ down
   for scheduling.  The idset only contains targets that are transitioning,
   not the full set of unavailable targets.
 
+property-add
+  (object) RFC 20 conforming properties object containing properties that
+  should be added to the specified execution targets. When present, this
+  key reflects an update to the instance resource inventory which MAY
+  affect job satisfiability, the determination of which is left to the
+  scheduler implementation.
+
+property-remove
+  (object) RFC 20 conforming properties object containing properties that
+  should be removed from the specified execution targets. When present,
+  this key reflects an update to the instance resource inventory which
+  MAY affect job satisfiability, the determination of which is left to the
+  scheduler implementation.
+
 
 Example:
 
@@ -158,6 +172,8 @@ Example:
    {
       "up": "3-6",
       "down": "2"
+      "property-add": { "foo": "0-1" },
+      "property-remove" { "bar": "3" }
    }
 
 If down resources are assigned to a job, the scheduler SHALL NOT raise an


### PR DESCRIPTION
This PR is a first stab at an extension to the resource acquire protocol which would allow dynamic addition and removal of execution target properties.

The end result of such an extension might be a `flux resource property add/remove` command, which could end up being useful in even single-user instances of Flux (e.g. if a workflow wants to partition resources in some way, detects slow vs fast nodes, mark nodes on which a job ran for data locality, etc.)

This is just a proposal at this point. Feel free to discuss the implementation here.

One drawback to adding new keys to the `resource.acquire` response stream payload is that a scheduler could just ignore these new keys and `flux resource property add/remove` would silently do nothing. Perhaps the scheduler should additionally have some way to announce supported capabilities when it issues the `resource.acquire` RPC? Or, maybe since we only really have 2 schedulers, this is not a practical concern at this point..