### PR TITLE
rfc23: support infinity as valid FSD

### DIFF
--- a/spec_23.rst
+++ b/spec_23.rst
@@ -69,8 +69,8 @@ The OPTIONAL unit suffix MUST be one of the following (case sensitive):
      - days
      - 86400
 
-As a special case, the string ``infinity`` SHALL be interpreted as a
-duration equivalent to the C99 macro [#f2]_ ``INFINITY``.
+As a special case, when N is ``infinity`` or ``inf``, the unit suffix SHALL
+be omitted.
 
 .. [#f1] `C99 - ISO/IEC 9899:1999 standard <https://www.iso.org/standard/29237.html>`__ section 7.20.1.3: The strtod, strtof, and strtold functions
 .. [#f2] `C99 - ISO/IEC 9899:1999 standard <https://www.iso.org/standard/29237.html>`__ section 7.12/4 INFINITY (p: 212-213)

--- a/spec_23.rst
+++ b/spec_23.rst
@@ -56,4 +56,8 @@ or ``strtod`` and SHALL be interpreted as:
 
 -  *days* if ``SUFFIX`` is ``d``.
 
+As a special case, the string ``infinity`` SHALL be interpreted as a
+duration equivalent to the C99 macro [#f2]_ ``INFINITY``.
+
 .. [#f1] `C99 - ISO/IEC 9899:1999 standard <https://www.iso.org/standard/29237.html>`__ section 7.20.1.3: The strtod, strtof, and strtold functions
+.. [#f2] `C99 - ISO/IEC 9899:1999 standard <https://www.iso.org/standard/29237.html>`__ section 7.12/4 INFINITY (p: 212-213)

--- a/spec_23.rst
+++ b/spec_23.rst
@@ -39,12 +39,13 @@ said to support "Flux Standard Duration."
 Implementation
 --------------
 
-A duration in Flux Standard Duration SHALL be of the form ``N[SUFFIX]``
-where ``SUFFIX`` SHALL be optional and, if provided, MUST be a string from
-the set { ``ms``, ``s``, ``m``, ``h``, ``d`` }. The value ``N`` MUST be a
-non-negative, non-infinite, floating-point number excluding ``NaN``. The
-value ``N`` SHALL be in one of the forms allowed by C99  [#f1]_ ``strtof``
-or ``strtod`` and SHALL be interpreted as:
+A Flux Standard Duration SHALL be a string of the form ``N[SUFFIX]``,
+where *N* is a floating point number and *SUFFIX* is an OPTIONAL unit.
+
+*N* SHALL have a range of [0:infinity] and SHALL be in a form allowed by
+C99  [#f1]_ ``strtof`` or ``strtod``.
+
+The OPTIONAL unit suffix MUST be one of the following (case sensitive):
 
 -  *milliseconds* if ``SUFFIX`` is ``ms``.
 

--- a/spec_23.rst
+++ b/spec_23.rst
@@ -72,5 +72,34 @@ The OPTIONAL unit suffix MUST be one of the following (case sensitive):
 As a special case, when N is ``infinity`` or ``inf``, the unit suffix SHALL
 be omitted.
 
+Test Vectors
+------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - FSD string
+     - duration (seconds)
+   * - 2ms
+     - 0.002
+   * - 0.1s
+     - 0.1
+   * - 30
+     - 30
+   * - 1.2h
+     - 4320
+   * - 5m
+     - 300
+   * - 0s
+     - 0
+   * - 5d
+     - 432000
+   * - inf
+     - INFINITY [#f2]_
+   * - INF
+     - INFINITY
+   * - infinity
+     - INFINITY
+
 .. [#f1] `C99 - ISO/IEC 9899:1999 standard <https://www.iso.org/standard/29237.html>`__ section 7.20.1.3: The strtod, strtof, and strtold functions
 .. [#f2] `C99 - ISO/IEC 9899:1999 standard <https://www.iso.org/standard/29237.html>`__ section 7.12/4 INFINITY (p: 212-213)

--- a/spec_23.rst
+++ b/spec_23.rst
@@ -47,15 +47,27 @@ C99  [#f1]_ ``strtof`` or ``strtod``.
 
 The OPTIONAL unit suffix MUST be one of the following (case sensitive):
 
--  *milliseconds* if ``SUFFIX`` is ``ms``.
+.. list-table::
+   :header-rows: 1
 
--  *seconds* if ``SUFFIX`` is not provided, or is ``s``.
-
--  *minutes* if ``SUFFIX`` is ``m``.
-
--  *hours* if ``SUFFIX`` is ``h``.
-
--  *days* if ``SUFFIX`` is ``d``.
+   * - Suffix
+     - Name
+     - Multiplier
+   * - ms
+     - milliseconds
+     - 1E-3
+   * - s
+     - seconds
+     - 1
+   * - m
+     - minutes
+     - 60
+   * - h
+     - hours
+     - 3600
+   * - d
+     - days
+     - 86400
 
 As a special case, the string ``infinity`` SHALL be interpreted as a
 duration equivalent to the C99 macro [#f2]_ ``INFINITY``.


### PR DESCRIPTION
Problem: There are times when a duration must be encoded as infinity or unlimited, but FSD does not offer a good way to express that.

Support the string "infinity" as a special case in RFC 23.