### PR TITLE
rfc21: allow jobspec-update to any key

### DIFF
--- a/spec_21.rst
+++ b/spec_21.rst
@@ -210,9 +210,11 @@ The ``submit`` event SHALL be the first event posted for each job.
 Jobspec-update Event
 ^^^^^^^^^^^^^^^^^^^^
 
-Set jobspec attributes after job submission.  The event context object SHALL
-consist of a dictionary of period-delimited keys beginning with ``attributes.``
-and MUST contain at least one entry.
+Change jobspec after job submission.  The event context object SHALL consist
+of a dictionary of period-delimited keys that SHALL be interpreted as a
+hierarchical JSON path.  The dictionary MUST contain at least one entry.
+If the key already exists in the jobspec object, the old value SHALL be
+replaced with the new value.
 
 Example:
 


### PR DESCRIPTION
Problem: the jobspec-update event is constrained to only allow updates to the `attributes` section, but updates to the resources section are needed to implement emerging requirements in flux-coral2.

Allow any key to be updated.

Add some clarity on JSON key "paths" and what is supposed to happen if the key already exists.

Fixes #395