### PR TITLE
rfc21: remove ambiguity about extra events and context keys

### DIFF
--- a/spec_21.rst
+++ b/spec_21.rst
@@ -170,7 +170,13 @@ Job state transitions are driven by events that are logged to
 ``job.<jobid>.eventlog`` as required by RFC 16.
 
 Events are formatted as described in RFC 18, with additional requirements
-described below:
+described below.
+
+Events beyond those listed below MAY appear in a job eventlog.
+
+Unless otherwise specified, keys beyond those listed as OPTIONAL and
+REQUIRED below MAY be included in event context objects for use by plugins
+or extensions.
 
 
 Submit Event


### PR DESCRIPTION
Problem: There is ambiguity in RFC 21 about the inclusion of extra events and context keys beyond those specified in the document.

Add a couple statements that make it clear that additional events and context keys are allowed.