### PR TITLE
rfc23: add "ms" suffix to Flux Standard Duration

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -63,6 +63,10 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README.md']
 master_doc = 'index'
 source_suffix = '.rst'
 
+linkcheck_ignore = [
+    "https://help.github.com/en/pull-requests", # 403 Forbidden
+]
+
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/spec_23.rst
+++ b/spec_23.rst
@@ -39,11 +39,14 @@ said to support "Flux Standard Duration."
 Implementation
 --------------
 
-A duration in Flux Standard Duration SHALL be of the form ``N[SUFFIX]`` where
-``SUFFIX`` SHALL be optional and, if provided, MUST be a single character from the
-set ``s,m,h,d``. The value ``N`` MUST be a non-negative, non-infinite,
-floating-point number excluding ``NaN``. The value ``N`` SHALL be in one of the
-forms allowed by C99  [#f1]_ ``strtof`` or ``strtod`` and SHALL be interpreted as:
+A duration in Flux Standard Duration SHALL be of the form ``N[SUFFIX]``
+where ``SUFFIX`` SHALL be optional and, if provided, MUST be a string from
+the set { ``ms``, ``s``, ``m``, ``h``, ``d`` }. The value ``N`` MUST be a
+non-negative, non-infinite, floating-point number excluding ``NaN``. The
+value ``N`` SHALL be in one of the forms allowed by C99  [#f1]_ ``strtof``
+or ``strtod`` and SHALL be interpreted as:
+
+-  *milliseconds* if ``SUFFIX`` is ``ms``.
 
 -  *seconds* if ``SUFFIX`` is not provided, or is ``s``.
 


### PR DESCRIPTION
Problem: The Flux Standard Duration specification only allows a unit
suffix of "s" (seconds) or greater, but there are times when it would
convenient to represent a duration in milliseconds (ms), especially
when converting a small duration into FSD.

Add an "ms" suffix to the FSD spec. Reword the specification to allow
for string suffixes instead of only a single character suffix.