### PR TITLE
rfc21: add version to submit event

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -156,8 +156,8 @@ used to generate Flux job IDs.
 This specification defines the version 1 format of the resource-set
 representation or *R* in short.
 
-:doc:`21/Job States and Events <spec_21>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`21/Job States and Events Version 1 <spec_21>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This specification describes Flux job states and the events that
 trigger job state transitions.

--- a/spec_21.rst
+++ b/spec_21.rst
@@ -2,8 +2,8 @@
    GitHub is NOT the preferred viewer for this file. Please visit
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_21.html
 
-21/Job States and Events
-========================
+21/Job States and Events Version 1
+==================================
 
 This specification describes Flux job states and the events that trigger
 job state transitions.
@@ -69,6 +69,10 @@ Design Criteria
 -  Events SHALL be logged to the job eventlog.
 
 -  Replaying the job eventlog SHALL accurately reproduce the current job state.
+
+-  The job manager SHOULD be capable of ingesting job eventlogs following
+   recent versions of this specification, to avoid losing job data when Flux
+   is restarted after a software upgrade.
 
 
 Implementation
@@ -185,11 +189,15 @@ userid
 flags
    (integer) Mask of flags (1=debug).
 
+version
+   (integer) Version of the job eventlog format.  This document describes
+   version 1.
+
 Example:
 
 .. code:: json
 
-   {"timestamp":1552593348.073045,"name":"submit","context":{"urgency":16,"userid":5588,"flags":0}}
+   {"timestamp":1552593348.073045,"name":"submit","context":{"urgency":16,"userid":5588,"flags":0,"version":1}}
 
 The ``submit`` event SHALL be the first event posted for each job.
 


### PR DESCRIPTION
Problem: the job eventlog format recently changed with the addition
of the validate event, and this made it difficult to detect and
handle eventlogs from earlier versions when restarting after a
Flux upgrade.

Add a version number to the submit event that can be used to
distinguish this and future changes to the eventlog format.

See also flux-framework/flux-core#4399