### PR TITLE
RFC21: add jobspec-update event

### DIFF
--- a/spec_21.rst
+++ b/spec_21.rst
@@ -193,6 +193,24 @@ Example:
 
 The ``submit`` event SHALL be the first event posted for each job.
 
+Jobspec-update Event
+^^^^^^^^^^^^^^^^^^^^
+
+Set jobspec attributes after job submission.  The event context object SHALL
+consist of a dictionary of period-delimited keys beginning with ``attributes.``
+and MUST contain at least one entry.
+
+Example:
+
+.. code:: json
+
+   {"timestamp":1552593348.073045,"name":"jobspec-update","context":{"attributes.system.duration":3600}}
+
+.. note::
+   The ``jobspec-update`` event affects only the Flux instance's view of the
+   job.  The signed request containing the user's original jobspec SHALL NOT
+   be altered.
+
 Validate Event
 ^^^^^^^^^^^^^^
 

--- a/spec_21.rst
+++ b/spec_21.rst
@@ -191,6 +191,8 @@ Example:
 
    {"timestamp":1552593348.073045,"name":"submit","context":{"urgency":16,"userid":5588,"flags":0}}
 
+The ``submit`` event SHALL be the first event posted for each job.
+
 Validate Event
 ^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Problem: RFC 33 refers to the `jobspec-update` event in RFC 21, but it does not appear there.

Add the event to RFC 21.