### PR TITLE
rfc23: note default fsd is in seconds

### DIFF
--- a/spec_23.rst
+++ b/spec_23.rst
@@ -69,6 +69,8 @@ The OPTIONAL unit suffix MUST be one of the following (case sensitive):
      - days
      - 86400
 
+If no suffix is specified, N is assumed to be in seconds.
+
 As a special case, when N is ``infinity`` or ``inf``, the unit suffix SHALL
 be omitted.
 


### PR DESCRIPTION
Problem: In commit

7eca38c882c8acc6b8e0a5c61cbab41a548060af

a list of suffixes was converted into a table.  This conversion accidentally dropped a note indicating that the default units of FSD are in seconds.

Solution: Add a sentence after the suffix table indicating the default is in seconds if no suffix is specified.