### PR TITLE
rfc14/25: add queue to common system attributes list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ sphinx-rtd-theme>=0.5.2
 sphinxcontrib-spelling
 pyyaml
 jsonschema
+urllib3<2

--- a/spec_14.rst
+++ b/spec_14.rst
@@ -343,6 +343,10 @@ Some common system attributes are:
    The value of the ``cwd`` attribute is a string containing the absolute
    path to the current working directory to use when spawning the task.
 
+**queue**
+   The value of the ``queue`` attribute is a string containing the name of
+   the job queue this job should be submitted to.
+
 **dependencies**
    The value of the ``dependencies`` attribute SHALL be a
    list of dictionaries following the format specified in RFC 26.

--- a/spec_25.rst
+++ b/spec_25.rst
@@ -175,6 +175,8 @@ definitions can be found in RFC14. Values MAY have any valid YAML type.
 
    -  cwd
 
+   -  queue
+
    -  dependencies
 
    -  constraints


### PR DESCRIPTION
Problem: "queue" is a common system attribute but is not listed.

Add it.