### PR TITLE
WIP: rfc37: add Flux JSON Archive specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Table of Contents
 - [34/Flux Task Map](spec_34.rst)
 - [35/Constraint Query Syntax](spec_35.rst)
 - [36/Batch Script Directives](spec_36.rst)
+- [37/Flux JSON Archive](spec_37.rst)
 
 Build Instructions
 ------------------

--- a/index.rst
+++ b/index.rst
@@ -251,6 +251,12 @@ JSON objects in the format described in RFC 31.
 This specification defines a method for embedding job submission options
 and other directives in files.
 
+:doc:`37/Flux JSON Archive <spec_37>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This specification defines a method for archiving a directory of files in
+JSON.
+
 .. Each file must appear in a toctree
 .. toctree::
    :hidden:
@@ -290,3 +296,4 @@ and other directives in files.
    spec_34
    spec_35
    spec_36
+   spec_37

--- a/spec_37.rst
+++ b/spec_37.rst
@@ -1,0 +1,105 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_37.html
+
+37/Flux JSON Archive
+====================
+
+This specification describes the format used to represent archives of
+files and directories in JSON.
+
+-  Name: github.com/flux-framework/rfc/spec_37.rst
+
+-  Editor: Mark Grondona <mark.grondona@gmail.com>
+
+-  State: raw
+
+
+Language
+--------
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
+
+
+Background
+----------
+
+When encoding one files into a JSON object, it is not problematic to
+use ad hoc solutions such as storing file contents in a well known key. A
+current trivial example is the placement of a batch job script into jobspec
+at a well known, but arbitrary, key. However, If there is a need to store
+an arbitrary number of files in JSON, or to encode a directory to JSON,
+then a more formal specification may be useful.
+
+
+Goals
+-----
+
+- Allow Flux utilities and jobs to store, access, and extract file and
+  directory content which are stored as JSON objects.
+
+- Allow a JSON archive to be incorporated into other JSON objects such
+  as jobspec.
+
+- Support text files, but allow future extensions to other encodings.
+
+Implementation
+--------------
+
+A Flux JSON Archive SHALL represent a filesystem directory as a JSON object,
+with a key per directory entry.
+
+A directory entry SHALL be represented as a JSON object with the following
+REQUIRED keys:
+
+- ``mode`` : integer representation of a file ``mode_t`` as passed to
+  ``chmod(2)``.
+
+- ``content``: The contents of the directory entry.
+
+The following keys are OPTIONAL:
+
+- ``type``: The file type; ``file`` or ``dir``. If not set the default is
+  "file".
+
+For a directory entry of type ``file``, ``content`` is the file contents
+encoded as UTF-8. If an entry of type ``file`` has contents of only JSON,
+``content`` MAY be encoded as JSON instead of an escaped string.
+
+For a directory entry of type ``dir``, ``content`` SHALL be a JSON Archive.
+
+Examples:
+
+- A single executable script:
+
+  .. code:: json
+
+    {"script.sh": {"mode": 384, "content": "#!/bin/sh\ndate;hostname\n"}}
+
+- A small archived directory hierarchy:
+
+  .. code:: json
+
+    {
+      "config": {
+        "content": {
+          "conf.json": {
+            "content": {
+              "tbon": {
+                "tcp_user_timeout": "30s"
+              }
+            },
+            "mode": 256
+          }
+        },
+        "mode": 448,
+        "type": "dir"
+      },
+      "script.sh": {
+        "content": "#!/bin/sh\ndate;hostname\n",
+        "mode": 384
+      }
+    }
+    

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -464,3 +464,7 @@ llsubmit
 multiline
 Lua
 docstring
+subinstance
+hoc
+config
+unarchive


### PR DESCRIPTION
This is a first rough draft specification for storing an "archive" of files in a JSON object. The spec is purposefully very simple for now.

The idea here is that once this RFC is official, we can specify an `attributes.system.inputs` or similar key in RFC 14 as a generic way to encode files that are used as input to a job, e.g. the batch script, an instance config file etc. The job shell would then treat all these inputs in the same way, extracting the "archive" to the job's TMPDIR and allowing the job to find all inputs in a standard way, instead of using a specific method or plugin for each file.

An archive can contain other directories in this specification, though perhaps that was a misstep since that isn't a known use case at this time. The content of regular files must be encoded as utf-8, as we may want to discourage the placement of large binary blobs in JSON. (we have the stage-in/out plugin for this). However, an `encoding` key could be added in the future to allow small binary files, e.g. to allow encrypted or compressed files.