### PR TITLE
rfc21: add resource-update event

### DIFF
--- a/spec_21.rst
+++ b/spec_21.rst
@@ -225,6 +225,20 @@ Example:
    job.  The signed request containing the user's original jobspec SHALL NOT
    be altered.
 
+Resource-update Event
+^^^^^^^^^^^^^^^^^^^^^
+
+Update R expiration time after allocation.  The event context object SHALL
+consist of a dictionary containing the key ``expiration`` with an integer
+value representing seconds since the Unix Epoch (1970-01-01 UTC).
+
+Example:
+
+.. code:: json
+
+   {"timestamp":1552593348.073045,"name":"resource-update","context":{"expiration":1692206240}}
+
+
 Validate Event
 ^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Problem: there is no way to update the expiration time in R once allocated.

Add a resource-update event similar to jobpspec-update. Currently the only allowed context key is expiration but this could be expanded in the future.