### PR TITLE
rfc21: make exception note required

### DIFF
--- a/spec_21.rst
+++ b/spec_21.rst
@@ -548,10 +548,12 @@ severity
    (integer) Specify the severity of the exception, in range of 0 (most severe)
    to to 7 (least severe).
 
-The following keys are OPTIONAL:
-
 note
-   (string) Brief human-readable explanation of the exception.
+
+   (string) Brief human-readable explanation of the exception.  If no explanation
+   is given, an empty string SHOULD be set for the note.
+
+The following keys are OPTIONAL:
 
 userid
    (integer) User ID that initiated the exception, if other than instance owner.


### PR DESCRIPTION
Problem: Currently the exception note is defined as optional.  Making the exception note optional makes parsing exceptions difficult.

Solution: Make an exception note required.  If one is not desired, it should be set to an empty string.

---

per discussion in https://github.com/flux-framework/flux-core/pull/5336

I went with the language "should" set it to empty string.  Because implementation could choose something different, eg. "no note specified", etc.  