### PR TITLE
rfc28: add expiration to list of possible keys in acquire response

### DIFF
--- a/spec_28.rst
+++ b/spec_28.rst
@@ -164,6 +164,10 @@ property-remove
   MAY affect job satisfiability, the determination of which is left to the
   scheduler implementation.
 
+expiration
+  (float) When present, this key notifies the scheduler that the expiration
+  time of the resource set has been updated to the included floating-point
+  value.
 
 Example:
 


### PR DESCRIPTION
Problem: RFC 21 defines a resource-update event which may modify the expiration time of the R for a job, but there is no way for an expiration update of a Flux instance running as a job to be communicated to the subinstance scheduler.

Add an expiration key to the RFC 28 acquire response which may be used by the instance reosurce module to notify the scheduler of an expiration update.

This approach was taken for now instead of a more generic extension to the acquire protocol (e.g. grow/shrink, etc) because this will be simplest to implement. A more generic extension to support future grow and shrink probably needs more thought and design.