### PR TITLE
rfc20: rework content

### DIFF
--- a/spec_20.rst
+++ b/spec_20.rst
@@ -67,17 +67,27 @@ where it primes the child scheduler with a block of allocatable resources.
 Design Goals
 ************
 
-The *R* format is designed with the following goals:
+*R* is designed with the following goals:
 
--  Allow the resource data conformant to our resource model (RFC 4)
-   to be serialized and deserialized with no data loss;
+-  Identify the specific resources where a job's tasks are to be launched.
 
--  Express the resource allocation information to the execution service;
+-  Identify the specific resources managed by a Flux instance.
 
--  Use the same format to release a resource subset of *R* to the scheduler;
+-  Be suitable for inclusion in a job's post-mortem record, and useful for
+   answering forensic questions like "did my job run on the node that failed?".
 
--  Allow the consumers of *R* to deserialize an *R* object while minimizing
-   the parsing complexity and the data to read;
+-  Handle nodes, cores, and GPUs simply to ease the initial Flux implementation.
+
+-  Allow schedulers to add proprietary enhancements that are ignored by
+   the rest of Flux.
+
+-  Don't explode in size on large clusters/jobs.
+
+-  Handle resource properties as described in RFC 31
+
+-  Build towards the general resource model of RFC 4.
+
+
 
 **************
 Implementation

--- a/spec_20.rst
+++ b/spec_20.rst
@@ -249,7 +249,7 @@ The following is an example of a version 1 resource specification.
 The example below indicates a resource set with the ranks 19
 through 22.  These ranks correspond to the nodes node186 through
 node189.  Each of the nodes contains 48 cores (0-47) and 8 gpus (0-7).
-The :data:`starttime` and data:`expiration` indicate the resources were valid
+The :data:`starttime` and :data:`expiration` indicate the resources were valid
 for about 30 minutes on February 16, 2023.
 
 .. literalinclude:: data/spec_20/example1.json

--- a/spec_20.rst
+++ b/spec_20.rst
@@ -41,6 +41,8 @@ Related Standards
 
 -  :doc:`29/Hostlist Format <spec_29>`
 
+-  :doc:`31/Job Constraints Specification <spec_31>`
+
 ********
 Overview
 ********

--- a/spec_20.rst
+++ b/spec_20.rst
@@ -111,26 +111,6 @@ Design Goals
 Implementation
 **************
 
-Producers and Consumers
-=======================
-
--  The scheduler for a Flux instance (or instance scheduler) uses
-   this format to serialize each resource allocation
-   as REQUIRED by the instance program execution service and OPTIONALLY
-   REQUIRED by child scheduler instances.
-
--  The instance scheduler deserializes an *R* object to build
-   its internal resource data used for scheduling.
-
--  Users MAY manually write an *R* object for testing and debugging.
-
--  User-facing utilities that query a resource status (e.g., what
-   resources are available or idle, or what resources are allocated to a job)
-   MAY use an *R* object to extract this information;
-
--  The program execution service emits a valid *R* object to release
-   a resource subset of an *R* to the instance scheduler.
-
 Resource Set Format Definition
 ==============================
 

--- a/spec_20.rst
+++ b/spec_20.rst
@@ -47,21 +47,39 @@ Related Standards
 Overview
 ********
 
-Flexible resource representation is important for some of the key
-components of Flux.
-Resource requests are part of Flux jobspec, described in RFC 14.
-This RFC describes the format of a concrete resource-set representation
-referred to as *R*, constructed by the scheduler in response
-to a resource request.
-*R* is input to the remote execution system, which uses information
-expressed in *R* to establish containment, binding, mapping,
-and execution of program tasks, apportioned across broker ranks.
-As a program terminates, the execution system releases
-shards of the original *R*, eventually
-adding up to its union, back to the scheduler.
-Finally, when a Flux instance launches a child instance,
-*R* is passed down from the enclosing instance to the child instance,
-where it primes the child scheduler with a block of allocatable resources.
+This specification describes a JSON object *R* used to represents sets of
+specific resources.  *R* is for representing concrete resources like "cores
+2-5 of node 9".  It is distinct from the *jobspec* resources section (RFC 14)
+which is for abstract resource requirements like "one node with four cores".
+
+The following Flux subsystems must handle *R*:
+
+resource module
+  A Flux instance has a resource inventory which it obtains from configuration,
+  through allocation from the enclosing instance, or via dynamic probing.
+  The end result is expressed as *R*.  The resources in *R* are also monitored
+  at the rank level for availability.
+
+scheduler
+  The scheduler obtains the resource inventory at initialization and fulfills
+  job requests by allocating *R* subsets to them.  When jobs terminate their
+  *R* subsets are returned to the scheduler and become available for
+  fulfilling other job requests.
+
+job manager
+  The job manager tracks *R* so it can pass it to the scheduler and execution
+  subsystems as the job transitions through job states.  In addition, *R* is
+  made available to jobtap plugins which extend the job manager's function.
+  Finally, when *R* is updated, for example to extend the duration of a
+  running job, the job manager coordinates *R* updates across subsystems.
+
+execution
+  The job execution system uses *R* to determine where to launch Flux shells.
+
+shell
+  The job shell uses *R* to determine where to launch tasks.  Shell plugins
+  may use *R* for various purposes such setting core and GPU affinity.
+
 
 ************
 Design Goals

--- a/spec_20.rst
+++ b/spec_20.rst
@@ -13,7 +13,7 @@ representation or *R* in short.
 
 -  Name: github.com/flux-framework/rfc/spec_20.rst
 
--  Editor: Dong H. Ahn <ahn1@llnl.gov>
+-  Editor: Jim Garlick <garlick@llnl.gov>
 
 -  State: Raw
 

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -475,3 +475,4 @@ usr
 ƒuzzybunny
 acceptor
 Fluxion
+mortem


### PR DESCRIPTION
RFC 20 contained a lot of prose that didn't really add clarity, and missed explicitly mentioning some requirements.

Rework the RFC so that it's more useful as a quick reference and includes clarifying points that were missing.