### PR TITLE
rfc36: fix invalid example

### DIFF
--- a/spec_36.rst
+++ b/spec_36.rst
@@ -130,11 +130,11 @@ Examples
        flux: --queue=batch
        flux: --job-name="my python job"
         
-       flux: # Set some arbitrary user data:
+       # Set some arbitrary user data:
        flux: --setattr=user.data='''
-       x, y, z
-       a, b, c
-       '''
+       flux: x, y, z
+       flux: a, b, c
+       flux: '''
        """
        run()
 
@@ -147,7 +147,7 @@ Examples
    --
    -- flux: -N1 --exclusive
    -- flux: --output=job.out
-   local aap = require 'app'
+   local app = require 'app'
    app.run()
 
  * Directives can be mixed with non-directive comments if they share


### PR DESCRIPTION
Problem: One of the examples in RFC 36 is invalid because it does not include the directive sentinel for all lines of a multiline quoted string.

Fix the invalid example to comply with the RFC.

Also fix a minor typo in another example.