### PR TITLE
rfc34: allow empty and document unknown task maps

### DIFF
--- a/spec_34.rst
+++ b/spec_34.rst
@@ -113,7 +113,10 @@ Implementation
 **************
 
 The Flux task map SHALL be represented as a JSON array to avoid the need
-for a custom parser.  The array MUST contain one or more *map blocks*.
+for a custom parser.  The array MUST contain zero or more *map blocks*.
+
+A Flux task map that contains zero map blocks SHALL indicate that the task
+mapping is unknown.
 
 A Flux task map block is a JSON array with four REQUIRED integer array
 elements:
@@ -182,6 +185,8 @@ Test Vectors
 
    * - raw task map
      - Flux task map
+   * - mapping unknown
+     - []
    * - 0
      - [[0,1,1,1]]
    * - 0;1


### PR DESCRIPTION
RFC 34 does not indicate how to specify an unknown task mapping, but indication of an unknown mapping is required when, for example, an encoded mapping is too large to distribute or the mapping is otherwise not known.

This PR documents that an empty string is an indicator of an "uknonwn" mapping for `PMI_process_mapping`, as is already documented in RFC 13, and also makes an empty string the official encoding of an unknown mapping in the Flux Task Map format.

Additionally, an "empty" mapping is also allowed by changing the task map requirement from "one or more blocks" to "zero or more". (This is probably only useful in testing, and also is the encoded output from a libtaskmap encoded result from `taskmap_create()` with no further initialization)