### PR TITLE
rfc33: update after implementing limits and jobspec defaults

### DIFF
--- a/spec_10.rst
+++ b/spec_10.rst
@@ -200,7 +200,7 @@ garbage collection.
 References
 ----------
 
--  `Perkeep lets you permanently keep your stuff, for life. <https://perkeep.org/>`__.
+-  `Perkeep lets you permanently keep your stuff, for life. <https://en.wikipedia.org/wiki/Perkeep>`__.
 
 -  `Venti: a new approach to archival storage <http://doc.cat-v.org/plan_9/4th_edition/papers/venti/>`__, Bell Labs, Quinlan and Dorward.
 

--- a/spec_33.rst
+++ b/spec_33.rst
@@ -262,7 +262,3 @@ to request jobs in other queues by name, or all queues.
 The job submission tools SHOULD leave the queue unset (thereby selecting
 the default.  An option SHALL be provided to direct jobs to other
 queues by name.
-
-.. note::
-   The ``sched.queue`` annotation defined in RFC 27 is no longer necessary
-   since the queue name is represented in the job jobspec as described above.

--- a/spec_33.rst
+++ b/spec_33.rst
@@ -129,13 +129,9 @@ policy.jobspec.defaults.system.queue
   (string) default queue name.
 
 .. note::
-   Jobspec updates are applied to the in-memory copy of the jobspec held
-   by the job manager.  The in-memory copy is also sent to the scheduler with
-   the job's ``alloc`` request.  The original jobspec in the KVS (both signed
-   and unsigned) is unaltered.  Since jobspec modifications are posted to the
-   job eventlog as ``jobspec-update`` events (RFC 21), the altered jobspec
-   may by reconstructed by fetching the original jobspec, then replaying any
-   ``jobspec-update`` events.
+   Jobspec defaults are applied at ingest to the unsigned copy of the jobspec
+   held stored in the KVS under the ``jobspec`` key.  The original jobspec
+   remains within the signed ``J`` key.
 
 Limits Policy
 ^^^^^^^^^^^^^

--- a/spec_33.rst
+++ b/spec_33.rst
@@ -154,14 +154,6 @@ policy.limits.job-size.min.nnodes
 policy.limits.duration
   (string) maximum job duration, in Flux Standard Duration format (RFC 23).
 
-.. note::
-   A general mechanism for configuring and applying limits in a distributed
-   fashion is proposed in rough form in
-   https://github.com/flux-framework/flux-core/issues/4309.
-   Consider creating an RFC for limits that can be referenced from this one
-   and skip those details here.
-
-
 Scheduler Policy
 ^^^^^^^^^^^^^^^^
 

--- a/spec_33.rst
+++ b/spec_33.rst
@@ -117,15 +117,15 @@ values SHALL override global policy values.
 Jobspec Defaults Policy
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``jobspec.defaults`` policy table contains default values for jobspec
+The ``policy.jobspec.defaults`` table contains default values for jobspec
 attributes that were not explicitly set by the user and MAY contain following
 OPTIONAL keys.  The key names are identical to the corresponding jobspec
 attribute names (RFC 14, 25).
 
-system.duration
+policy.jobspec.defaults.system.duration
   (string) default duration, in Flux Standard Duration format (RFC 23).
 
-system.queue
+policy.jobspec.defaults.system.queue
   (string) default queue name.
 
 .. note::
@@ -140,22 +140,22 @@ system.queue
 Limits Policy
 ^^^^^^^^^^^^^
 
-The `limits` policy table configures job limits and MAY contain the following
+The ``policy.limits`` table configures job limits and MAY contain the following
 OPTIONAL keys.
 
-job-size.max.nnodes
+policy.limits.job-size.max.nnodes
   (integer) maximum number of nodes.
 
-job-size.max.ncores
+policy.limits.job-size.max.ncores
   (integer) maximum number of cores.
 
-job-size.max.ngpus
+policy.limits.job-size.max.ngpus
   (integer) maximum number of gpus.
 
-job-size.min.nnodes
+policy.limits.job-size.min.nnodes
   (integer) minimum number of nodes.
 
-duration
+policy.limits.duration
   (string) maximum job duration, in Flux Standard Duration format (RFC 23).
 
 .. note::
@@ -169,7 +169,7 @@ duration
 Scheduler Policy
 ^^^^^^^^^^^^^^^^
 
-The ``scheduler`` policy table is read by the scheduler implementation
+The ``policy.scheduler`` table is read by the scheduler implementation
 and is opaque to the rest of Flux.
 
 Priority Policy
@@ -180,14 +180,14 @@ TBD
 Access Policy
 ^^^^^^^^^^^^^
 
-The ``access`` policy table MAY restrict queue access by UNIX user and group.
+The ``policy.access`` table MAY restrict queue access by UNIX user and group.
 It MAY contain following OPTIONAL keys:
 
-allow-user
+policy.access.allow-user
   (list of strings) Specify a list of UNIX user names that are to be granted
   access.
 
-allow-group
+policy.access.allow-group
   (list of strings) Specify a list of UNIX group names that are to be granted
   access.
 
@@ -204,13 +204,13 @@ A ``queues`` TOML table MAY define one or more named queues.  Each queue
 SHALL be represented as a sub-table that MAY contain the following OPTIONAL
 keys:
 
-requires
+queues.NAME.requires
   (table) Specify queue-specific resource constraint(s) in RFC 31 format,
   that SHALL be added to the jobspec ``system.constraints`` attribute of all
   jobs submitted to this queue.  If the jobspec already specifies constraints,
   then the queue-specific constraints SHALL be added with an ``and`` operator.
 
-policy
+queues.NAME.policy
   (table) Specify policy fragments that apply only to this queue, using the
   form described in the previous section.  If the same policy appears in the
   top-level ``policy`` table  and a queue-specific ``policy`` table, the
@@ -221,10 +221,9 @@ Initial Assignment of Job to Queue
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Job requests MAY specify a queue name at submission time by setting the
-``queue`` jobspec system attribute (RFC 14).  If a queue was not explicitly
+``system.queue`` jobspec attribute (RFC 14).  If a queue was not explicitly
 named in the jobspec, and a default queue is defined, the queue SHALL be
-assigned by the job manager during the initial request validation,
-before the jobtap ``job.validate`` callbacks are run.
+assigned by before the jobtap ``job.validate`` callbacks are run.
 
 Request Validation
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Problem:  The design for applying jobspec defaults and implementing limits has evolved somewhat since the RFC was written.  In addition, some notes were placed there during discussions that were thought would be ongoing, but which did not go anywhere.

Make a pass through RFC 33 to get it in sync with current plans.