### PR TITLE
rfc13: use function directive to make PMI API docs more readable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -16,12 +16,12 @@ jobs:
     name: make check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v4
       with:
-        python-version: 3.6
+        python-version: '3.9'
     - name: install dependencies
       run: |
         pip3 install --upgrade -r ./requirements.txt
@@ -33,12 +33,12 @@ jobs:
     name: make linkcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v4
       with:
-        python-version: 3.6
+        python-version: '3.9'
     - name: install dependencies
       run: |
         pip3 install --upgrade -r ./requirements.txt

--- a/spec_13.rst
+++ b/spec_13.rst
@@ -270,9 +270,7 @@ indicating the result of the operation:
 Initialization
 ==============
 
-.. code:: c
-
-   int PMI_Init (int *spawned);
+.. c:function:: int PMI_Init (int *spawned)
 
 Initialize the PMI library for this process. Upon success, the value
 of ``spawned`` (boolean) SHALL bet set to (1) if this process was created
@@ -284,9 +282,7 @@ Errors:
 
 -  PMI_FAIL - initialization failed
 
-.. code:: c
-
-   int PMI_Initialized (int *initialized);
+.. c:function:: int PMI_Initialized (int *initialized)
 
 Check if the PMI library has been initialized for this process.
 Upon success, the the value of ``initialized`` (boolean) SHALL be set to
@@ -298,12 +294,10 @@ Errors:
 
 -  PMI_FAIL - unable to set the variable
 
-.. code:: c
-
-   int PMI_KVS_Get_name_length_max (int *length);
-   int PMI_KVS_Get_key_length_max (int *length);
-   int PMI_KVS_Get_value_length_max (int *length);
-   int PMI_Get_id_length_max (int *length);
+.. c:function:: int PMI_KVS_Get_name_length_max (int *length)
+.. c:function:: int PMI_KVS_Get_key_length_max (int *length)
+.. c:function:: int PMI_KVS_Get_value_length_max (int *length)
+.. c:function:: int PMI_Get_id_length_max (int *length)
 
 Obtain the maximum length (including terminating NULL) of KVS name,
 key, value, and id strings. Upon success, the PMI library SHALL
