### PR TITLE
rfc14: add `files` section to jobspec

### DIFF
--- a/spec_14.rst
+++ b/spec_14.rst
@@ -378,6 +378,21 @@ Some common system attributes are:
       for the job shell. A job shell and its plugins are free to define
       what keys and values should go into ``options``.
 
+**files**
+   The ``files`` key SHALL consist of a dictionary in RFC 37 File Archive
+   Format containing files that SHALL be made available to the job.
+   The ``files`` key is intended to allow batch scripts, configuration
+   files, and user defined input files to be embedded in jobspec. The job
+   shell SHALL unarchive each file encoded in the archive into a temporary
+   directory for use by the job. The following top-level files in the
+   input archive are reserved:
+
+   **script**
+      The ``script`` key SHALL be reserved for a batch job script.
+
+   **conf.json**
+      The ``conf.json`` key SHALL be reserved for use as a subinstance
+      configuration file.
 
 Example Jobspec
 ~~~~~~~~~~~~~~~

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -468,3 +468,5 @@ blobvec
 mtime
 ctime
 unarchived
+subinstance
+unarchive


### PR DESCRIPTION
Problem; There is no standardized method for embedding files in jobspec.  Currently, `flux batch` and the job shell use an ad-hoc mechanism to store the batch script under `attributes.system.batch.script`, but it would be useful to formalize this case and open the door for the storage of other simple files in jobspec, with automated extraction by the job shell.

Document `attributes.system.files` as an RFC 37 file archive, which shall be extracted by the job shell into the job's temporary directory. Reserve two files: `script` for any job batch script, and `conf.json` for a subinstance config file.

This PR is currently a WIP while a prototype of the job shell and cli interface are developed. We can also start a discussion to make sure all use cases are covered with this simple proposal.