### PR TITLE
rfc10: use hash digests in raw message payloads not blobrefs

### DIFF
--- a/spec_10.rst
+++ b/spec_10.rst
@@ -51,7 +51,13 @@ Store (KVS).  The goals of the content storage service are:
 -  The cryptographic hash algorithm is configurable per instance.
 
 This kind of store has interesting and well-understood properties, as
-explored in Venti, Git, and Camlistore (see References below).
+explored in Venti, Git, and Camlistore (see References below), for example:
+
+-  Writes are idempotent
+
+-  De-duplication is automatic
+
+-  The address may be used to check the integrity of the addressed content
 
 
 Implementation

--- a/spec_10.rst
+++ b/spec_10.rst
@@ -51,7 +51,7 @@ Store (KVS).  The goals of the content storage service are:
 -  The cryptographic hash algorithm is configurable per instance.
 
 This kind of store has interesting and well-understood properties, as
-explored in Venti, Git, and Camlistore (see References below), for example:
+explored in Venti, Git, and Perkeep (see References below), for example:
 
 -  Writes are idempotent
 
@@ -130,8 +130,7 @@ Example:
 
    sha1-f1d2d2f924e986ac86fdf7b36c94bcdf32beec15
 
-Note: "blobref" was shamelessly borrowed from Camlistore
-(see References below).
+Note: "blobref" was shamelessly borrowed from Perkeep (see References below).
 
 
 Store
@@ -201,7 +200,7 @@ garbage collection.
 References
 ----------
 
--  `Camlistore is your personal storage system for life <https://camlistore.org/>`__.
+-  `Perkeep lets you permanently keep your stuff, for life. <https://perkeep.org/>`__.
 
 -  `Venti: a new approach to archival storage <http://doc.cat-v.org/plan_9/4th_edition/papers/venti/>`__, Bell Labs, Quinlan and Dorward.
 

--- a/spec_10.rst
+++ b/spec_10.rst
@@ -109,11 +109,14 @@ avoid failures resulting from extreme workloads.  The original limit will
 be restored once KVS *hdir* objects are implemented.
 
 
-Blobref
+Address
 ~~~~~~~
 
-Each unique, stored blob of content SHALL be addressable by its blobref.
-A blobref SHALL consist of a string formed by the concatenation of:
+Each unique, stored blob of content SHALL be addressable by its hash digest.
+
+A human-readable *blobref* MAY be used as an alternate representation of
+the hash digest.  A blobref SHALL consist of a string formed by the
+concatenation of:
 
 -  the name of hash algorithm used to store the content
 
@@ -138,7 +141,7 @@ A store request SHALL be encoded as a Flux request message with the blob
 as raw payload (blob length > 0), or no payload (blob length = 0).
 
 A store response SHALL be encoded as a Flux response message with
-NULL-terminated blobref string as raw payload, or an error response.
+the message digest as raw payload, or an error response.
 
 A request to store content that exceeds the maximum size SHALL
 receive error number 27, "File too large", in response.
@@ -151,7 +154,7 @@ Load
 ~~~~
 
 A load request SHALL be encoded as a Flux request message with
-NULL-terminated blobref string as raw payload.
+message digest as raw payload.
 
 A load response SHALL be encoded as a Flux response message with blob
 as raw payload (blob length > 0), no payload (blob length = 0),

--- a/spec_10.rst
+++ b/spec_10.rst
@@ -76,6 +76,8 @@ Rank 0 SHALL retain all content previously stored by the instance.
 Rank 0 MAY extend its cache with an OPTIONAL backing store, the details
 of which are beyond the scope of this RFC.
 
+The content service SHALL NOT be accessible by guest users.
+
 
 Content
 ~~~~~~~

--- a/spec_10.rst
+++ b/spec_10.rst
@@ -79,6 +79,25 @@ of which are beyond the scope of this RFC.
 The content service SHALL NOT be accessible by guest users.
 
 
+Hash Algorithm
+~~~~~~~~~~~~~~
+
+A Flux instance SHALL select a hash algorithm at startup.  This selection
+MUST NOT change throughout the lifetime of the instance.
+
+The configured algorithm SHALL be made available to Flux components via the
+``content.hash`` broker attribute.
+
+The hash algorithm:
+
+-  MUST have a high enough collision resistance so that the probability of
+   storing two different blobs with the same address is extremely unlikely
+
+-  is RECOMMENDED to have high space efficiency
+
+-  is RECOMMENDED to have low computational overhead
+
+
 Content
 ~~~~~~~
 

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -126,7 +126,7 @@ pre
 bcdf
 beec
 blobref
-Camlistore
+Perkeep
 cryptographic
 Dorward
 dropcache


### PR DESCRIPTION
This changes the content load and store message definitions to carry raw hash digests rather than blobrefs, which reduces message size and processing overhead slightly.  This simplification is possible because we no longer expect to need to support multiple hash algorithms within a given instance, nor sharing of raw content between instances.  Also, we have restricted access by guests and recast the service as a KVS layer rather than general purpose.

It also feels like protocol cleanup, given that the blobref strings are being sent as raw payload.  If we're not sending them as strings within a JSON object, why not just send the more space efficient raw representation?

I also added some info that fills out this rather sparse RFC a bit.

I do have a prototype branch which implements these changes and uses the hash digest to as a zhashx key in the broker content cache, rather than running blobrefs through the default Bernstein hash that is the zhashx default which is...redundant.   I didn't notice any difference in the job throughput numbers in this branch though FWIW.  This still seems like good cleanup however.