@@ -327,9 +321,7 @@ Notes:
 -  ``PMI_Get_id_length_max()`` was dropped from pmi.h [#f3]_ on 2011-01-28 in
    `commit f17423ef <https://github.com/pmodels/mpich/commit/f17423ef535f562bcacf981a9f7e379838962c6e>`__.
 
-.. code:: c
-
-   int PMI_Finalize (void);
+.. c:function:: int PMI_Finalize (void)
 
 Finalize the PMI library for this process.
 
@@ -337,9 +329,7 @@ Errors:
 
 -  PMI_FAIL - finalization failed
 
-.. code:: c
-
-   int PMI_Abort (int exit_code, const char error_msg[]);
+.. c:function:: int PMI_Abort (int exit_code, const char error_msg[])
 
 Abort the process group associated with this process.
 The PMI library SHALL print ``error_msg`` to standard error, then exit this
@@ -349,9 +339,7 @@ process with with ``exit_code``. This function SHALL NOT return.
 Process Group Information
 =========================
 
-.. code:: c
-
-   int PMI_Get_size (int *size);
+.. c:function:: int PMI_Get_size (int *size)
 
 Obtain the size of the process group to which the local process belongs.
 Upon success, the value of ``size`` SHALL be set to the size of the process
@@ -363,9 +351,7 @@ Errors:
 
 -  PMI_FAIL - unable to return the size
 
-.. code:: c
-
-   int PMI_Get_rank (int *rank);
+.. c:function:: int PMI_Get_rank (int *rank)
 
 Obtain the rank (0…​size-1) of the local process in the process group.
 Upon success, ``rank`` SHALL be set to the rank of the local process.
@@ -376,9 +362,7 @@ Errors:
 
 -  PMI_FAIL - unable to return the rank
 
-.. code:: c
-
-   int PMI_Get_universe_size (int *size);
+.. c:function:: int PMI_Get_universe_size (int *size)
 
 Obtain the universe size, which is the the maximum future size of the
 process group for dynamic applications. Upon success, ``size`` SHALL
@@ -394,9 +378,7 @@ Notes:
 
 -  See MPI-2 [#f2]_ section `5.5.1. Universe Size <https://www.mpi-forum.org/docs/mpi-2.0/mpi-20-html/node111.htm>`__.
 
-.. code:: c
-
-   int PMI_Get_appnum (int *appnum);
+.. c:function:: int PMI_Get_appnum (int *appnum)
 
 Obtain the application number. Upon success, ``appnum`` SHALL be set to
 the application number.
@@ -415,9 +397,7 @@ Notes
 Local Process Group Information
 ===============================
 
-.. code:: c
-
-   int PMI_Get_clique_ranks (int ranks[], int length);
+.. c:function:: int PMI_Get_clique_ranks (int ranks[], int length)
 
 Get the ranks of the local processes in the process group.
 This is a simple topology function to distinguish between processes that can
@@ -448,9 +428,7 @@ Notes:
 -  The implementation should fetch the ``PMI_process_mapping`` value from the
    KVS and calculate the clique ranks (see below).
 
-.. code:: c
-
-   int PMI_Get_clique_size (int *size);
+.. c:function:: int PMI_Get_clique_size (int *size)
 
 Obtain the number of processes on the local node. Upon success, ``size``
 SHALL be set to the number of processes on the local node.
@@ -473,9 +451,7 @@ Notes:
 Key Value Store
 ===============
 
-.. code:: c
-
-   int PMI_KVS_Put (const char kvsname[], const char key[], const char value[]);
+.. c:function:: int PMI_KVS_Put (const char kvsname[], const char key[], const char value[])
 
 Put a key/value pair in a keyval space.
 The user SHALL set ``kvsname`` to the name returned from
@@ -505,9 +481,7 @@ Notes:
 
 -  A key SHALL NOT be put more than once to a keyval space.
 
-.. code:: c
-
-   int PMI_KVS_Commit (const char kvsname[]);
+.. c:function:: int PMI_KVS_Commit (const char kvsname[])
 
 Commit all previous puts to the keyval space. Upon success, all puts
 since the last ``PMI_KVS_Commit()`` shall be stored into the specified
@@ -527,9 +501,7 @@ Notes:
 -  It is a process local operation, thus in some implementations,
    it MAY have no effect and still return PMI_SUCCESS.
 
-.. code:: c
-
-   int PMI_KVS_Get (const char kvsname[], const char key[], char value[], int length);
+.. c:function:: int PMI_KVS_Get (const char kvsname[], const char key[], char value[], int length)
 
 Get a key/value pair from a keyval space.
 The user SHALL set ``kvsname`` to the name returned from
@@ -553,11 +525,9 @@ Errors:
 
 -  PMI_FAIL - get failed
 
-.. code:: c
-
-   int PMI_KVS_Get_my_name (char kvsname[], int length);
-   int PMI_Get_kvs_domain_id (char kvsname[], int length);
-   int PMI_Get_id( char kvsname[], int length );
+.. c:function:: int PMI_KVS_Get_my_name (char kvsname[], int length)
+.. c:function:: int PMI_Get_kvs_domain_id (char kvsname[], int length)
+.. c:function:: int PMI_Get_id (char kvsname[], int length)
 
 This function returns the common keyval space for this process group.
 The user SHALL set set ``length`` to the length of the ``kvsname`` array,
@@ -586,9 +556,7 @@ Notes:
 -  ``PMI_Get_kvs_domain_id()`` and ``PMI_Get_id()`` were dropped from pmi.h
    [#f3]_ on 2011-01-28 in `commit f17423ef <https://github.com/pmodels/mpich/commit/f17423ef535f562bcacf981a9f7e379838962c6e>`__.
 
-.. code:: c
-
-   int PMI_Barrier (void);
+.. c:function:: int PMI_Barrier (void)
 
 This function is a collective call across all processes in the process group
 the local process belongs to. The PMI library SHALL attempt to block until
@@ -609,12 +577,10 @@ Notes:
 -  The barrier operation MUST be usable as a generic synchronization mechanism,
    without requiring KVS data to be queued for exchange.
 
-.. code:: c
-
-   int PMI_KVS_Create( char kvsname[], int length );
-   int PMI_KVS_Destroy( const char kvsname[] );
-   int PMI_KVS_Iter_first(const char kvsname[], char key[], int key_len, char val[], int val_len);
-   int PMI_KVS_Iter_next(const char kvsname[], char key[], int key_len, char val[], int val_len);
+.. c:function:: int PMI_KVS_Create (char kvsname[], int length)
+.. c:function:: int PMI_KVS_Destroy (const char kvsname[]);
+.. c:function:: int PMI_KVS_Iter_first (const char kvsname[], char key[], int key_len, char val[], int val_len)
+.. c:function:: int PMI_KVS_Iter_next (const char kvsname[], char key[], int key_len, char val[], int val_len)
 
 Notes:
 
@@ -634,15 +600,7 @@ Dynamic Process Management
        char * val;
    } PMI_keyval_t;
 
-   int PMI_Spawn_multiple (int count,
-                           const char * cmds[],
-                           const char ** argvs[],
-                           const int maxprocs[],
-                           const int info_keyval_sizesp[],
-                           const PMI_keyval_t * info_keyval_vectors[],
-                           int preput_keyval_size,
-                           const PMI_keyval_t preput_keyval_vector[],
-                           int errors[]);
+.. c:function:: int PMI_Spawn_multiple (int count, const char *cmds[], const char **argvs[], const int maxprocs[], const int info_keyval_sizesp[], const PMI_keyval_t *info_keyval_vectors[], int preput_keyval_size, const PMI_keyval_t preput_keyval_vector[], int errors[])
 
 This function spawns a set of processes into a new process group.
 ``count`` refers to the size of the array parameters ``cmd``, ``argvs``,
@@ -678,11 +636,9 @@ Notes:
 
 -  See MPI-2 [#f2]_ section `5.3.5.1. Manager-worker Example, Using MPI_SPAWN. <https://www.mpi-forum.org/docs/mpi-2.0/mpi-20-html/node98.htm>`__
 
-.. code:: c
-
-   int PMI_Publish_name (const char service_name[], const char port[]);
-   int PMI_Unpublish_name (const char service_name[]);
-   int PMI_Lookup_name (const char service_name[], char port[]);
+.. c:function:: int PMI_Publish_name (const char service_name[], const char port[])
+.. c:function:: int PMI_Unpublish_name (const char service_name[])
+.. c:function:: int PMI_Lookup_name (const char service_name[], char port[])
 
 Publish/unpublish/lookup a name.
 
@@ -699,12 +655,10 @@ Notes:
 
 -  See MPI-2 [#f2]_ section `5.4.4. Name Publishing <https://www.mpi-forum.org/docs/mpi-2.0/mpi-20-html/node104.htm>`__.
 
-.. code:: c
-
-   int PMI_Parse_option (int num_args, char *args[], int *num_parsed, PMI_keyval_t **keyvalp, int *size);
-   int PMI_Args_to_keyval (int *argcp, char *((*argvp)[]), PMI_keyval_t **keyvalp, int *size);
-   int PMI_Free_keyvals (PMI_keyval_t keyvalp[], int size);
-   int PMI_Get_options (char *str, int *length);
+.. c:function:: int PMI_Parse_option (int num_args, char *args[], int *num_parsed, PMI_keyval_t **keyvalp, int *size)
+.. c:function:: int PMI_Args_to_keyval (int *argcp, char *((*argvp)[]), PMI_keyval_t **keyvalp, int *size)
+.. c:function:: int PMI_Free_keyvals (PMI_keyval_t keyvalp[], int size)
+.. c:function:: int PMI_Get_options (char *str, int *length)
 
 Notes:
 

--- a/spec_13.rst
+++ b/spec_13.rst
@@ -6,6 +6,8 @@
 13/Simple Process Manager Interface v1
 ======================================
 
+.. highlight:: c
+
 The MPI process manager interface (PMI) version 1 is a de-facto standard
 API and wire protocol for communication between MPI runtimes and resource
 managers. It was added to the MPICH2 MPI-2 reference implementation in
@@ -274,7 +276,7 @@ Initialization
 
 Initialize the PMI library for this process. Upon success, the value
 of ``spawned`` (boolean) SHALL bet set to (1) if this process was created
-by ``PMI_Spawn_multiple()``, or (0) if not.
+by :c:func:`PMI_Spawn_multiple`, or (0) if not.
 
 Errors:
 
@@ -315,10 +317,10 @@ Notes:
 -  Process Management in MPICH [#f1]_ recommends minimum lengths for
    name, key, and value of 16, 32, and 64, respectively.
 
--  ``PMI_Get_id_length_max()`` SHALL be considered an alias for
-   ``PMI_Get_name_length_max()``.
+-  :c:func:`PMI_Get_id_length_max` SHALL be considered an alias for
+   :c:func:`PMI_KVS_Get_name_length_max`.
 
--  ``PMI_Get_id_length_max()`` was dropped from pmi.h [#f3]_ on 2011-01-28 in
+-  :c:func:`PMI_Get_id_length_max` was dropped from pmi.h [#f3]_ on 2011-01-28 in
    `commit f17423ef <https://github.com/pmodels/mpich/commit/f17423ef535f562bcacf981a9f7e379838962c6e>`__.
 
 .. c:function:: int PMI_Finalize (void)
@@ -403,7 +405,7 @@ Get the ranks of the local processes in the process group.
 This is a simple topology function to distinguish between processes that can
 communicate through IPC mechanisms (e.g., shared memory) and other network
 mechanisms. The user SHALL set ``length`` to the size returned by
-``PMI_Get_clique_size()``, and ``ranks`` to an integer array of that length.
+:c:func:`PMI_Get_clique_size`, and ``ranks`` to an integer array of that length.
 Upon success, the PMI library SHALL fill each slot of the array with the
 rank of a local process in the process group.
 
@@ -420,7 +422,7 @@ Notes:
 -  This function returns the ranks of the processes on the local node.
 
 -  The array must be at least as large as the size returned by
-   ``PMI_Get_clique_size()``.
+   :c:func:`PMI_Get_clique_size`.
 
 -  This function was dropped from pmi.h [#f3]_ on 2011-01-28 in
    `commit f17423ef <https://github.com/pmodels/mpich/commit/f17423ef535f562bcacf981a9f7e379838962c6e>`__
@@ -455,13 +457,13 @@ Key Value Store
 
 Put a key/value pair in a keyval space.
 The user SHALL set ``kvsname`` to the name returned from
-``PMI_KVS_Get_my_name()``.  The user SHALL set ``key`` and ``value`` to NULL
+:c:func:`PMI_KVS_Get_my_name`.  The user SHALL set ``key`` and ``value`` to NULL
 terminated strings no longer (with NULL) than the sizes returned by
-``PMI_KVS_Get_key_length_max()`` and ``PMI_KVS_Get_value_length_max()``
+:c:func:`PMI_KVS_Get_key_length_max` and :c:func:`PMI_KVS_Get_value_length_max`
 respectively.
 
 Upon success, the PMI value SHALL be visible to other processes after
-``PMI_KVS_Commit()`` and ``PMI_Barrier()`` are called.
+:c:func:`PMI_KVS_Commit` and :c:func:`PMI_Barrier` are called.
 
 Errors:
 
@@ -484,7 +486,7 @@ Notes:
 .. c:function:: int PMI_KVS_Commit (const char kvsname[])
 
 Commit all previous puts to the keyval space. Upon success, all puts
-since the last ``PMI_KVS_Commit()`` shall be stored into the specified
+since the last :c:func:`PMI_KVS_Commit` shall be stored into the specified
 ``kvsname``.
 
 Errors:
@@ -505,11 +507,11 @@ Notes:
 
 Get a key/value pair from a keyval space.
 The user SHALL set ``kvsname`` to the name returned from
-``PMI_KVS_Get_my_name()``.  The user SHALL set ``length`` to the length of the
+:c:func:`PMI_KVS_Get_my_name`.  The user SHALL set ``length`` to the length of the
 ``value`` array, which SHALL be no shorter than the length returned by
-``PMI_KVS_Get_value_length_max()``.  The user SHALL set 'key' to a NULL
+:c:func:`PMI_KVS_Get_value_length_max`.  The user SHALL set 'key' to a NULL
 terminated string no longer (with NULL) than the size returned by
-``PMI_KVS_Get_key_length_max()``.
+:c:func:`PMI_KVS_Get_key_length_max`.
 
 Upon success, the PMI library SHALL fill ``value`` with the value of ``key``.
 
@@ -532,7 +534,7 @@ Errors:
 This function returns the common keyval space for this process group.
 The user SHALL set set ``length`` to the length of the ``kvsname`` array,
 which SHALL be no shorter than the length returned by
-``PMI_KVS_Get_name_length_max()``.
+:c:func:`PMI_KVS_Get_name_length_max`.
 
 Upon success, the PMI library SHALL set ``kvsname`` to a NULL terminated
 string representing the keyval space.
@@ -548,10 +550,10 @@ Errors:
 Notes:
 
 -  length SHALL be greater than or equal to the length returned
-   by ``PMI_KVS_Get_name_length_max()``.
+   by :c:func:`PMI_KVS_Get_name_length_max`.
 
--  ``PMI_Get_kvs_domain_id()`` and ``PMI_Get_id()`` SHALL be considered
-   an alias for ``PMI_KVS_Get_my_name()``.
+-  :c:func:`PMI_Get_kvs_domain_id` and :c:func:`PMI_Get_id` SHALL be considered
+   an alias for :c:func:`PMI_KVS_Get_my_name`.
 
 -  ``PMI_Get_kvs_domain_id()`` and ``PMI_Get_id()`` were dropped from pmi.h
    [#f3]_ on 2011-01-28 in `commit f17423ef <https://github.com/pmodels/mpich/commit/f17423ef535f562bcacf981a9f7e379838962c6e>`__.

--- a/spec_13.rst
+++ b/spec_13.rst
@@ -2,6 +2,7 @@
    GitHub is NOT the preferred viewer for this file. Please visit
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_13.html
 
+======================================
 13/Simple Process Manager Interface v1
 ======================================
 
@@ -20,22 +21,25 @@ managers that must support current and legacy MPI implementations.
 -  State: raw
 
 
+********
 Language
---------
+********
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
 be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
 
 
+*****************
 Related Standards
------------------
+*****************
 
 -  :doc:`12/Flux Security Architecture <spec_12>`
 
 
+*****
 Goals
------
+*****
 
 -  Decrease coupling between process managers and MPI implementations by
    clarifying their "contract" for communication.
@@ -51,8 +55,9 @@ Goals
 -  Identify which functions are optional, and under what circumstances.
 
 
+************
 PMI Versions
-------------
+************
 
 This document covers PMI 1.1 with a few notes about backwards
 compatibility with earlier versions.
@@ -72,8 +77,9 @@ PMIX ("X" for extension), is as set of extensions to PMI-2. The PMIX
 extensions are not covered here.
 
 
+********
 Overview
---------
+********
 
 PMI was designed as an interface between process managers and parallel
 programs, including, but not limited to, MPI runtimes. It has two main
@@ -106,8 +112,9 @@ implemented using the PMI-1 wire protocol; or less flexibly, a shared
 library providing the PMI-1 API implemented using a proprietary protocol.
 
 
+***********
 Terminology
------------
+***********
 
 Process manager
   The provider of PMI services. A resource manager MAY operate in the role
@@ -125,8 +132,9 @@ PMI library
   A shared library that provides the PMI-1 API.
 
 
+*******
 Caveats
--------
+*******
 
 Some deficiencies of PMI 1 are noted in the PMI-2 paper [#f6]_:
 
@@ -147,8 +155,9 @@ in stronger coupling between process managers and MPI implementations
 than necessary.
 
 
+***********
 Environment
------------
+***********
 
 The process manager MAY use the UNIX environment to communicate basic
 process group information to processes.
@@ -171,8 +180,9 @@ set the following environment variables:
      - only set (to 1) if the program was created by ``PMI_Spawn_multiple()``
 
 
+*********************************
 Application Programming Interface
----------------------------------
+*********************************
 
 Programs SHOULD NOT strongly bind to a particular process manager’s
 PMI library, for example with rpath, as this complicates running a
@@ -198,7 +208,7 @@ therefore PMI libraries SHALL NOT implement functions not defined below.
 
 
 Return Codes
-~~~~~~~~~~~~
+============
 
 All PMI-1 functions SHALL return one of the following integer values,
 indicating the result of the operation:
@@ -258,7 +268,7 @@ indicating the result of the operation:
 
 
 Initialization
-~~~~~~~~~~~~~~
+==============
 
 .. code:: c
 
@@ -337,7 +347,7 @@ process with with ``exit_code``. This function SHALL NOT return.
 
 
 Process Group Information
-~~~~~~~~~~~~~~~~~~~~~~~~~
+=========================
 
 .. code:: c
 
@@ -403,7 +413,7 @@ Notes
 
 
 Local Process Group Information
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+===============================
 
 .. code:: c
 
@@ -461,7 +471,7 @@ Notes:
 
 
 Key Value Store
-~~~~~~~~~~~~~~~
+===============
 
 .. code:: c
 
@@ -615,7 +625,7 @@ Notes:
 
 
 Dynamic Process Management
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+==========================
 
 .. code:: c
 
@@ -704,8 +714,9 @@ Notes:
    `commit 52c462d <https://github.com/pmodels/mpich/commit/52c462d2be6a8d0720788d36e1e096e991dcff38>`__
 
 
+*************
 Wire Protocol
--------------
+*************
 
 The reference implementation of the PMI-1.1 wire protocol is the MPICH
 Hydra [#f4]_ process manager.
@@ -729,7 +740,7 @@ For maximum interoperability, a message parser SHOULD allow
 
 
 Connection
-~~~~~~~~~~
+==========
 
 If the wire protocol is offered, the process manager SHALL "pre-connect"
 a file descriptor, arrange for the file descriptor to be inherited by
@@ -738,7 +749,7 @@ at process launch time.
 
 
 Version Negotiation
-~~~~~~~~~~~~~~~~~~~
+===================
 
 The client SHALL send the init request first, with the highest version
 of PMI supported by the client. The server SHALL respond with the
@@ -747,7 +758,7 @@ send other commands until the init operation has completed.
 
 
 Error Handling
-~~~~~~~~~~~~~~
+==============
 
 All responses MAY include an "rc" key.
 On error, the "rc" key SHALL be set to a nonzero value.
@@ -763,7 +774,7 @@ the problem can be tracked down.
 
 
 Spawn Operation
-~~~~~~~~~~~~~~~
+===============
 
 The spawn request consists of multiple newline-terminated messages.
 These messages SHALL NOT be interspersed with messages for other operations.
@@ -774,7 +785,7 @@ elements SHALL begin with zero and increase monotonically.
 
 
 Protocol Definition
-~~~~~~~~~~~~~~~~~~~
+===================
 
 .. code-block:: ABNF
 
@@ -900,15 +911,16 @@ Protocol Definition
 
 
 Back Compatibility
-~~~~~~~~~~~~~~~~~~
+==================
 
 Earlier versions of the PMI-1 wire protocol did not include the init
 operation in which versions are exchanged. Protocol operations that
 were culled in PMI 1.1 are not covered here.
 
 
+*******************************
 Local Process Group Information
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*******************************
 
 The process manager SHALL provide the local process group information
 to programs via the KVS under the "PMI_process_mapping" key.  It MAY be
@@ -952,8 +964,9 @@ manager SHALL return a value consisting of an empty string, indicating that
 the mapping is unknown.
 
 
+**********
 References
-----------
+**********
 
 .. [#f1] `Process Management in MPICH Draft 2.1 <https://drive.google.com/file/d/0B273EWJxZUxsbS15SEkzZGtXU2c/view?usp=sharing>`__
 


### PR DESCRIPTION
Just a bit of cleanup in RFC 13 which I had been referring to lately.  Now the  PMI function defintions look more like Jansson's API docs!