### PR TITLE
rfc38: clarify disposition of null characters in keys and string values

### DIFF
--- a/spec_15.rst
+++ b/spec_15.rst
@@ -29,6 +29,8 @@ Related Standards
 
 -  :doc:`12/Flux Security Architecture <spec_12>`
 
+-  :doc:`38/Flux Security Key Value Encoding <spec_38>`
+
 
 Introduction
 ------------

--- a/spec_38.rst
+++ b/spec_38.rst
@@ -64,6 +64,14 @@ character, a type character, a UTF-8 value string, and a NULL character.
 
 Each key SHALL have a length greater than zero.
 
+Keys and string values MAY NOT contain the UTF-8 NULL character.
+
+.. note::
+   A zero byte MAY NOT be embedded in any key or value encoding because
+   it would be indistinguishable from the NULL field delimiter.  The only UTF-8
+   encoding that contains a zero byte is that of the NULL character, therefore
+   the NULL character is forbidden.
+
 Value type characters and associated value string encodings are as follows:
 
 s

--- a/spec_38.rst
+++ b/spec_38.rst
@@ -36,7 +36,7 @@ Background
 The flux-security project requires simple objects to be encoded for
 communication in the following security-sensitive situations:
 
-- To receive *J* (signed jobspec plus metadata).
+- To encode the header component of *J* (signed jobspec plus metadata).
 
 - When communicating options between privileged and unprivileged sections
   of the IMP.


### PR DESCRIPTION
Problem: rfc38 doesn't say anything about (valid) UTF-8 strings containg the NULL character.

Add clarification.