### PR TITLE
rfc10: fix typo

### DIFF
--- a/spec_10.rst
+++ b/spec_10.rst
@@ -158,7 +158,7 @@ non-essential entries from its cache.
 Garbage Collection
 ~~~~~~~~~~~~~~~~~~
 
-References to content are the responsibility of the Flux key Value Store.
+References to content are the responsibility of the Flux Key Value Store.
 Content that the KVS no longer references MAY NOT be removed while the Flux
 instance is running.
 


### PR DESCRIPTION
Fix typo in RFC 10 caught by @chu11 after PR was merged.