### PR TITLE
misc cleanup

### DIFF
--- a/common/language.rst
+++ b/common/language.rst
@@ -1,0 +1,3 @@
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
+be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.

--- a/index.rst
+++ b/index.rst
@@ -260,7 +260,7 @@ for a series of typed key-value pairs.
 The Flux Security Signature is a NUL terminated string that represents
 content secured with a digital signature.
 
-:doc:`40/Fluxion Resource Set Extension <spec_39>`
+:doc:`40/Fluxion Resource Set Extension <spec_40>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This specification defines the data format used by the Fluxion scheduler

--- a/index.rst
+++ b/index.rst
@@ -18,64 +18,64 @@ processes.
 Active RFC Documents
 --------------------
 
-:doc:`1/C4.1 - Collective Code Construction Contract <spec_1>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_1`
+~~~~~~~~~~~~~
 
 The Collective Code Construction Contract (C4.1) is an evolution of
 the github.com Fork + Pull Model, aimed at providing an optimal
 collaboration model for free software projects.
 
-:doc:`2/Flux Licensing and Collaboration Guidelines <spec_2>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_2`
+~~~~~~~~~~~~~
 
 The Flux framework is a family of projects used to build
 site-customized resource management systems for High Performance
 Computing (HPC) data centers. This document specifies licensing and
 collaboration guidelines for Flux projects.
 
-:doc:`3/Flux Message Protocol <spec_3>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_3`
+~~~~~~~~~~~~~
 
 This specification describes the format of Flux messages, Version 1.
 
-:doc:`4/Flux Resource Model <spec_4>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_4`
+~~~~~~~~~~~~~
 
 The Flux Resource Model describes the conceptual model used for
 resources within the Flux framework.
 
-:doc:`5/Flux Broker Modules <spec_5>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_5`
+~~~~~~~~~~~~~
 
 This specification describes the broker extension modules used to
 implement Flux services.
 
-:doc:`6/Flux Remote Procedure Call Protocol <spec_6>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_6`
+~~~~~~~~~~~~~
 
 This specification describes how Flux Remote Procedure Call (RPC) is
 built on top of Flux request and response messages.
 
-:doc:`7/Flux Coding Style Guide <spec_7>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_7`
+~~~~~~~~~~~~~
 
 This specification presents the recommended standards when
 contributing C code to the Flux code base.
 
-:doc:`9/Distributed Communication and Synchronization Best Practices <spec_9>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_9`
+~~~~~~~~~~~~~
 
 Establishes best practices, preferred patterns and anti-patterns for
 distributed services in the flux framework.
 
-:doc:`10/Content Storage <spec_10>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_10`
+~~~~~~~~~~~~~~
 
 This specification describes the Flux content storage service and
 the messages used to access it.
 
-:doc:`11/Key Value Store Tree Object Format v1 <spec_11>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_11`
+~~~~~~~~~~~~~~
 
 The Flux Key Value Store (KVS) implements hierarchical key
 namespaces layered atop the content storage service described in
@@ -83,8 +83,8 @@ RFC 10. Namespaces are organized as hash trees of content-addressed
 tree objects and values. This specification defines the version 1
 format of key value store tree objects.
 
-:doc:`12/Flux Security Architecture <spec_12>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_12`
+~~~~~~~~~~~~~~
 
 This document describes the mechanisms used to secure Flux instances
 against unauthorized access and prevent privilege escalation and
@@ -92,8 +92,8 @@ other attacks, while ensuring programs run with appropriate user
 credentials and are contained within their set of allocated
 resources.
 
-:doc:`13/Simple Process Manager Interface v1 <spec_13>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_13`
+~~~~~~~~~~~~~~
 
 The MPI process manager interface (PMI) version 1 is a de-facto
 standard API and wire protocol for communication between MPI
@@ -104,8 +104,8 @@ and has been only lightly documented. This RFC is an attempt to
 document PMI-1 to guide developers of resource managers that must
 support current and legacy MPI implementations.
 
-:doc:`14/Canonical Job Specification <spec_14>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_14`
+~~~~~~~~~~~~~~
 
 A domain specific language based on YAML is defined to express the
 resource requirements and other attributes of one or more programs
@@ -113,27 +113,27 @@ submitted to a Flux instance for execution. This RFC describes the
 canonical form of the jobspec language, which represents a request
 to run exactly one program.
 
-:doc:`15/Independent Minister of Privilege for Flux: The Security IMP <spec_15>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_15`
+~~~~~~~~~~~~~~
 
 This specification describes Flux Security IMP, a privileged service
 used by multi-user Flux instances to launch, monitor, and control
 processes running as users other than the instance owner.
 
-:doc:`16/KVS Job Schema <spec_16>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_16`
+~~~~~~~~~~~~~~
 
 This specification describes the format of data stored in the KVS
 for Flux jobs.
 
-:doc:`18/KVS Event Log Format <spec_18>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_18`
+~~~~~~~~~~~~~~
 
 A log format is defined that can be used to log job state
 transitions and other date-stamped events.
 
-:doc:`19/Flux Locally Unique ID (FLUID) <spec_19>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_19`
+~~~~~~~~~~~~~~
 
 This specification describes a scheme for a distributed,
 uncoordinated *flux locally unique ID* service that generates 64 bit
@@ -141,127 +141,127 @@ k-ordered, unique identifiers that are a combination of timestamp
 since some epoch, generator id, and sequence number. The scheme is
 used to generate Flux job IDs.
 
-:doc:`20/Resource Set Specification <spec_20>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_20`
+~~~~~~~~~~~~~~
 
 This specification defines the version 1 format of the resource-set
 representation or *R* in short.
 
-:doc:`21/Job States and Events Version 1 <spec_21>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_21`
+~~~~~~~~~~~~~~
 
 This specification describes Flux job states and the events that
 trigger job state transitions.
 
-:doc:`22/Idset String Representation <spec_22>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_22`
+~~~~~~~~~~~~~~
 
 This specification describes a compact form for expressing a set of
 non-negative, integer ids.
 
-:doc:`23/Flux Standard Duration <spec_23>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_23`
+~~~~~~~~~~~~~~
 
 This specification describes a standard form for time duration.
 
-:doc:`24/Flux Job Standard I/O Version 1 <spec_24>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_24`
+~~~~~~~~~~~~~~
 
 This specification describes the format used to represent standard
 I/O streams in the Flux KVS.
 
-:doc:`25/Job Specification Version 1 <spec_25>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_25`
+~~~~~~~~~~~~~~
 
 Version 1 of the domain specific job specification language
 canonically defined in RFC14.
 
-:doc:`26/Job Dependency Specification <spec_26>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_26`
+~~~~~~~~~~~~~~
 
 An extension to the canonical jobspec designed to express the
 dependencies between one or more programs submitted to a Flux instance
 for execution.
 
-:doc:`27/Flux Resource Allocation Protocol Version 1 <spec_27>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_27`
+~~~~~~~~~~~~~~
 
 This specification describes Version 1 of the Flux Resource Allocation
 Protocol implemented by the job manager and a compliant Flux scheduler.
 
-:doc:`28/Flux Resource Acquisition Protocol Version 1 <spec_28>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_28`
+~~~~~~~~~~~~~~
 
 This specification describes the Flux service that schedulers use to
 acquire exclusive access to resources and monitor their ongoing
 availability.
 
-:doc:`29/Hostlist Format <spec_29>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_29`
+~~~~~~~~~~~~~~
 
 This specification describes the Flux implementation of the Hostlist Format
 -- a compressed representation of lists of hostnames.
 
-:doc:`30/Job Urgency <spec_30>`
+:doc:`spec_30`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This specification describes the Flux job urgency parameter.
 
-:doc:`31/Job Constraints Specification <spec_31>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_31`
+~~~~~~~~~~~~~~
 
 This specification describes an extensible format for the description of
 job constraints.
 
-:doc:`32/Flux Job Execution Protocol Version 1 <spec_32>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_32`
+~~~~~~~~~~~~~~
 
 This specification describes Version 1 of the Flux Execution Protocol
 implemented by the job manager and job execution system.
 
-:doc:`33/Flux Job Queues <spec_33>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_33`
+~~~~~~~~~~~~~~
 
 This specification describes Flux Job Queues. A Flux Job queue is a named,
 user-visible container for job requests sorted by priority.
 
-:doc:`34/Flux Task Map <spec_34>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_34`
+~~~~~~~~~~~~~~
 
 The Flux Task Map is a compact mapping between job task ranks and node IDs.
 
-:doc:`35/Constraint Query Syntax <spec_35>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_35`
+~~~~~~~~~~~~~~
 
 The Constraint Query Syntax describes a simple text-based syntax for generating
 JSON objects in the format described in RFC 31.
 
-:doc:`36/Batch Script Directives <spec_36>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_36`
+~~~~~~~~~~~~~~
 
 This specification defines a method for embedding job submission options
 and other directives in files.
 
-:doc:`37/File Archive Format <spec_37>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_37`
+~~~~~~~~~~~~~~
 
 The File Archive Format defines a JSON representation of a set or list
 of file system objects.
 
-:doc:`38/Flux Security Key Value Encoding <spec_38>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_38`
+~~~~~~~~~~~~~~
 
 The Flux Security Key Value Encoding is a serialization format
 for a series of typed key-value pairs.
 
-:doc:`39/Flux Security Signature <spec_39>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_39`
+~~~~~~~~~~~~~~
 
 The Flux Security Signature is a NUL terminated string that represents
 content secured with a digital signature.
 
-:doc:`40/Fluxion Resource Set Extension <spec_40>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:doc:`spec_40`
+~~~~~~~~~~~~~~
 
 This specification defines the data format used by the Fluxion scheduler
 to store resource graph data in RFC 20 *R* version 1 objects.

--- a/spec_1.rst
+++ b/spec_1.rst
@@ -29,9 +29,8 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 -----------------
 
--  :doc:`2/Flux Licensing and Collaboration Guidelines <spec_2>`
-
--  :doc:`7/Flux Coding Style Guide <spec_7>`
+- :doc:`spec_2`
+- :doc:`spec_7`
 
 
 Goals

--- a/spec_1.rst
+++ b/spec_1.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_1.html
 
 1/C4.1 - Collective Code Construction Contract
-==============================================
+##############################################
 
 The Collective Code Construction Contract (C4.1) is an evolution of the
 github.com `Fork + Pull Model <https://help.github.com/en/pull-requests/>`__,
@@ -23,19 +23,18 @@ projects.
     - draft
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Related Standards
------------------
+*****************
 
 - :doc:`spec_2`
 - :doc:`spec_7`
 
-
 Goals
------
+*****
 
 C4.1 is meant to provide a reusable optimal collaboration model for open source software projects. It has these specific goals:
 
@@ -53,11 +52,10 @@ C4.1 is meant to provide a reusable optimal collaboration model for open source 
 
 
 Design
-------
-
+******
 
 Preliminaries
-~~~~~~~~~~~~~
+=============
 
 -  The project SHALL use the git distributed revision control system.
 
@@ -77,9 +75,8 @@ Preliminaries
 
 -  Everyone, without distinction or discrimination, SHALL have an equal right to become a Contributor under the terms of this contract.
 
-
 Licensing and Ownership
-~~~~~~~~~~~~~~~~~~~~~~~
+=======================
 
 -  The project SHALL use a share-alike license, such as the GPLv3 or a variant thereof (LGPL, AGPL), or the MPLv2 for reasons outlined in :doc:`RFC 2 <spec_2>`.
 
@@ -91,9 +88,8 @@ Licensing and Ownership
 
 -  The git commit history SHALL be considered the primary source of contributor identities.
 
-
 Patch Requirements
-~~~~~~~~~~~~~~~~~~
+==================
 
 -  Maintainers and Contributors MUST have a Platform account and SHOULD use their real names or a well-known alias.
 
@@ -127,9 +123,8 @@ Patch Requirements
 
 -  A "Correct Patch" is one that satisfies the above requirements.
 
-
 Development Process
-~~~~~~~~~~~~~~~~~~~
+===================
 
 -  Change on the project SHALL be governed by the pattern of accurately identifying problems and applying minimal, accurate solutions to these problems.
 
@@ -174,9 +169,8 @@ Development Process
 -  Autotools products, if applicable, SHOULD NOT be checked into the project
    revision control system
 
-
 Release Process
-~~~~~~~~~~~~~~~
+===============
 
 -  Releases SHALL be tagged with git annotated tags.
 
@@ -187,9 +181,8 @@ Release Process
    "dist tarballs"; that is, a source distribution with pre-generated
    configure script, Makefile.in, etc..
 
-
 Creating Stable Releases
-~~~~~~~~~~~~~~~~~~~~~~~~
+========================
 
 -  The project SHALL have one branch ("master") that always holds the latest in-progress version and SHOULD always build.
 
@@ -203,9 +196,8 @@ Creating Stable Releases
 
 -  A patch to a stabilization project declared "stable" SHALL be accompanied by a reproducible test case.
 
-
 Evolution of Public Contracts
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=============================
 
 -  All Public Contracts (APIs or protocols) SHOULD be documented.
 
@@ -223,9 +215,8 @@ Evolution of Public Contracts
 
 -  When old names are removed, their implementations MUST provoke an exception (assertion) if used by applications.
 
-
 Project Administration
-~~~~~~~~~~~~~~~~~~~~~~
+======================
 
 -  The project founders SHALL act as Administrators to manage the set of project Maintainers.
 
@@ -235,9 +226,8 @@ Project Administration
 
 -  Administrators MAY remove Maintainers who are inactive for an extended period of time, or who repeatedly fail to apply this process accurately.
 
-
 Further Reading
----------------
+***************
 
 -  `ZeroMQ - The Guide, Chapter 6: The ZeroMQ Community <https://zguide.zeromq.org/docs/chapter6/#the-community>`__
 
@@ -245,9 +235,8 @@ Further Reading
 
 -  `Toyota Kata <http://en.wikipedia.org/wiki/Toyota_Kata>`__ - covering the Improvement Kata (fixing problems one at a time) and the Coaching Kata (helping others to learn the Improvement Kata).
 
-
 Implementations
----------------
+***************
 
 -  The `ZeroMQ community <http://zeromq.org>`__ uses the C4.1 process for many projects.
 

--- a/spec_1.rst
+++ b/spec_1.rst
@@ -25,9 +25,7 @@ projects.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
+.. include:: common/language.rst
 
 Related Standards
 -----------------

--- a/spec_1.rst
+++ b/spec_1.rst
@@ -10,14 +10,17 @@ github.com `Fork + Pull Model <https://help.github.com/en/pull-requests/>`__,
 aimed at providing an optimal collaboration model for free software
 projects.
 
--  Name: github.com/flux-framework/rfc/spec_1.rst
+.. list-table::
+  :widths: 25 75
 
--  Forked from: rfc.zeromq.org/spec:22/C4.1
-
--  Editor: Jim Garlick <garlick@llnl.gov>
-
--  State: draft
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_1.rst
+  * - **Forked from**
+    - rfc.zeromq.org/spec:22/C4.1
+  * - **Editor**
+    - Jim Garlick <garlick@llnl.gov>
+  * - **State**
+    - draft
 
 Language
 --------

--- a/spec_10.rst
+++ b/spec_10.rst
@@ -26,9 +26,8 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 -----------------
 
--  :doc:`3/Flux Message Protocol <spec_3>`
-
--  :doc:`11/Key Value Store Tree Object Format v1 <spec_11>`
+- :doc:`spec_3`
+- :doc:`spec_11`
 
 
 Goals

--- a/spec_10.rst
+++ b/spec_10.rst
@@ -8,12 +8,15 @@
 This specification describes the Flux content storage service
 and the messages used to access it.
 
--  Name: github.com/flux-framework/rfc/spec_10.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Jim Garlick <garlick@llnl.gov>
-
--  State: raw
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_10.rst
+  * - **Editor**
+    - Jim Garlick <garlick@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_10.rst
+++ b/spec_10.rst
@@ -21,10 +21,7 @@ and the messages used to access it.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
-
+.. include:: common/language.rst
 
 Related Standards
 -----------------

--- a/spec_10.rst
+++ b/spec_10.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_10.html
 
 10/Content Storage Service
-==========================
+##########################
 
 This specification describes the Flux content storage service
 and the messages used to access it.
@@ -19,19 +19,18 @@ and the messages used to access it.
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Related Standards
------------------
+*****************
 
 - :doc:`spec_3`
 - :doc:`spec_11`
 
-
 Goals
------
+*****
 
 The Flux content storage service is the storage layer for the Flux Key Value
 Store (KVS).  The goals of the content storage service are:
@@ -58,9 +57,8 @@ explored in Venti, Git, and Perkeep (see References below), for example:
 
 -  The address may be used to check the integrity of the addressed content
 
-
 Implementation
---------------
+**************
 
 The content service SHALL be implemented as a distributed cache with a
 presence on each broker rank. Each rank MAY cache content according
@@ -77,9 +75,8 @@ of which are beyond the scope of this RFC.
 
 The content service SHALL NOT be accessible by guest users.
 
-
 Hash Algorithm
-~~~~~~~~~~~~~~
+==============
 
 A Flux instance SHALL select a hash algorithm at startup.  This selection
 MUST NOT change throughout the lifetime of the instance.
@@ -96,9 +93,8 @@ The hash algorithm:
 
 -  is RECOMMENDED to have low computational overhead
 
-
 Content
-~~~~~~~
+=======
 
 Content SHALL consist of from zero to 1,048,576 bytes of data.
 Content SHALL NOT be interpreted by the content service.
@@ -107,9 +103,8 @@ Note: The blob size limit was temporarily increased to one gigabyte to
 avoid failures resulting from extreme workloads.  The original limit will
 be restored once KVS *hdir* objects are implemented.
 
-
 Address
-~~~~~~~
+=======
 
 Each unique, stored blob of content SHALL be addressable by its hash digest.
 
@@ -131,9 +126,8 @@ Example:
 
 Note: "blobref" was shamelessly borrowed from Perkeep (see References below).
 
-
 Store
-~~~~~
+=====
 
 A store request SHALL be encoded as a Flux request message with the blob
 as raw payload (blob length > 0), or no payload (blob length = 0).
@@ -147,9 +141,8 @@ receive error number 27, "File too large", in response.
 After the successful store response is received, the blob SHALL be
 accessible from any rank in the instance.
 
-
 Load
-~~~~
+====
 
 A load request SHALL be encoded as a Flux request message with
 message digest as raw payload.
@@ -161,9 +154,8 @@ or an error response.
 A request to load unknown content SHALL receive error number 2,
 "No such file or directory", in response.
 
-
 Flush
-~~~~~
+=====
 
 A flush request SHALL cause the local rank content service to finish
 storing any dirty cache entries. A flush response SHALL NOT be sent
@@ -175,16 +167,15 @@ On rank > 0, "dirty" SHALL be defined as "not stored on rank 0".
 A flush request SHALL receive error number 38, "Function not implemented",
 on rank 0 if a backing store is not configured.
 
-
 Dropcache
-~~~~~~~~~
+=========
 
 A dropcache request SHALL cause the local content service to drop all
 non-essential entries from its cache.
 
 
 Garbage Collection
-~~~~~~~~~~~~~~~~~~
+==================
 
 References to content are the responsibility of the Flux Key Value Store.
 Content that the KVS no longer references MAY NOT be removed while the Flux
@@ -195,9 +186,8 @@ down.  The shutdown process, after the KVS service has been stopped, MAY choose
 to omit content that the final KVS root does not reference as a form of
 garbage collection.
 
-
 References
-----------
+**********
 
 -  `Perkeep lets you permanently keep your stuff, for life. <https://en.wikipedia.org/wiki/Perkeep>`__.
 

--- a/spec_11.rst
+++ b/spec_11.rst
@@ -11,12 +11,15 @@ Namespaces are organized as hash trees of content-addressed *tree objects*
 and values. This specification defines the version 1 format of key value
 store tree objects.
 
--  Name: github.com/flux-framework/rfc/spec_11.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Jim Garlick <garlick@llnl.gov>
-
--  State: raw
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_11.rst
+  * - **Editor**
+    - Jim Garlick <garlick@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_11.rst
+++ b/spec_11.rst
@@ -29,7 +29,7 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 -----------------
 
--  :doc:`10/Content Storage Service <spec_10>`
+- :doc:`spec_10`
 
 
 Goals

--- a/spec_11.rst
+++ b/spec_11.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_11.html
 
 11/Key Value Store Tree Object Format v1
-========================================
+########################################
 
 The Flux Key Value Store (KVS) implements hierarchical key namespaces
 layered atop the content storage service described in RFC 10.
@@ -22,18 +22,17 @@ store tree objects.
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Related Standards
------------------
+*****************
 
 - :doc:`spec_10`
 
-
 Goals
------
+*****
 
 -  Define KVS metadata compatible with the RFC 10 content storage service.
 
@@ -51,9 +50,8 @@ Goals
 
 -  Large directories are not expensive to access or update.
 
-
 Implementation
---------------
+**************
 
 In contrast to the original KVS prototype, in this specification, KVS
 values are unstructured, opaque data.
@@ -84,9 +82,8 @@ There are six types:
 -  *symlink*, data is an object containing a target key and optionally
    a namespace.
 
-
 Valref
-~~~~~~
+======
 
 A *valref* refers to opaque data in the content store (the actual data,
 not a *val* object).
@@ -98,9 +95,8 @@ not a *val* object).
      "data":["sha1-aaa...","sha1-bbb...",...],
    }
 
-
 Val
-~~~
+===
 
 A *val* represents opaque data directly, base64-encoded.
 
@@ -117,9 +113,8 @@ blobs SHOULD be represented as a *val* when written to the content store.
 The *val* object MAY be used as part of the protocol for sending key-value
 tuples of any size to the KVS in the JSON payload of an RPC.
 
-
 Dirref
-~~~~~~
+======
 
 A *dirref* refers to a *dir* or *hdir* object that was serialized and
 stored in the content store.
@@ -134,9 +129,8 @@ stored in the content store.
 Although the *dirref* definition supports an array of multiple blobrefs,
 at this time the array size is limited to one.
 
-
 Dir
-~~~
+===
 
 A *dir* is a dictionary mapping keys to any of the tree object types.
 
@@ -152,9 +146,8 @@ A *dir* is a dictionary mapping keys to any of the tree object types.
      }
    }
 
-
 Hdir
-~~~~
+====
 
 A *hdir* is a dictionary mapping keys to any of the tree object types,
 though a level of indirection. The *hdir* object is for efficiently
@@ -185,9 +178,8 @@ Hash buckets MAY be sparsely populated. Each hash bucket contains a single
 
 At this time, *hdir* objects have not been implemented.
 
-
 Symlink
-~~~~~~~
+=======
 
 A *symlink* is a symbolic pointer to a another KVS key, which may or
 may not be fully qualified. Optionally, a namespace can be specified

--- a/spec_11.rst
+++ b/spec_11.rst
@@ -24,10 +24,7 @@ store tree objects.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
-
+.. include:: common/language.rst
 
 Related Standards
 -----------------

--- a/spec_12.rst
+++ b/spec_12.rst
@@ -27,13 +27,10 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 *****************
 
-- :doc:`3/Flux Message Protocol <spec_3>`
-
-- :doc:`6/Flux Remote Procedure Call Protocol <spec_6>`
-
-- :doc:`15/Independent Minister of Privilege for Flux: The Security IMP <spec_15>`
-
-- :doc:`39/Flux Security Signature <spec_39>`
+- :doc:`spec_3`
+- :doc:`spec_6`
+- :doc:`spec_15`
+- :doc:`spec_39`
 
 *****
 Goals

--- a/spec_12.rst
+++ b/spec_12.rst
@@ -2,7 +2,6 @@
    GitHub is NOT the preferred viewer for this file. Please visit
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_12.html
 
-#################################
 12/Flux Role-based Access Control
 #################################
 
@@ -19,13 +18,11 @@ secure access to services.
   * - **State**
     - raw
 
-********
 Language
 ********
 
 .. include:: common/language.rst
 
-*****************
 Related Standards
 *****************
 
@@ -34,7 +31,6 @@ Related Standards
 - :doc:`spec_15`
 - :doc:`spec_39`
 
-*****
 Goals
 *****
 
@@ -47,7 +43,6 @@ Goals
 
 - Describe pub/sub message privacy.
 
-**********
 Background
 **********
 
@@ -78,7 +73,6 @@ in a multi-user Flux instance may be decomposed into two main topics:
 This RFC describes how message credentials are used to implement role-based
 access control in a multi-user Flux instance.
 
-**************
 Implementation
 **************
 

--- a/spec_12.rst
+++ b/spec_12.rst
@@ -9,11 +9,15 @@
 This document describes the how Flux message credentials are used to
 secure access to services.
 
--  Name: github.com/flux-framework/rfc/spec_12.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Jim Garlick <garlick@llnl.gov>
-
--  State: raw
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_12.rst
+  * - **Editor**
+    - Jim Garlick <garlick@llnl.gov>
+  * - **State**
+    - raw
 
 ********
 Language

--- a/spec_12.rst
+++ b/spec_12.rst
@@ -23,9 +23,7 @@ secure access to services.
 Language
 ********
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
+.. include:: common/language.rst
 
 *****************
 Related Standards

--- a/spec_13.rst
+++ b/spec_13.rst
@@ -18,12 +18,15 @@ standardized by the MPI Forum and has been only lightly documented.
 This RFC is an attempt to document PMI-1 to guide developers of resource
 managers that must support current and legacy MPI implementations.
 
--  Name: github.com/flux-framework/rfc/spec_13.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Jim Garlick <garlick@llnl.gov>
-
--  State: raw
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_13.rst
+  * - **Editor**
+    - Jim Garlick <garlick@llnl.gov>
+  * - **State**
+    - raw
 
 ********
 Language

--- a/spec_13.rst
+++ b/spec_13.rst
@@ -2,9 +2,8 @@
    GitHub is NOT the preferred viewer for this file. Please visit
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_13.html
 
-======================================
 13/Simple Process Manager Interface v1
-======================================
+######################################
 
 .. highlight:: c
 
@@ -28,20 +27,16 @@ managers that must support current and legacy MPI implementations.
   * - **State**
     - raw
 
-********
 Language
 ********
 
 .. include:: common/language.rst
 
-*****************
 Related Standards
 *****************
 
 - :doc:`spec_12`
 
-
-*****
 Goals
 *****
 
@@ -58,8 +53,6 @@ Goals
 
 -  Identify which functions are optional, and under what circumstances.
 
-
-************
 PMI Versions
 ************
 
@@ -79,8 +72,6 @@ that is not covered here.
 PMIX ("X" for extension), is a set of extensions to PMI-2. The PMIX
 extensions are not covered here.
 
-
-********
 Overview
 ********
 
@@ -114,8 +105,6 @@ the PMI-1 wire protocol; a shared library providing the PMI-1 API
 implemented using the PMI-1 wire protocol; or less flexibly, a shared
 library providing the PMI-1 API implemented using a proprietary protocol.
 
-
-***********
 Terminology
 ***********
 
@@ -134,8 +123,6 @@ process
 PMI library
   A shared library that provides the PMI-1 API.
 
-
-*******
 Caveats
 *******
 
@@ -157,8 +144,6 @@ non-conforming PMI library implementations. This in turn has resulted
 in stronger coupling between process managers and MPI implementations
 than necessary.
 
-
-***********
 Environment
 ***********
 
@@ -182,8 +167,6 @@ set the following environment variables:
    * - PMI_SPAWNED
      - only set (to 1) if the program was created by :func:`PMI_Spawn_multiple`
 
-
-*********************************
 Application Programming Interface
 *********************************
 
@@ -208,7 +191,6 @@ to return PMI_FAIL with no effect.
 There is no defined mechanism to extend PMI-1 without inadvertently
 coupling users of a extension to a PMI library and/or process manager,
 therefore PMI libraries SHALL NOT implement functions not defined below.
-
 
 Return Codes
 ============
@@ -268,7 +250,6 @@ indicating the result of the operation:
    * - PMI_ERR_INVALID_SIZE
      - 13
      - invalid size argument
-
 
 Initialization
 ==============
@@ -338,7 +319,6 @@ Abort the process group associated with this process.
 The PMI library SHALL print :var:`error_msg` to standard error, then exit
 this process with with :var:`exit_code`. This function SHALL NOT return.
 
-
 Process Group Information
 =========================
 
@@ -396,7 +376,6 @@ Notes
 
 -  See MPI-2 [#f2]_ section `5.5.3. MPI_APPNUM <https://www.mpi-forum.org/docs/mpi-2.0/mpi-20-html/node113.htm>`__.
 
-
 Local Process Group Information
 ===============================
 
@@ -449,7 +428,6 @@ Notes:
 
 -  The implementation should fetch the ``PMI_process_mapping`` value from the
    KVS and calculate the clique ranks (see below).
-
 
 Key Value Store
 ===============
@@ -593,7 +571,6 @@ Notes:
 -  Dropped from pmi.h [#f3]_ on 2011-01-28 in
    `commit f17423ef <https://github.com/pmodels/mpich/commit/f17423ef535f562bcacf981a9f7e379838962c6e>`__,
 
-
 Dynamic Process Management
 ==========================
 
@@ -671,8 +648,6 @@ Notes:
 -  These functions were dropped from pmi.h [#f3]_ on 2009-05-01 in
    `commit 52c462d <https://github.com/pmodels/mpich/commit/52c462d2be6a8d0720788d36e1e096e991dcff38>`__
 
-
-*************
 Wire Protocol
 *************
 
@@ -696,7 +671,6 @@ For maximum interoperability, a message parser SHOULD allow
 
 -  additional keys to be present
 
-
 Connection
 ==========
 
@@ -705,7 +679,6 @@ a file descriptor, arrange for the file descriptor to be inherited by
 the process, and pass its number in the PMI_FD environment variable
 at process launch time.
 
-
 Version Negotiation
 ===================
 
@@ -713,7 +686,6 @@ The client SHALL send the init request first, with the highest version
 of PMI supported by the client. The server SHALL respond with the
 version of PMI that will be used for this connection. The client SHALL NOT
 send other commands until the init operation has completed.
-
 
 Error Handling
 ==============
@@ -730,7 +702,6 @@ If a protocol error occurs, the detecting side SHALL immediately close
 the connection and abort the program. IT SHOULD log the message so that
 the problem can be tracked down.
 
-
 Spawn Operation
 ===============
 
@@ -740,7 +711,6 @@ These messages SHALL NOT be interspersed with messages for other operations.
 The spawn operation passes zero or more arguments, zero or more "preput"
 elements, and zero or more "info" elements. The numbered indices of these
 elements SHALL begin with zero and increase monotonically.
-
 
 Protocol Definition
 ===================
@@ -867,7 +837,6 @@ Protocol Definition
    int             = *1("+" "-") uint              ; signed integer
    uint            = 1*DIGIT                       ; unsigned integer
 
-
 Back Compatibility
 ==================
 
@@ -875,8 +844,6 @@ Earlier versions of the PMI-1 wire protocol did not include the init
 operation in which versions are exchanged. Protocol operations that
 were culled in PMI 1.1 are not covered here.
 
-
-*******************************
 Local Process Group Information
 *******************************
 
@@ -921,8 +888,6 @@ If the process mapping value is too long to fit in a KVS value, the process
 manager SHALL return a value consisting of an empty string, indicating that
 the mapping is unknown.
 
-
-**********
 References
 **********
 

--- a/spec_13.rst
+++ b/spec_13.rst
@@ -38,7 +38,7 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 *****************
 
--  :doc:`12/Flux Security Architecture <spec_12>`
+- :doc:`spec_12`
 
 
 *****

--- a/spec_13.rst
+++ b/spec_13.rst
@@ -32,10 +32,7 @@ managers that must support current and legacy MPI implementations.
 Language
 ********
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
-
+.. include:: common/language.rst
 
 *****************
 Related Standards

--- a/spec_14.rst
+++ b/spec_14.rst
@@ -11,12 +11,15 @@ submitted to a Flux instance for execution. This RFC describes the
 canonical jobspec form, which represents a request to run exactly
 one program.
 
--  Name: github.com/flux-framework/rfc/spec_14.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Tom Scogland <scogland1@llnl.gov>
-
--  State: raw
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_14.rst
+  * - **Editor**
+    -  Tom Scogland <scogland1@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_14.rst
+++ b/spec_14.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_14.html
 
 14/Canonical Job Specification
-==============================
+##############################
 
 A domain specific language based on YAML is defined to express the
 resource requirements and other attributes of one or more programs
@@ -22,12 +22,12 @@ one program.
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Related Standards
------------------
+*****************
 
 -  :doc:`spec_4`
 -  :doc:`spec_20`
@@ -36,7 +36,7 @@ Related Standards
 
 
 Goals
------
+*****
 
 -  Express the resource requirements of a program to the scheduler.
 
@@ -55,9 +55,8 @@ Goals
 
 -  Promote sharing and reuse of jobspec.
 
-
 Overview
---------
+********
 
 This RFC describes the canonical form of "jobspec", a domain specific
 language based on YAML  [#f1]_. The canonical jobspec SHALL consist of
@@ -80,9 +79,8 @@ or other sources. Such tools MAY:
 
 -  convert command line arguments to jobspec, e.g. "flux mpirun"
 
-
 Jobspec and Program Life Cycle
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+==============================
 
 The jobspec SHALL be submitted to a job submission service. Malformed
 jobspec SHALL be immediately rejected by the job submission service.
@@ -106,24 +104,22 @@ be returned to the scheduler.
 Once a job is retired, the jobspec SHALL be retained as part of
 its provenance record.
 
-
 Resource Matching
-~~~~~~~~~~~~~~~~~
+=================
 
 Resources are represented as hierarchies or graphs, as described in RFC 4.
 
 FIXME: describe how Flux hierarchical resource representation affects
 jobspec design.
 
-
 Terminology
-~~~~~~~~~~~
+===========
 
 FIXME: Fill in
 
 
 Jobspec Language Definition
----------------------------
+***************************
 
 A canonical jobspec YAML document SHALL consist of a dictionary
 defining the resources, tasks and other attributes of a single
@@ -134,9 +130,8 @@ Each of the listed jobspec keys SHALL meet the form and requirements
 listed in detail in the sections below. For reference, a ruleset for
 compliant canonical jobspec is provided in the **Schema** section below.
 
-
 Resources
-~~~~~~~~~
+=========
 
 The value of the ``resources`` key SHALL be a strict list which MUST
 define at least one resource. Each list element SHALL represent a
@@ -216,9 +211,8 @@ following keys
    The value of the ``id`` key SHALL be a string indicating a set of
    matching resource identifiers.
 
-
 Reserved Resource Types
-^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------
 
 **slot**
    A resource type of ``type: slot`` SHALL indicate a grouping
@@ -232,9 +226,8 @@ Reserved Resource Types
    to the program described in the jobspec, unless otherwise specified
    in the ``exclusive`` field of the associated resource.
 
-
 Tasks
-~~~~~
+=====
 
 The value of the ``tasks`` key SHALL be a strict list which MUST
 define at least one task. Each list element SHALL be a dictionary
@@ -285,9 +278,8 @@ descriptor SHALL contain the following keys:
    be used as input to the launcher’s algorithm for task placement and
    layout among task slots.
 
-
 Attributes
-~~~~~~~~~~
+==========
 
 The value of the ``attributes`` key SHALL be a dictionary of dictionaries.
 The ``attributes`` dictionary MAY contain one or both of the following keys
@@ -390,7 +382,7 @@ Some common system attributes are:
       configuration file.
 
 Example Jobspec
-~~~~~~~~~~~~~~~
+***************
 
 Under the description above, the following is an example of a fully compliant
 canonical jobspec. The example below declares a request for 4 "nodes"
@@ -406,9 +398,8 @@ Another example, running one task on each of four nodes.
 .. literalinclude:: data/spec_14/example2.yaml
    :language: yaml
 
-
 Schema
-~~~~~~
+******
 
 A jobspec conforming to the canonical language definition SHALL
 adhere to the following ruleset, described using JSON Schema  [#f2]_.
@@ -416,17 +407,15 @@ adhere to the following ruleset, described using JSON Schema  [#f2]_.
 .. literalinclude:: data/spec_14/schema.json
    :language: json
 
-
-
 Basic Use Cases
----------------
+***************
 
 To implement basic resource manager functionality, the following use
 cases SHALL be supported by the jobspec:
 
 
 Section 1: Node-level Requests
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+==============================
 
 The following "node-level" requests are all requests to start an instance,
 i.e. run a single copy of ``flux start`` per allocated node. Many of these
@@ -544,7 +533,7 @@ Jobspec YAML
       :language: yaml
 
 Section 2: General Requests
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+===========================
 
 The following use cases are more general and include more complex slot placement
 and task counts.
@@ -680,6 +669,8 @@ Jobspec YAML
    .. literalinclude:: data/spec_14/use_case_2.9.yaml
       :language: yaml
 
+References
+**********
 
 .. [#f1] `YAML Ain’t Markup Language (YAML) Version 1.1 <http://yaml.org/spec/1.1/current.html>`__, O. Ben-Kiki, C. Evans, B. Ingerson, 2004.
 

--- a/spec_14.rst
+++ b/spec_14.rst
@@ -29,13 +29,10 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 -----------------
 
--  :doc:`4/Flux Resource Model <spec_4>`
-
--  :doc:`20/Resource Set Specification Version 1 <spec_20>`
-
--  :doc:`26/Job Dependency Specification <spec_26>`
-
--  :doc:`31/Job Constraints Specification <spec_31>`
+-  :doc:`spec_4`
+-  :doc:`spec_20`
+-  :doc:`spec_26`
+-  :doc:`spec_31`
 
 
 Goals

--- a/spec_14.rst
+++ b/spec_14.rst
@@ -24,10 +24,7 @@ one program.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
-
+.. include:: common/language.rst
 
 Related Standards
 -----------------

--- a/spec_15.rst
+++ b/spec_15.rst
@@ -9,12 +9,15 @@ This specification describes Flux Security IMP, a privileged service
 used by multi-user Flux instances to launch, monitor, and control
 processes running as users other than the instance owner.
 
--  Name: github.com/flux-framework/rfc/spec_10.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Mark A. Grondona <mgrondona@llnl.gov>
-
--  State: raw
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_15.rst
+  * - **Editor**
+    - Mark A. Grondona <mgrondona@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_15.rst
+++ b/spec_15.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_15.html
 
 15/Independent Minister of Privilege for Flux: The Security IMP
-===============================================================
+###############################################################
 
 This specification describes Flux Security IMP, a privileged service
 used by multi-user Flux instances to launch, monitor, and control
@@ -20,19 +20,18 @@ processes running as users other than the instance owner.
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Related Standards
------------------
+*****************
 
 - :doc:`spec_12`
 - :doc:`spec_38`
 
-
 Introduction
-------------
+************
 
 In the traditional resource management model, a monolithic resource
 manager runs with the credentials of a privileged user, typically using
@@ -86,9 +85,8 @@ the following benefits are realized:
 -  Arbitrary users can run multi-user instances of Flux, thus allowing
    users to share their jobs
 
-
 User Roles
-~~~~~~~~~~
+==========
 
 For the purposes of this RFC there are four main user roles:
 
@@ -111,9 +109,8 @@ superuser, or root
    system setup or initialization, container manipulation, etc. Typically
    the root user.
 
-
 Implementation Requirements
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+===========================
 
 The Flux Security IMP SHALL be implemented with the following overall
 design
@@ -139,9 +136,8 @@ a site may configure permissions such that only a ``flux`` user has execute
 permissions, thus allowing a multi-user system instance running as ``flux``,
 but disallowing sub-instance jobs access to multi-user capabilities.
 
-
 Overall Design
-~~~~~~~~~~~~~~
+==============
 
 When a guest makes a request for a job to a multi-user instance of
 Flux, the guest will create a message with information such as the job
@@ -201,9 +197,8 @@ Flux instance.
 
    Depiction of multi-user Flux IMP overall design. Here user ``bob`` is the instance owner, and ``alice`` is a guest.
 
-
 Input to the IMP
-----------------
+****************
 
 The input to the IMP includes the following fields
 
@@ -256,13 +251,11 @@ Where above fields have the following specific meanings and requirements
    will act as interpreter of the Jobspec in **J**. If missing, a default
    will be supplied by IMP configuration.
 
-
 IMP Internal Operation
-----------------------
-
+**********************
 
 Privilege Separation
-~~~~~~~~~~~~~~~~~~~~
+====================
 
 When the IMP is invoked *and* has setuid privileges, the process MAY
 use privilege separation to limit the impact of programming errors or
@@ -270,9 +263,8 @@ bugs in libraries. For more information on privilege separation, see
 the paper on privilege separated OpenSSH: "Preventing Privilege
 Escalation"  [#f1]_.
 
-
 Request Verification
-~~~~~~~~~~~~~~~~~~~~
+====================
 
 Once the privileged IMP process has read its input
 it SHALL perform the following verification steps:
@@ -306,9 +298,8 @@ plugins have been run, the container for the job is empty, the IMP
 will abort with an error. Therefore an initial verification check
 may be redundant.
 
-
 Resource ownership verification
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-------------------------------
 
 Resources in Flux are initially owned by the *system owner*, i.e. the
 user which runs the system instance. Typically, this would be some
@@ -334,9 +325,8 @@ ownership by ensuring that the current container includes the
 resources in the assigned resource set, and that the invoking user
 is owner of the current container.
 
-
 Revoking resource ownership
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------
 
 Resource ownership MUST be revokable. The result of a revocation SHALL
 include termination of all processes currently running in the container
@@ -344,9 +334,8 @@ associated with the revoked resource grant. A revocation is recursive,
 and removes the container and all child containers, including ancillary
 data.
 
-
 IMP post-verification execution
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+===============================
 
 After verification of input is complete, the ``flux-imp`` executable
 invokes required job setup code as the superuser. This setup code SHALL
@@ -370,26 +359,23 @@ the **job shell path** specified in **J**, or a IMP configuration default.
 After the call to exec(2) the security IMP is replaced by the guest user
 process, and is no longer active.
 
-
 Other IMP operational requirements
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+==================================
 
 A multi-user instance of Flux not only requires the ability to execute
 work as a guest user, but it must also have privilege to monitor and
 kill these processes as part of normal resource manager operation.
 
-
 Signaling and terminating jobs in a multi-user instance
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-------------------------------------------------------
 
 For terminating and signaling processes the IMP SHALL include a ``kill``
 subcommand which, using the process tracking functionality, SHALL allow
 an instance owner to signal or terminate any guest processes including
 ancestors thereof that were started by the owner’s instance.
 
-
 IMP configuration
-~~~~~~~~~~~~~~~~~
+=================
 
 On execution, ``flux-imp`` SHALL read a site configuration
 file which MAY contain site-specific information such as paths to trusted
@@ -397,9 +383,8 @@ executables, plugin locations, certificate authority information etc.
 The IMP SHALL check for correct permissions on all configuration
 files to reduce the risk of tampering.
 
-
 Specific Defenses
-~~~~~~~~~~~~~~~~~
+=================
 
 This section describes some attacks and their specific defenses. It
 is still a work in progress.
@@ -416,5 +401,8 @@ is still a work in progress.
    guest request, and a fixed time-to-live prevents the request from
    being used indefinitely. Finally, ``flux-imp`` logs all
    invocations, thereby allowing replays to be detected and audited.
+
+References
+**********
 
 .. [#f1] `Preventing Privilege Escalation <https://www.usenix.org/legacy/events/sec03/tech/full_papers/provos_et_al/provos_et_al.pdf>`__, Niels Provos, Markus Friedl, Peter Honeyman.

--- a/spec_15.rst
+++ b/spec_15.rst
@@ -27,9 +27,8 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 -----------------
 
--  :doc:`12/Flux Security Architecture <spec_12>`
-
--  :doc:`38/Flux Security Key Value Encoding <spec_38>`
+- :doc:`spec_12`
+- :doc:`spec_38`
 
 
 Introduction

--- a/spec_15.rst
+++ b/spec_15.rst
@@ -22,10 +22,7 @@ processes running as users other than the instance owner.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
-
+.. include:: common/language.rst
 
 Related Standards
 -----------------

--- a/spec_16.rst
+++ b/spec_16.rst
@@ -26,17 +26,12 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 -----------------
 
--  :doc:`12/Flux Security Architecture <spec_12>`
-
--  :doc:`14/Canonical Job Specification <spec_14>`
-
--  :doc:`15/Independent Minister of Privilege for Flux: The Security IMP <spec_15>`
-
--  :doc:`18/KVS Event Log Format <spec_18>`
-
--  :doc:`20/Resource Set Specification <spec_20>`
-
--  :doc:`21/Job States <spec_21>`
+- :doc:`spec_12`
+- :doc:`spec_14`
+- :doc:`spec_15`
+- :doc:`spec_18`
+- :doc:`spec_20`
+- :doc:`spec_21`
 
 
 Background

--- a/spec_16.rst
+++ b/spec_16.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_16.html
 
 16/KVS Job Schema
-=================
+#################
 
 This specification describes the format of data stored in the KVS
 for Flux jobs.
@@ -19,12 +19,12 @@ for Flux jobs.
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Related Standards
------------------
+*****************
 
 - :doc:`spec_12`
 - :doc:`spec_14`
@@ -33,13 +33,11 @@ Related Standards
 - :doc:`spec_20`
 - :doc:`spec_21`
 
-
 Background
-----------
-
+**********
 
 Components that use the KVS job schema
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+======================================
 
 Instance components have direct, read/write access to the primary KVS
 namespace:
@@ -60,9 +58,8 @@ Guest components have direct, read/write access to a private KVS namespace:
 
 -  *Command line tools*
 
-
 Job Life Cycle
-~~~~~~~~~~~~~~
+==============
 
 A job is submitted to the *ingest agent* which validates jobspec, adds
 the job to the KVS, and informs the *job manager* of the new job.
@@ -88,13 +85,11 @@ takes the active role in moving a job through its life cycle:
 
 The job is now complete.
 
-
 Implementation
---------------
-
+**************
 
 Primary KVS Namespace
-~~~~~~~~~~~~~~~~~~~~~
+=====================
 
 The Flux instance has a default, shared namespace that is accessible
 only by the instance owner.
@@ -106,9 +101,8 @@ Jobs listed in the ``jobs`` directory may need to be periodically
 archived and purged to keep its size manageable in long-running
 instances.
 
-
 Guest KVS Namespace
-~~~~~~~~~~~~~~~~~~~
+===================
 
 A guest-writable KVS namespace is created by the *exec service*
 for the use of the *job shell* and the application. While the job
@@ -122,9 +116,8 @@ When the job transitions to inactive, the final snapshot of the
 guest namespace content is linked by the *exec service* into the primary
 namespace, and the guest namespace is destroyed.
 
-
 Access to Primary Namespace by Guest Users
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+==========================================
 
 Guests may access data in the primary KVS namespace only through instance
 services that allow selective guest access, by proxy or by staging copies
@@ -133,9 +126,8 @@ to the guest namespace.
 Guest access for primary namespace contents ``R``, ``J``, ``jobspec``, and
 ``eventlog`` is provided via a proxy service in the instance.
 
-
 Event Log
-~~~~~~~~~
+=========
 
 Active jobs undergo change represented as events that are recorded under
 the key ``job.<jobid>.eventlog``. A KVS append operation
@@ -144,9 +136,8 @@ is used to add events to this log.
 Each append consists of a string matching the format described in
 :doc:`RFC 18 <spec_18>`.
 
-
 Content Produced by Ingest Agent
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+================================
 
 A user submits *J* with attached signature, as described in
 :doc:`RFC 15 <spec_15>`.
@@ -167,9 +158,8 @@ The *ingest agent* logs one event to the eventlog:
 ``submit`` ``userid=UID urgency=N``
    job was submitted, with authenticated userid and urgency (0-31)
 
-
 Content Consumed/Produced by Job Manager
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+========================================
 
 Upon notification of a new ``job.<jobid>``, the *job manager* takes
 the active role in moving a job through its life cycle, and logs events
@@ -178,9 +168,8 @@ to the eventlog as described in :doc:`RFC 21 <spec_21>`.
 When the *job manager* is restarted, it recovers its state by scanning
 ``jobs`` and replaying the eventlog for each job found there.
 
-
 Content Consumed/Produced by Scheduler
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+======================================
 
 When the *scheduler* receives an allocation request containing a jobid,
 it reads the jobspec from ``job.<jobid>.jobspec``.
@@ -194,9 +183,8 @@ leaving ``R`` in place for job provenance. During a restart, the
 *job manager* uses the eventlog to determine whether ``R`` is currently
 allocated.
 
-
 Content Consumed/Produced by Exec Service
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=========================================
 
 When the *exec system* receives a start request containing a jobid,
 it reads the ``job.<jobid>.R`` and ``job.<jobid>.jobspec``
@@ -213,9 +201,8 @@ the guest namespace have stopped, the *exec system* links the guest
 namespace into the primary KVS namespace before notifying the *job
 manager* that the job is finished.
 
-
 Content Produced/Consumed by Other Instance Services
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+====================================================
 
 Other services not mentioned in this RFC MAY store arbitrary data associated
 with jobs under the ``job.<jobid>.data.<service>`` directory,
@@ -223,24 +210,21 @@ where ``<service>`` is a name unique to the service producing the data.
 For example, a job tracing service may store persistent trace data under
 the ``job.<jobid>.data.trace`` directory.
 
-
 Content Consumed/Produced by Other Guest Services
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=================================================
 
 Other guest services not mentioned in this RFC MAY store service-specific
 data in the guest KVS namespace under ``<service>``, where ``<service>`` is
 a name unique to the service producing the data.
 
-
 Content Consumed/Produced by the Application
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+============================================
 
 The application MAY store application-specific data in the guest KVS
 namespace under ``application``.
 
-
 Content Consumed/Produced by Tools
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+==================================
 
 Tools such as parallel debuggers, running as the guest, MAY store data
 in the guest KVS namespace under ``tools.<name>``, where ``<name>`` is

--- a/spec_16.rst
+++ b/spec_16.rst
@@ -8,12 +8,15 @@
 This specification describes the format of data stored in the KVS
 for Flux jobs.
 
--  Name: github.com/flux-framework/rfc/spec_16.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Jim Garlick <garlick@llnl.gov>
-
--  State: raw
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_16.rst
+  * - **Editor**
+    - Jim Garlick <garlick@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_16.rst
+++ b/spec_16.rst
@@ -21,10 +21,7 @@ for Flux jobs.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
-
+.. include:: common/language.rst
 
 Related Standards
 -----------------

--- a/spec_18.rst
+++ b/spec_18.rst
@@ -20,10 +20,7 @@ This specification describes the format for Flux KVS Event Logs.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
-
+.. include:: common/language.rst
 
 Related Standards
 -----------------

--- a/spec_18.rst
+++ b/spec_18.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_18.html
 
 18/KVS Event Log Format
-=======================
+#######################
 
 This specification describes the format for Flux KVS Event Logs.
 
@@ -18,18 +18,18 @@ This specification describes the format for Flux KVS Event Logs.
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Related Standards
------------------
+*****************
 
 - :doc:`spec_21`
 
 
 Background
-----------
+**********
 
 The initial use case for Flux KVS Event Logs is recording events
 that cause Flux job state transitions, for historical and
@@ -40,9 +40,8 @@ KVS atomic append capability enables multiple writers to add events to
 a single Flux Event Log in a race-free manner. KVS watch capability
 enables a Flux Event Log to be used for synchronization.
 
-
 Event Log Format
-----------------
+****************
 
 A Flux KVS Event Log SHALL consist of events separated by newlines.
 Each event SHALL be an independent JSON object, serialized without
@@ -69,7 +68,7 @@ context
 
 
 Example
--------
+*******
 
 An example Flux Event Log:
 

--- a/spec_18.rst
+++ b/spec_18.rst
@@ -7,12 +7,15 @@
 
 This specification describes the format for Flux KVS Event Logs.
 
--  Name: github.com/flux-framework/rfc/spec_18.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Stephen Herbein <sherbein@llnl.gov>
-
--  State: raw
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_18.rst
+  * - **Editor**
+    - Stephen Herbein <sherbein@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_18.rst
+++ b/spec_18.rst
@@ -25,7 +25,7 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 -----------------
 
--  :doc:`21/Job States and Events <spec_21>`
+- :doc:`spec_21`
 
 
 Background

--- a/spec_19.rst
+++ b/spec_19.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_19.html
 
 19/Flux Locally Unique ID (FLUID)
-=================================
+#################################
 
 This specification describes a scheme for a distributed, uncoordinated
 *flux locally unique ID* service that generates 64 bit k-ordered, unique
@@ -22,16 +22,15 @@ Flux job IDs.
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Background
-----------
-
+**********
 
 Criteria
-~~~~~~~~
+========
 
 *Very low probability of collision:* Like 128 bit UUIDs on a global scale,
 FLUIDs should provide a reasonable guarantee against collisions on a
@@ -46,9 +45,8 @@ typically monotonically increasing integers that reflect job submission
 order. This property is of debatable utility, but following the principle
 of least astonishment, FLUIDs should retain it if possible.
 
-
 Existing Solutions
-~~~~~~~~~~~~~~~~~~
+==================
 
 The design of FLUIDs is patterned after
 `Twitter Snowflake <https://blog.twitter.com/2010/announcing-snowflake>`__, and
@@ -62,9 +60,8 @@ separate machine ID per generator ensures uniqueness without coordination,
 and the sequence number ensures each generator can create a certain number
 of IDs per timestamp unit.
 
-
 Implementation
---------------
+**************
 
 FLUIDs are composed of ``[ timestamp | id | sequence ]`` similar to Snowflake,
 to allow distributed, uncoordinated ID generation across a Flux instance,
@@ -86,9 +83,8 @@ FLUIDs per second for 34 years.
 This type of generator *guarantees* unique IDs, with probability of collision
 equal to zero, so no collision detection is required.
 
-
 Representation
-~~~~~~~~~~~~~~
+==============
 
 A FLUID is a 64-bit integer, e.g. ``6731191091817518``.
 
@@ -98,9 +94,8 @@ for instance for compactness or ease of transcription over the phone.
 The following sections describe the set of supported alternate
 representations for FLUIDs.
 
-
 FLUID base58 (F58) Encoding
-+++++++++++++++++++++++++++
+---------------------------
 
 In order to create a compact, human readable representation
 of a FLUID, the main alternate encoding of a FLUID SHALL be `Base58
@@ -119,7 +114,7 @@ ASCII lowercase ``f`` will also be decoded as F58.
 Examples: ``ƒZemgA8Bzf``, ``ƒ278oEf7zGf``
 
 FLUID Hexadecimal (hex) Encoding
-++++++++++++++++++++++++++++++++
+--------------------------------
 
 A hexadecimal encoding SHALL represent a FLUID in base16, including
 a ``0x`` prefix to unambiguously differentiate the representation from
@@ -127,9 +122,8 @@ other FLUID standard encodings.
 
 Examples: ``0x17e9fb8df16c2e``, ``0xedaf97d000000``
 
-
 FLUID Dotted-Hexadecimal (dothex) Encoding
-++++++++++++++++++++++++++++++++++++++++++
+------------------------------------------
 
 In order to support indexing of FLUIDs in a hierarchical KVS namespace,
 a dotted-hexadecimal encoding SHALL represent a FLUID in base16,
@@ -137,9 +131,8 @@ with each 4 hexadecimal digits separated by dots (``.``).
 
 Examples: ``0017.e9fb.8df1.6c2e``, ``000e.daf9.7d00.0000``
 
-
 FLUID Mnemonic (words) Encoding
-+++++++++++++++++++++++++++++++
+-------------------------------
 
 In order to ease transferring of FLUIDs via human interaction, a
 mnemonic representation of FLUIDS SHALL be supported by a conformant
@@ -153,7 +146,7 @@ by speaking, e.g. over the phone.
 Examples: ``reform-remote-galileo--heart-package-academy``, ``random-idea-yoyo--sugar-printer-academy``
 
 FLUID Emoji Encoding
-++++++++++++++++++++
+--------------------
 
 In order to encode a FLUID using a minimal number of printable characters,
 and to increase visual appeal when displaying FLUIDs in various settings,
@@ -188,7 +181,7 @@ smiling eyes) SHALL represent 1, etc.
 Examples: ``🚹💂🙌😳💱🏃``, ``😄😹🎇📥🏧🙉🔞``, ``🚹💂🈳💰🎩🏃``
 
 Decoding Alternate FLUID Representations
-++++++++++++++++++++++++++++++++++++++++
+----------------------------------------
 
 The standard FLUID representations described in this RFC are
 unambiguous by design. That is, the type of FLUID encoding can

--- a/spec_19.rst
+++ b/spec_19.rst
@@ -24,10 +24,7 @@ Flux job IDs.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
-
+.. include:: common/language.rst
 
 Background
 ----------

--- a/spec_19.rst
+++ b/spec_19.rst
@@ -11,12 +11,15 @@ identifiers that are a combination of timestamp since some epoch,
 generator id, and sequence number. The scheme is used to generate
 Flux job IDs.
 
--  Name: github.com/flux-framework/rfc/spec_19.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Mark Grondona <mgrondona@llnl.gov>
-
--  State: raw
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_19.rst
+  * - **Editor**
+    - Mark Grondona <mgrondona@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_2.rst
+++ b/spec_2.rst
@@ -23,10 +23,7 @@ for Flux projects.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
-
+.. include:: common/language.rst
 
 Goals
 -----

--- a/spec_2.rst
+++ b/spec_2.rst
@@ -10,12 +10,15 @@ resource management systems for High Performance Computing (HPC) data
 centers. This document specifies licensing and collaboration guidelines
 for Flux projects.
 
--  Name: github.com/flux-framework/rfc/spec_2.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Jim Garlick <garlick@llnl.gov>
-
--  State: raw
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_2.rst
+  * - **Editor**
+    - Jim Garlick <garlick@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_2.rst
+++ b/spec_2.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_2.html
 
 2/Flux Licensing and Collaboration Guidelines
-=============================================
+#############################################
 
 The Flux framework is a family of projects used to build site-customized
 resource management systems for High Performance Computing (HPC) data
@@ -21,12 +21,12 @@ for Flux projects.
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Goals
------
+*****
 
 A Flux project is defined as software which implements a resource
 manager function, or is otherwise tightly coupled to the resource
@@ -56,13 +56,11 @@ Our licensing and collaboration guidelines must balance the following goals:
    projects such as applications, application runtimes, and tools, that are
    distributed under a wide variety of open source and commercial licenses.
 
-
 Design
-------
-
+******
 
 Collaboration Model for Flux Projects
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=====================================
 
 -  Flux projects SHALL adopt the Collective Code Construction Contract
    (C4.1) described in Flux RFC 1.
@@ -74,9 +72,8 @@ Collaboration Model for Flux Projects
 -  It is RECOMMENDED that Flux projects be discussed on the Flux
    discussion list <flux-discuss@lists.llnl.gov>.
 
-
 License for Flux Projects
-~~~~~~~~~~~~~~~~~~~~~~~~~
+=========================
 
 -  Flux projects are RECOMMENDED to be licensed under the `GNU Lesser General Public License (LGPL) version 3 <https://www.gnu.org/licenses/lgpl-3.0.en.html>`__.
 
@@ -84,9 +81,8 @@ License for Flux Projects
    under the project’s base license version, or any later version per
    `Free Software Foundation recommendations <http://www.gnu.org/licenses/gpl-faq.html#VersionThreeOrLater>`__.
 
-
 Copyright
-~~~~~~~~~
+=========
 
 -  Copyright for a particular Flux project SHALL be held jointly by
    the contributors to that project.
@@ -113,6 +109,9 @@ Copyright
     */
 
 -  The SPDX license shorthand is RECOMMENDED [#f2]_.
+
+References
+**********
 
 .. [#f1] `The Free-Libre / Open Source Software (FLOSS) License Slide <https://dwheeler.com/essays/floss-license-slide.html>`__, David A. Wheeler.
 

--- a/spec_20.rst
+++ b/spec_20.rst
@@ -4,7 +4,6 @@
 
 .. default-domain:: js
 
-#######################################
 20/Resource Set Specification Version 1
 #######################################
 
@@ -21,13 +20,11 @@ representation or *R* in short.
   * - **State**
     - raw
 
-********
 Language
 ********
 
 .. include:: common/language.rst
 
-*****************
 Related Standards
 *****************
 
@@ -39,7 +36,6 @@ Related Standards
 - :doc:`spec_29`
 - :doc:`spec_31`
 
-********
 Overview
 ********
 
@@ -76,8 +72,6 @@ shell
   The job shell uses *R* to determine where to launch tasks.  Shell plugins
   may use *R* for various purposes such setting core and GPU affinity.
 
-
-************
 Design Goals
 ************
 
@@ -101,9 +95,6 @@ Design Goals
 
 -  Build towards the general resource model of RFC 4.
 
-
-
-**************
 Implementation
 **************
 
@@ -256,7 +247,6 @@ R Format
       manages multiple job queues may add ``queue=batch``
       to indicate that this resource set was allocated from within
       its ``batch`` queue.
-
 
 Example R
 =========

--- a/spec_20.rst
+++ b/spec_20.rst
@@ -29,19 +29,13 @@ in this document are to be interpreted as described in RFC 2119.
 Related Standards
 *****************
 
--  :doc:`4/Flux Resource Model <spec_4>`
-
--  :doc:`14/Canonical Job Specification <spec_14>`
-
--  :doc:`15/Independent Minister of Privilege for Flux <spec_15>`
-
--  :doc:`16/KVS Job Schema <spec_16>`
-
--  :doc:`22/Idset String Representation <spec_22>`
-
--  :doc:`29/Hostlist Format <spec_29>`
-
--  :doc:`31/Job Constraints Specification <spec_31>`
+- :doc:`spec_4`
+- :doc:`spec_14`
+- :doc:`spec_15`
+- :doc:`spec_16`
+- :doc:`spec_22`
+- :doc:`spec_29`
+- :doc:`spec_31`
 
 ********
 Overview

--- a/spec_20.rst
+++ b/spec_20.rst
@@ -25,9 +25,7 @@ representation or *R* in short.
 Language
 ********
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
-"SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL"
-in this document are to be interpreted as described in RFC 2119.
+.. include:: common/language.rst
 
 *****************
 Related Standards

--- a/spec_20.rst
+++ b/spec_20.rst
@@ -11,11 +11,15 @@
 This specification defines the version 1 format of the resource-set
 representation or *R* in short.
 
--  Name: github.com/flux-framework/rfc/spec_20.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Jim Garlick <garlick@llnl.gov>
-
--  State: Raw
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_20.rst
+  * - **Editor**
+    - Jim Garlick <garlick@llnl.gov>
+  * - **State**
+    - raw
 
 ********
 Language

--- a/spec_21.rst
+++ b/spec_21.rst
@@ -21,10 +21,7 @@ job state transitions.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
-
+.. include:: common/language.rst
 
 Related Standards
 -----------------

--- a/spec_21.rst
+++ b/spec_21.rst
@@ -8,12 +8,15 @@
 This specification describes Flux job states and the events that trigger
 job state transitions.
 
--  Name: github.com/flux-framework/rfc/spec_21.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Jim Garlick <garlick@llnl.gov>
-
--  State: raw
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_21.rst
+  * - **Editor**
+    - Jim Garlick <garlick@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_21.rst
+++ b/spec_21.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_21.html
 
 21/Job States and Events Version 1
-==================================
+##################################
 
 This specification describes Flux job states and the events that trigger
 job state transitions.
@@ -19,21 +19,20 @@ job state transitions.
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Related Standards
------------------
+*****************
 
 - :doc:`spec_16`
 - :doc:`spec_18`
 - :doc:`spec_22`
 - :doc:`spec_27`
 
-
 Background
-----------
+**********
 
 The job state machine is intended to be a useful abstraction of job life
 cycle for users. If a job is not yet running, the job state communicates
@@ -44,9 +43,8 @@ such as workflow managers.
 A job is said to be *active* if it has not yet reached the captive end state,
 and *inactive* once it has.
 
-
 Design Criteria
-~~~~~~~~~~~~~~~
+***************
 
 -  Job states SHOULD exist for job phases with the potential for long duration,
    to provide transparency to users.
@@ -71,19 +69,16 @@ Design Criteria
    recent versions of this specification, to avoid losing job data when Flux
    is restarted after a software upgrade.
 
-
 Implementation
---------------
-
+**************
 
 State Diagram
-~~~~~~~~~~~~~
+=============
 
 |states|
 
-
 State Descriptions
-~~~~~~~~~~~~~~~~~~
+==================
 
 NEW
    Initial state. The required first ``submit`` event logs the job’s creation,
@@ -124,9 +119,8 @@ CLEANUP
 INACTIVE
    Job data in KVS is now read-only (captive state).
 
-
 Virtual States
-~~~~~~~~~~~~~~
+--------------
 
 In the interest of encouraging consistent language, we define the following
 "virtual states" as shorthand for the union of two or more actual job states:
@@ -140,9 +134,8 @@ RUNNING
 ACTIVE
   The job is in DEPEND, PRIORITY, SCHED, RUN, or CLEANUP states.
 
-
 Exceptions
-~~~~~~~~~~
+==========
 
 An exception event is an extraordinary occurrence that MAY interrupt the
 "normal" job life cycle.
@@ -159,9 +152,8 @@ More than one exception MAY occur per job.
 
 The exception event format is described below.
 
-
 Event Descriptions
-~~~~~~~~~~~~~~~~~~
+==================
 
 Job state transitions are driven by events that are logged to
 ``job.<jobid>.eventlog`` as required by RFC 16.
@@ -175,9 +167,8 @@ Unless otherwise specified, keys beyond those listed as OPTIONAL and
 REQUIRED below MAY be included in event context objects for use by plugins
 or extensions.
 
-
 Submit Event
-^^^^^^^^^^^^
+------------
 
 Job was submitted.
 
@@ -205,7 +196,7 @@ Example:
 The ``submit`` event SHALL be the first event posted for each job.
 
 Jobspec-update Event
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 
 Change jobspec after job submission.  The event context object SHALL consist
 of a dictionary of period-delimited keys that SHALL be interpreted as a
@@ -225,7 +216,7 @@ Example:
    be altered.
 
 Resource-update Event
-^^^^^^^^^^^^^^^^^^^^^
+---------------------
 
 Update R expiration time after allocation.  The event context object SHALL
 consist of a dictionary containing the key ``expiration`` with an integer
@@ -237,9 +228,8 @@ Example:
 
    {"timestamp":1552593348.073045,"name":"resource-update","context":{"expiration":1692206240}}
 
-
 Validate Event
-^^^^^^^^^^^^^^
+--------------
 
 Job submission is valid.
 
@@ -252,7 +242,7 @@ Example:
     {"timestamp":1605115080.0358412,"name":"validate"}
 
 Invalidate Event
-^^^^^^^^^^^^^^^^
+----------------
 
 Job submission is invalid.  The job (including the KVS eventlog) SHALL be
 immediately removed.
@@ -266,7 +256,7 @@ Example:
     {"timestamp":1605115080.0358412,"name":"invalidate"}
 
 Set-flags Event
-^^^^^^^^^^^^^^^
+---------------
 
 One or more flags have been set on the job.
 
@@ -281,9 +271,8 @@ Example:
 
    {"timestamp":1552593348.073045,"name":"set-flags","context":{"flags":["debug"]}}
 
-
 Dependency-add Event
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 
 A dependency has been added to the job. This dependency must then be removed
 via a ``dependency-remove`` event.
@@ -297,9 +286,8 @@ description
 
    {"timestamp":1552593348.073045,"name":"dependency-add","context":{"description":"begin-time=1552594348"}}
 
-
 Dependency-remove Event
-^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------
 
 A dependency has be removed from a job. The dependency description MUST
 match a previously added dependency from a ``dependency-add`` event.
@@ -313,9 +301,8 @@ description
 
    {"timestamp":1552594348.0,"name":"dependency-remove","context":{"description":"begin-time=1552594348"}}
 
-
 Depend Event
-^^^^^^^^^^^^
+------------
 
 All job dependencies have been met.
 
@@ -327,9 +314,8 @@ Example:
 
     {"timestamp":1605115080.0358412,"name":"depend"}
 
-
 Priority Event
-^^^^^^^^^^^^^^
+--------------
 
 Job's priority has been assigned.
 
@@ -342,9 +328,8 @@ priority
 
    {"timestamp":1552593547.411336,"name":"priority","context":{"priority":42}}
 
-
 Flux-Restart Event
-^^^^^^^^^^^^^^^^^^
+------------------
 
 The job manager has restarted.
 
@@ -356,9 +341,8 @@ Example:
 
     {"timestamp":1605115080.0358412,"name":"flux-restart"}
 
-
 Urgency Event
-^^^^^^^^^^^^^
+-------------
 
 Job's urgency has changed.
 
@@ -374,9 +358,8 @@ userid
 
    {"timestamp":1552593547.411336,"name":"urgency","context":{"urgency":0,"userid":5588}}
 
-
 Alloc Event
-^^^^^^^^^^^
+-----------
 
 Resources have been allocated by the scheduler.
 
@@ -391,9 +374,8 @@ Example:
 
    {"timestamp":1552593348.088391,"name":"alloc","context":{"annotations":{"sched.resource_summary":"rank0/core[0-1]"}}}
 
-
 Prolog-start Event
-^^^^^^^^^^^^^^^^^^
+------------------
 
 A prolog action has started for the job. This event SHALL prevent the job
 manager from initiating a start request to the execution system until the
@@ -408,9 +390,8 @@ description
 
    {"timestamp":1552593348.073045,"name":"prolog-start","context":{"description":"/usr/sbin/job-prolog.sh"}}
 
-
 Prolog-finish Event
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 A prolog action for the job has completed. The prolog description SHOULD
 match a previous ``prolog-start`` event.
@@ -428,9 +409,8 @@ status
 
    {"timestamp":1552594348.0,"name":"prolog-finish","context":{"description":"/usr/sbin/job-prolog.sh", "status":0}}
 
-
 Epilog-start Event
-^^^^^^^^^^^^^^^^^^
+------------------
 
 An epilog action has started for the job. This event SHALL prevent the job
 manager from initiating a free request to the scheduler until the
@@ -445,9 +425,8 @@ description
 
    {"timestamp":1552593348.073045,"name":"epilog-start","context":{"description":"/usr/sbin/job-epilog.sh"}}
 
-
 Epilog-finish Event
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 A epilog action for the job has completed. The epilog description SHOULD
 match a previous ``epilog-start`` event.
@@ -465,9 +444,8 @@ status
 
    {"timestamp":1552594348.0,"name":"epilog-finish","context":{"description":"/usr/sbin/job-epilog.sh", "status":0}}
 
-
 Free Event
-^^^^^^^^^^
+----------
 
 Resources have been released to the scheduler.
 
@@ -479,9 +457,8 @@ Example:
 
    {"timestamp":1552593348.093541,"name":"free"}
 
-
 Start Event
-^^^^^^^^^^^
+-----------
 
 Job shells have started.
 
@@ -493,9 +470,8 @@ Example:
 
    {"timestamp":1552593348.089787,"name":"start"}
 
-
 Release Event
-^^^^^^^^^^^^^
+-------------
 
 Resources have been released.
 
@@ -514,9 +490,8 @@ Example:
 
    {"timestamp":1552593348.092830,"name":"release","context":{"ranks":"all","final":true}}
 
-
 Finish Event
-^^^^^^^^^^^^
+------------
 
 Job shells have terminated.
 
@@ -532,9 +507,8 @@ Example:
 
    {"timestamp":1552593348.090927,"name":"finish","context":{"status":0}}
 
-
 Clean Event
-^^^^^^^^^^^
+-----------
 
 Cleanup has completed.
 
@@ -546,9 +520,8 @@ Example:
 
    {"timestamp":1552593348.104432,"name":"clean"}
 
-
 Exception Event
-^^^^^^^^^^^^^^^
+---------------
 
 An exception occurred.
 
@@ -598,7 +571,7 @@ free
    A problem occurred while releasing resources to the scheduler.
 
 Memo Event
-^^^^^^^^^^
+----------
 
 A brief data record has been associated with the job.
 
@@ -613,7 +586,7 @@ Example:
   {"timestamp":1637723184.3725791,"name":"memo","context":{"key":"value"}}
 
 Debug Event
-^^^^^^^^^^^
+-----------
 
 Debug event names are prefixed with "debug." They are optional and
 are intended to provide context in the eventlog that aids debugging.
@@ -626,9 +599,8 @@ Example:
 
    {"timestamp":1552594649.848032,"name":"debug.free-request"}
 
-
 Synchronization
-~~~~~~~~~~~~~~~
+===============
 
 Any state but ``NEW`` is valid for synchronization.
 

--- a/spec_21.rst
+++ b/spec_21.rst
@@ -26,13 +26,10 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 -----------------
 
--  :doc:`16/KVS Job Schema <spec_16>`
-
--  :doc:`18/KVS Event Log Format <spec_18>`
-
--  :doc:`22/Idset String Representation <spec_22>`
-
--  :doc:`27/Flux Resource Allocation Protocol Version 1 <spec_27>`
+- :doc:`spec_16`
+- :doc:`spec_18`
+- :doc:`spec_22`
+- :doc:`spec_27`
 
 
 Background

--- a/spec_22.rst
+++ b/spec_22.rst
@@ -21,10 +21,7 @@ expressing a set of non-negative, integer ids.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
-
+.. include:: common/language.rst
 
 Background
 ----------

--- a/spec_22.rst
+++ b/spec_22.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_22.html
 
 22/Idset String Representation
-==============================
+##############################
 
 This specification describes a compact form for
 expressing a set of non-negative, integer ids.
@@ -19,12 +19,12 @@ expressing a set of non-negative, integer ids.
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Background
-----------
+**********
 
 It is often necessary to represent a set of non-negative, integer ids
 as a compact string for human input, output, or in messages. For example:
@@ -35,9 +35,8 @@ as a compact string for human input, output, or in messages. For example:
 
 -  A set of resource ids or indices.
 
-
 Implementation
---------------
+**************
 
 An idset SHALL consist of unique, non-negative integer ids.
 

--- a/spec_22.rst
+++ b/spec_22.rst
@@ -8,12 +8,15 @@
 This specification describes a compact form for
 expressing a set of non-negative, integer ids.
 
--  Name: github.com/flux-framework/rfc/spec_22.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Jim Garlick <garlick@llnl.gov>
-
--  State: raw
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_22.rst
+  * - **Editor**
+    - Jim Garlick <garlick@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_23.rst
+++ b/spec_23.rst
@@ -21,10 +21,7 @@ a duration of time.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
-
+.. include:: common/language.rst
 
 Background
 ----------

--- a/spec_23.rst
+++ b/spec_23.rst
@@ -8,12 +8,15 @@
 This specification describes a simple string format used to represent
 a duration of time.
 
--  Name: github.com/flux-framework/rfc/spec_23.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Mark A. Grondona <mark.grondona@gmail.com>
-
--  State: raw
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_23.rst
+  * - **Editor**
+    - Mark A. Grondona <mark.grondona@gmail.com>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_23.rst
+++ b/spec_23.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_23.html
 
 23/Flux Standard Duration
-=========================
+#########################
 
 This specification describes a simple string format used to represent
 a duration of time.
@@ -19,12 +19,12 @@ a duration of time.
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Background
-----------
+**********
 
 Many Flux utilities and services may take a time *duration* as input
 either via user-provided options, configuration input, or message payload
@@ -35,9 +35,8 @@ a duration format that is human readable, easily parsed, and compact.
 Utilities and services that support the duration form described here are
 said to support "Flux Standard Duration."
 
-
 Implementation
---------------
+**************
 
 A Flux Standard Duration SHALL be a string of the form ``N[SUFFIX]``,
 where *N* is a floating point number and *SUFFIX* is an OPTIONAL unit.
@@ -75,7 +74,7 @@ As a special case, when N is ``infinity`` or ``inf``, the unit suffix SHALL
 be omitted.
 
 Test Vectors
-------------
+************
 
 .. list-table::
    :header-rows: 1
@@ -102,6 +101,9 @@ Test Vectors
      - INFINITY
    * - infinity
      - INFINITY
+
+References
+**********
 
 .. [#f1] `C99 - ISO/IEC 9899:1999 standard <https://www.iso.org/standard/29237.html>`__ section 7.20.1.3: The strtod, strtof, and strtold functions
 .. [#f2] `C99 - ISO/IEC 9899:1999 standard <https://www.iso.org/standard/29237.html>`__ section 7.12/4 INFINITY (p: 212-213)

--- a/spec_24.rst
+++ b/spec_24.rst
@@ -21,10 +21,7 @@ standard I/O streams in the Flux KVS.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
-
+.. include:: common/language.rst
 
 Related Standards
 -----------------

--- a/spec_24.rst
+++ b/spec_24.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_24.html
 
 24/Flux Job Standard I/O Version 1
-==================================
+##################################
 
 This specification describes the format used to represent
 standard I/O streams in the Flux KVS.
@@ -19,20 +19,19 @@ standard I/O streams in the Flux KVS.
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Related Standards
------------------
+*****************
 
 - :doc:`spec_16`
 - :doc:`spec_18`
 - :doc:`spec_22`
 
-
 Goals
------
+*****
 
 -  Incorporate task I/O streams into KVS job record.
 
@@ -60,18 +59,16 @@ Goals
 
 -  Support de-duplication of stream contents, where applicable.
 
-
 Implementation
---------------
+**************
 
 Standard I/O streams SHALL be stored under two keys in the
 KVS job schema: ``job.<jobid>.guest.output`` and ``job.<jobid>.guest.input``.
 The values SHALL be formatted as a KVS event log (RFC 18), with events as
 described below.
 
-
 Header Event
-~~~~~~~~~~~~
+============
 
 The header event describes the input or output events that follow.
 There SHALL be exactly one header event in each log, appearing first.
@@ -115,15 +112,13 @@ Example:
      }
    }
 
-
 Header Options
-^^^^^^^^^^^^^^
+--------------
 
 TBD: input distribution options.
 
-
 Data Event
-~~~~~~~~~~
+==========
 
 The output event encapsulates a blob of input or output data.
 
@@ -175,9 +170,8 @@ Example:
      }
    }
 
-
 Redirect Event
-~~~~~~~~~~~~~~
+==============
 
 The redirect event indicates that a stream’s data has been redirected
 away from the log. The caller should not expect any additional data
@@ -212,9 +206,8 @@ Example:
      }
    }
 
-
 Log Event
-~~~~~~~~~
+=========
 
 The log event supports error and debug logging from the Flux shells.
 

--- a/spec_24.rst
+++ b/spec_24.rst
@@ -8,12 +8,15 @@
 This specification describes the format used to represent
 standard I/O streams in the Flux KVS.
 
--  Name: github.com/flux-framework/rfc/spec_24.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Jim Garlick <garlick.jim@gmail.com>
-
--  State: raw
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_24.rst
+  * - **Editor**
+    - Jim Garlick <garlick@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_24.rst
+++ b/spec_24.rst
@@ -26,11 +26,9 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 -----------------
 
--  :doc:`16/KVS Job Schema <spec_16>`
-
--  :doc:`18/KVS Event Log Format <spec_18>`
-
--  :doc:`22/Idset String Representation <spec_22>`
+- :doc:`spec_16`
+- :doc:`spec_18`
+- :doc:`spec_22`
 
 
 Goals

--- a/spec_25.rst
+++ b/spec_25.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_25.html
 
 25/Job Specification Version 1
-==============================
+##############################
 
 A domain specific language based on YAML is defined to express the resource
 requirements and other attributes of one or more programs submitted to a Flux
@@ -23,12 +23,12 @@ version of the canonical jobspec format described in
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Related Standards
------------------
+*****************
 
 - :doc:`spec_4`
 - :doc:`spec_14`
@@ -37,7 +37,7 @@ Related Standards
 - :doc:`spec_31`
 
 Goals
------
+*****
 
 -  Express the resource requirements of a program to the scheduler.
 
@@ -47,9 +47,8 @@ Goals
 -  Express program attributes such as arguments, run time, and
    task layout, to be considered by the execution service
 
-
 Overview
---------
+********
 
 This RFC describes the version 1 form of "jobspec", a domain specific language
 based on YAML  [#f1]_. The version 1 of jobspec SHALL consist of
@@ -57,9 +56,8 @@ a single YAML document representing a reusable request to run
 exactly one program. Hereafter, "jobspec" refers to the version 1
 form, and "non-canonical jobspec" refers to the non-canonical form.
 
-
 Jobspec Language Definition
----------------------------
+***************************
 
 A jobspec V1 YAML document SHALL consist of a dictionary
 defining the resources, tasks and other attributes of a single
@@ -70,9 +68,8 @@ Each of the listed jobspec keys SHALL meet the form and requirements
 listed in detail in the sections below. For reference, a ruleset for
 compliant jobspec V1 is provided in the **Schema** section below.
 
-
 Resources
-~~~~~~~~~
+=========
 
 The value of the ``resources`` key SHALL be a strict list which MUST define either
 ``node`` or ``slot`` as the first and only resource. Each list element SHALL represent a
@@ -109,9 +106,8 @@ following:
    resources matching the current vertex. The ``count`` SHALL be a single integer
    value representing a fixed count
 
-
 V1-Specific Resource Graph Restrictions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------------------
 
 In V1, the ``resources`` list MUST contain exactly one element, which MUST be
 either ``node`` or ``slot``. Additionally, the resource graph MUST contain the
@@ -131,9 +127,8 @@ well. Therefore, the complete enumeration of valid resource graphs in V1 is:
 
 -  ``node>slot>(core,gpu)``
 
-
 Tasks
-~~~~~
+=====
 
 The value of the ``tasks`` key SHALL be a strict list which MUST define exactly
 one task. The list element SHALL be a dictionary representing a task to run as
@@ -150,9 +145,8 @@ definitions SHALL match those provided in RFC14:
 
    -  total
 
-
 Attributes
-~~~~~~~~~~
+==========
 
 The ``attributes`` key SHALL be a dictionary of
 dictionaries. The ``attributes`` dictionary MUST contain ``system`` key and MAY
@@ -178,9 +172,8 @@ definitions can be found in RFC14. Values MAY have any valid YAML type.
 Most system attributes are optional, but the ``duration`` attribute is required in
 jobspec V1.
 
-
 Example Jobspec
-~~~~~~~~~~~~~~~
+***************
 
 Under the description above, the following is an example of a fully compliant
 version 1 jobspec. The example below declares a request for 4 "nodes"
@@ -191,16 +184,14 @@ task slot for a total of 4 tasks.
 .. literalinclude:: data/spec_25/example1.yaml
    :language: yaml
 
-
 Basic Use Cases
----------------
+===============
 
 To implement basic resource manager functionality, the following use
 cases SHALL be supported by the jobspec:
 
-
 Section 1: Node-level Requests
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------
 
 The following "node-level" requests are all requests to start an instance,
 i.e. run a single copy of ``flux start`` per allocated node. Many of these
@@ -224,9 +215,8 @@ Jobspec YAML
    .. literalinclude:: data/spec_25/use_case_1.1.yaml
       :language: yaml
 
-
 Section 2: General Requests
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------
 
 The following use cases are more general and include more complex slot placement
 and task counts.
@@ -290,15 +280,18 @@ Jobspec YAML
    .. literalinclude:: data/spec_25/use_case_2.4.yaml
       :language: yaml
 
-
 Schema
-~~~~~~
+******
 
 A jobspec conforming to version 1 of the language definition SHALL
 adhere to the following ruleset, described using JSON Schema [#f2]_.
 
+
 .. literalinclude:: data/spec_25/schema.json
    :language: json
+
+References
+**********
 
 .. [#f1] `YAML Ain’t Markup Language (YAML) Version 1.1 <http://yaml.org/spec/1.1/current.html>`__, O. Ben-Kiki, C. Evans, B. Ingerson, 2004.
 

--- a/spec_25.rst
+++ b/spec_25.rst
@@ -30,15 +30,11 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 -----------------
 
--  :doc:`4/Flux Resource Model <spec_4>`
-
--  :doc:`14/Canonical Job Specification <spec_14>`
-
--  :doc:`20/Resource Set Specification Version 1 <spec_20>`
-
--  :doc:`26/Job Dependency Specification <spec_26>`
-
--  :doc:`31/Job Constraints Specification <spec_31>`
+- :doc:`spec_4`
+- :doc:`spec_14`
+- :doc:`spec_20`
+- :doc:`spec_26`
+- :doc:`spec_31`
 
 Goals
 -----

--- a/spec_25.rst
+++ b/spec_25.rst
@@ -12,12 +12,15 @@ represents a request to run exactly one program. This version is a simplified
 version of the canonical jobspec format described in
 :doc:`RFC 14 <spec_14>`.
 
--  Name: github.com/flux-framework/rfc/spec_25.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Stephen Herbein <herbein1@llnl.gov>
-
--  State: raw
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_25.rst
+  * - **Editor**
+    - Stephen Herbein <herbein1@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_25.rst
+++ b/spec_25.rst
@@ -25,10 +25,7 @@ version of the canonical jobspec format described in
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
-
+.. include:: common/language.rst
 
 Related Standards
 -----------------

--- a/spec_26.rst
+++ b/spec_26.rst
@@ -8,9 +8,15 @@
 An extension to the canonical jobspec designed to express the dependencies
 between one or more programs submitted to a Flux instance for execution.
 
--  Name: github.com/flux-framework/rfc/spec_26.rst
--  Editor: Stephen Herbein <herbein1@llnl.gov>
--  State: raw
+.. list-table::
+  :widths: 25 75
+
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_26.rst
+  * - **Editor**
+    - Stephen Herbein <herbein1@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_26.rst
+++ b/spec_26.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_26.html
 
 26/Job Dependency Specification
-===============================
+###############################
 
 An extension to the canonical jobspec designed to express the dependencies
 between one or more programs submitted to a Flux instance for execution.
@@ -19,12 +19,12 @@ between one or more programs submitted to a Flux instance for execution.
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Related Standards
------------------
+*****************
 
 - :doc:`spec_14`
 - :doc:`spec_19`
@@ -32,9 +32,8 @@ Related Standards
 - `OpenMP Specification <https://www.openmp.org/wp-content/uploads/OpenMP-API-Specification-5.0.pdf>`__
 - `IETF RFC3986: Uniform Resource Identifier (URI) <https://tools.ietf.org/html/rfc3986>`__
 
-
 Goals
------
+*****
 
 -  Define how job dependencies are represented in jobspec.
 -  Define how job dependencies are represented as command line arguments.
@@ -44,9 +43,8 @@ Goals
    (DAG).
 -  Describe a mechanism for specifying more advanced, runtime dependencies.
 
-
 Background
-----------
+**********
 
 RFC 21 defines a DEPEND state for jobs, which is exited once all job
 dependencies have been satisfied, or a fatal exception has occurred.
@@ -69,7 +67,7 @@ service outside of the job manager; for example, a separate broker module
 or an entity that is not part of Flux.
 
 Dependency Event Semantics
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+==========================
 
 Dependency events SHALL only be posted to the job eventlog by job manager
 plugins.
@@ -89,9 +87,8 @@ dependencies SHALL NOT raise a plugin error and SHALL NOT be posted.
 Attempts to post duplicate ``dependency-add`` events for satisfied
 dependencies SHALL raise a plugin error.
 
-
 Representation
---------------
+**************
 
 A job dependency SHALL be represented as a JSON object with the following
 REQUIRED keys:
@@ -106,7 +103,7 @@ A dependency object MAY contain additional OPTIONAL key-value pairs,
 whose semantics are determined by the scheme.
 
 in jobspec
-~~~~~~~~~~
+==========
 
 Each dependency requested by the user SHALL be represented as an element in
 the jobspec ``attributes.system.dependencies`` array.  Each element SHALL
@@ -116,7 +113,7 @@ If job requests no dependencies, the key ``attributes.system.dependencies``
 SHALL NOT be added to the jobspec.
 
 on command line
-~~~~~~~~~~~~~~~
+===============
 
 On the command line, a job dependency MAY be expressed in a compact, URI-like
 form, with the first OPTIONAL key-value pair represented as a URI query
@@ -136,14 +133,13 @@ Examples:
 This form SHOULD be translated by the command line tool to the object
 form above before being shared with other parts of the system.
 
-
 Simple Dependencies
--------------------
+*******************
 
 The following dependency schemes are built-in.
 
 after
-~~~~~
+=====
 
 ``value`` SHALL be interpreted as the antecedent jobid, in any valid
 FLUID encoding from RFC 19.
@@ -153,9 +149,8 @@ and posts a ``start`` event. If the antecedent job reaches INACTIVE state
 without entering RUN state and posting a ``start`` event, a fatal exception
 SHOULD be raised on the dependent job.
 
-
 afterany
-~~~~~~~~
+========
 
 ``value`` SHALL be interpreted as the antecedent jobid, in any valid
 FLUID encoding from RFC 19.
@@ -164,7 +159,7 @@ The dependency SHALL be satisfied once the antecedent job enters INACTIVE
 state, regardless of result.
 
 afterok
-~~~~~~~
+=======
 
 ``value`` SHALL be interpreted as the antecedent jobid, in any valid
 FLUID encoding from RFC 19.
@@ -174,7 +169,7 @@ state, with a successful result.  If the antecedent job does not conclude
 successfully, a fatal exception SHOULD be raised on the dependent job.
 
 afternotok
-~~~~~~~~~~
+==========
 
 ``value`` SHALL be interpreted as the antecedent jobid, in any valid
 FLUID encoding from RFC 19.
@@ -184,21 +179,20 @@ state, with an unsuccessful result.  If the antecedent job concludes
 successfully, a fatal exception SHOULD be raised on the dependent job.
 
 begin-time
-~~~~~~~~~~
+==========
 
 ``value`` SHALL be interpreted as a floating point timestamp in seconds
 since the UNIX epoch. The dependency SHALL be satisfied once the system
 time reaches the specified timestamp.
 
-
 OpenMP-style Dependencies
--------------------------
+*************************
 
 The ``string`` and ``fluid`` schemes are reserved for more sophisticated
 symbolic and jobid based dependencies, inspired by the OpenMP specification.
 
 string
-~~~~~~
+======
 
 ``value`` SHALL be interpreted as a symbolic dependency name.
 
@@ -211,7 +205,7 @@ scope
   (string) ``user`` or ``global`` as described below.
 
 fluid
-~~~~~
+=====
 
 ``value`` SHALL be interpreted as a jobid, in any valid FLUID encoding from
 RFC 19.
@@ -226,7 +220,7 @@ A dependency of this ``scheme`` with a ``type`` of ``out`` SHALL be generated
 automatically for every job when OpenMP-style dependencies are active.
 
 Type
-~~~~
+====
 
 The value of the ``type`` key SHALL be one of the following:
 
@@ -246,7 +240,7 @@ The value of the ``type`` key SHALL be one of the following:
 Planned future values for ``type`` include ``inoutset``, ``runtime``, and ``all``.
 
 Scope
-~~~~~
+=====
 
 The value of the ``scope`` key SHALL be one of the following:
 
@@ -258,9 +252,8 @@ The value of the ``scope`` key SHALL be one of the following:
    of any type within this scope. A non-instance owner can only create a
    dependency with the type ``in`` within this scope.
 
-
 Examples
-~~~~~~~~
+========
 
 Under the description above, the following are examples of fully compliant
 dependency declarations.

--- a/spec_26.rst
+++ b/spec_26.rst
@@ -22,11 +22,11 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 -----------------
 
--  :doc:`14/Canonical Job Specification <spec_14>`
--  :doc:`19/Flux Locally Unique ID <spec_19>`
--  :doc:`21/Job States and Events <spec_21>`
--  `OpenMP Specification <https://www.openmp.org/wp-content/uploads/OpenMP-API-Specification-5.0.pdf>`__
--  `IETF RFC3986: Uniform Resource Identifier (URI) <https://tools.ietf.org/html/rfc3986>`__
+- :doc:`spec_14`
+- :doc:`spec_19`
+- :doc:`spec_21`
+- `OpenMP Specification <https://www.openmp.org/wp-content/uploads/OpenMP-API-Specification-5.0.pdf>`__
+- `IETF RFC3986: Uniform Resource Identifier (URI) <https://tools.ietf.org/html/rfc3986>`__
 
 
 Goals

--- a/spec_26.rst
+++ b/spec_26.rst
@@ -21,9 +21,7 @@ between one or more programs submitted to a Flux instance for execution.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
+.. include:: common/language.rst
 
 Related Standards
 -----------------

--- a/spec_27.rst
+++ b/spec_27.rst
@@ -26,15 +26,11 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 -----------------
 
--  :doc:`14/Canonical Job Specification <spec_14>`
-
--  :doc:`16/KVS Job Schema <spec_16>`
-
--  :doc:`20/Resource Set Specification Version 1 <spec_20>`
-
--  :doc:`21/Job States and Events <spec_21>`
-
--  :doc:`23/Flux Standard Duration <spec_23>`
+- :doc:`spec_14`
+- :doc:`spec_16`
+- :doc:`spec_20`
+- :doc:`spec_21`
+- :doc:`spec_23`
 
 
 Background

--- a/spec_27.rst
+++ b/spec_27.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_27.html
 
 27/Flux Resource Allocation Protocol Version 1
-==============================================
+##############################################
 
 This specification describes Version 1 of the Flux Resource Allocation
 Protocol implemented by the job manager and a compliant Flux scheduler.
@@ -19,12 +19,12 @@ Protocol implemented by the job manager and a compliant Flux scheduler.
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Related Standards
------------------
+*****************
 
 - :doc:`spec_14`
 - :doc:`spec_16`
@@ -32,9 +32,8 @@ Related Standards
 - :doc:`spec_21`
 - :doc:`spec_23`
 
-
 Background
-----------
+**********
 
 The Flux job manager's role is managing the queue of pending job requests
 and transitioning jobs through the job states defined in RFC 21, actively
@@ -65,9 +64,8 @@ and identify resources that are already allocated at scheduler startup.
 It does not cover the mechanism by which a scheduler discovers the initial
 inventory of resources.
 
-
 Design Criteria
----------------
+***************
 
 - Support multiple scheduler implementations, minimizing repeated code
   in schedulers.
@@ -101,9 +99,8 @@ Design Criteria
 
 - Allow the expiration time of a resource allocation to be adjusted.
 
-
 Implementation
---------------
+**************
 
 To escape scalability limitations of the Flux "tag pool", ``sched.alloc`` and
 ``sched.free`` RPCs use the job ID to match requests and responses, and set the
@@ -131,9 +128,8 @@ The other RPCs behave conventionally.
 
 A detailed description of these RPCs follows.
 
-
 Hello
-~~~~~
+=====
 
 Before any other RPCs are sent to the job manager, the scheduler SHALL
 send an empty request to ``job-manager.sched-hello`` with the
@@ -176,9 +172,8 @@ If an error response other than ENODATA is returned to the
 ``job-manager.sched-hello`` request, the scheduler SHALL log the error
 and exit its module thread.
 
-
 Ready
-~~~~~
+=====
 
 Once the scheduler has processed the ``job-manager.sched-hello`` handshake,
 it SHALL notify the job manager that it is ready to accept allocation requests
@@ -223,9 +218,8 @@ MAY immediately begin sending ``sched.alloc`` and ``sched.free`` requests.
 If an error response is returned to the ``job-manager.sched-ready`` request,
 the scheduler SHALL log the error and exit its module thread.
 
-
 Alloc
-~~~~~
+=====
 
 The job manager SHALL send a ``sched.alloc`` request when a job enters SCHED
 state, and concurrency criteria established by the initialization handshake
@@ -307,7 +301,7 @@ CANCEL (3)
 The ``alloc`` request MAY receive multiple responses.
 
 Alloc Success
-^^^^^^^^^^^^^
+-------------
 
 If resources can be allocated, the scheduler SHALL ensure that *R* has
 been successfully committed to the KVS per the job schema (RFC 16)
@@ -347,7 +341,7 @@ After the SUCCESS response, the ``sched.alloc`` request is complete and may be
 retired by the job manager and scheduler.
 
 Alloc Annotate
-^^^^^^^^^^^^^^
+--------------
 
 While a job is in SCHED state, the scheduler MAY send multiple ANNOTATE
 type responses to the ``sched.alloc`` request to update scheduler-defined
@@ -418,7 +412,7 @@ to the ``sched.alloc`` request, as described in Alloc Success above.
 Annotations SHALL be discarded by the job manager if the allocation fails.
 
 Alloc Deny
-^^^^^^^^^^
+----------
 
 If the resource request can never be fulfilled, the scheduler SHALL
 respond to the ``sched.alloc`` with a DENY type response.
@@ -446,7 +440,7 @@ After the DENY response, the ``sched.alloc`` request is complete and may be
 retired by the job manager and scheduler.
 
 Alloc Cancel
-^^^^^^^^^^^^
+------------
 
 When the scheduler receives a ``sched.cancel`` request for a job (see below),
 it SHALL respond to the corresponding ``sched.alloc`` request with response
@@ -464,9 +458,8 @@ Example:
 After the CANCEL response, the ``sched.alloc`` request is complete and may be
 retired by the job manager and scheduler.
 
-
 Cancel
-~~~~~~
+======
 
 The job manager may cancel a pending ``sched.alloc`` request by sending
 a request to ``sched.cancel`` with payload consisting of a JSON object
@@ -495,9 +488,8 @@ outstanding ``sched.alloc`` requests in response to the queue being
 administratively disabled, or to make room for higher priority jobs
 in ``single`` mode.
 
-
 Prioritize
-~~~~~~~~~~
+==========
 
 When jobs with outstanding ``sched.alloc`` requests are re-prioritized,
 the job manager notifies the scheduler by sending a ``sched.prioritize``
@@ -540,7 +532,7 @@ No response is sent to the ``sched.prioritize`` request.
     ``sched.prioritize`` request.
 
 Expiration
-~~~~~~~~~~
+==========
 
 The job manager MAY request an adjustment to the expiration time of an
 existing allocation by sending a ``sched.expiration`` request.  The request
@@ -575,7 +567,7 @@ The request MAY fail, for example if:
     execution system, not the scheduler.
 
 Free
-~~~~
+====
 
 The job manager SHALL send a ``sched.free`` request when a job that is
 holding resources enters CLEANUP state.  The request payload consists of
@@ -614,9 +606,8 @@ Example:
 After the ``sched.free`` response, the request is complete and may be
 retired by the job manager and scheduler.
 
-
 Finalization
-~~~~~~~~~~~~
+============
 
 If the job manager receives a conventional Flux error response to
 a ``sched.alloc`` or ``sched.free`` request, it SHALL log the error
@@ -630,9 +621,8 @@ scheduler, it SHALL suspend scheduler operations.
 Operations MAY resume if the scheduler re-establishes itself with the
 ``job-manager.sched-hello`` and ``job-manager.sched-ready`` handshakes.
 
-
 Exceptions
-~~~~~~~~~~
+==========
 
 When a job encounters a fatal exception, the job manager transitions it
 to CLEANUP state.

--- a/spec_27.rst
+++ b/spec_27.rst
@@ -8,12 +8,15 @@
 This specification describes Version 1 of the Flux Resource Allocation
 Protocol implemented by the job manager and a compliant Flux scheduler.
 
--  Name: github.com/flux-framework/rfc/spec_27.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Jim Garlick <garlick@llnl.gov>
-
--  State: raw
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_27.rst
+  * - **Editor**
+    - Jim Garlick <garlick@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_27.rst
+++ b/spec_27.rst
@@ -21,10 +21,7 @@ Protocol implemented by the job manager and a compliant Flux scheduler.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
-
+.. include:: common/language.rst
 
 Related Standards
 -----------------

--- a/spec_28.rst
+++ b/spec_28.rst
@@ -22,10 +22,7 @@ availability.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
-
+.. include:: common/language.rst
 
 Related Standards
 -----------------

--- a/spec_28.rst
+++ b/spec_28.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_28.html
 
 28/Flux Resource Acquisition Protocol Version 1
-===============================================
+###############################################
 
 This specification describes the Flux service that schedulers use to
 acquire exclusive access to resources and monitor their ongoing
@@ -20,20 +20,19 @@ availability.
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Related Standards
------------------
+*****************
 
 - :doc:`spec_20`
 - :doc:`spec_22`
 - :doc:`spec_27`
 
-
 Background
-----------
+**********
 
 A Flux instance manages a set of resources.  This resource set may be obtained
 from a configuration file, dynamically discovered, or assigned by the enclosing
@@ -59,9 +58,8 @@ availability changes.
 Version 1 of this protocol supports a static resource set per Flux instance.
 Resource *grow* and *shrink* are to be handled by a future protocol revision.
 
-
 Design Criteria
----------------
+***************
 
 - Provide resource discovery service to scheduler implementations.
 
@@ -74,23 +72,20 @@ Design Criteria
 
 - Support administrative exclusion of execution targets.
 
-
 Implementation
---------------
+**************
 
 The scheduler SHALL send a ``resource.acquire`` streaming RPC request at
 initialization to obtain resources to be used for scheduling and monitor
 changes in status.
 
-
 Acquire Request
-^^^^^^^^^^^^^^^
+===============
 
 The ``resource.acquire`` request has no payload.
 
-
 Initial Acquire Response
-^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------
 
 The initial ``resource.acquire`` response SHALL include the following keys:
 
@@ -131,9 +126,8 @@ Example:
       "up": "0-2"
    }
 
-
 Additional Acquire Responses
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+----------------------------
 
 Subsequent ``resource.acquire`` responses SHALL include one or more
 of the following OPTIONAL keys:
@@ -189,16 +183,15 @@ request for the offline resources.
   in the protocol.
 
 Error Response
-^^^^^^^^^^^^^^
+--------------
 
 If an error response is returned to ``resource.acquire``, the scheduler
 should log the error and exit the reactor, as failure indicates either a
 catastrophic error, a failure to acquire any resources, or a failure to
 conform to this protocol.
 
-
 Disconnect Request
-^^^^^^^^^^^^^^^^^^
+==================
 
 If the scheduler is unloaded, a disconnect request is automatically sent to
 the flux-core resource module.  This cancels the ``resource.acquire`` request

--- a/spec_28.rst
+++ b/spec_28.rst
@@ -9,12 +9,15 @@ This specification describes the Flux service that schedulers use to
 acquire exclusive access to resources and monitor their ongoing
 availability.
 
--  Name: github.com/flux-framework/rfc/spec_28.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Jim Garlick <garlick@llnl.gov>
-
--  State: raw
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_28.rst
+  * - **Editor**
+    - Jim Garlick <garlick@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_28.rst
+++ b/spec_28.rst
@@ -27,11 +27,9 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 -----------------
 
--  :doc:`20/Resource Set Specification Version 1 <spec_20>`
-
--  :doc:`22/Idset String Representation <spec_22>`
-
--  :doc:`27/Flux Resource Allocation Protocol Version 1 <spec_27>`
+- :doc:`spec_20`
+- :doc:`spec_22`
+- :doc:`spec_27`
 
 
 Background

--- a/spec_29.rst
+++ b/spec_29.rst
@@ -21,10 +21,7 @@ hostnames which contain an optional numerical part.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
-
+.. include:: common/language.rst
 
 Background
 ----------

--- a/spec_29.rst
+++ b/spec_29.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_29.html
 
 29/Hostlist Format
-==================
+##################
 
 This specification describes a compact form for expressing a list of
 hostnames which contain an optional numerical part.
@@ -19,12 +19,12 @@ hostnames which contain an optional numerical part.
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Background
-----------
+**********
 
 The *hostlist* is a somewhat well known format supported by
 existing HPC tools such as `pdsh <https://github.com/chaos/pdsh>`_,
@@ -37,7 +37,7 @@ a possibly large list of hosts by name, e.g. ``prefix[0-1024]``.
 This RFC details the Flux implementation of the hostlist format.
 
 Implementation
---------------
+**************
 
 A *hostlist* SHALL represent an ordered list of strings.
 
@@ -71,7 +71,7 @@ Within a *hostlist expression*, an *idlist* SHALL be enclosed in square
 brackets, e.g. ``host[0-10,12]``.
 
 Test Vectors
-------------
+************
 
  - ``""`` = ``""``
  - ``"foox,fooy,fooz"`` = ``"foox,fooy,fooz"``

--- a/spec_29.rst
+++ b/spec_29.rst
@@ -8,12 +8,15 @@
 This specification describes a compact form for expressing a list of
 hostnames which contain an optional numerical part.
 
--  Name: github.com/flux-framework/rfc/spec_29.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Mark A. Grondona <mgrondona@llnl.gov>
-
--  State: raw
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_29.rst
+  * - **Editor**
+    - Mark A. Grondona <mgrondona@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_3.rst
+++ b/spec_3.rst
@@ -9,12 +9,15 @@
 This specification describes the format of Flux message broker
 messages, Version 1.
 
--  Name: github.com/flux-framework/rfc/spec_3.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Jim Garlick <garlick@llnl.gov>
-
--  State: draft
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_3.rst
+  * - **Editor**
+    - Jim Garlick <garlick@llnl.gov>
+  * - **State**
+    - draft
 
 ********
 Language

--- a/spec_3.rst
+++ b/spec_3.rst
@@ -29,10 +29,8 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 *****************
 
--  :doc:`6/Flux Remote Procedure Call Protocol <spec_6>`
-
--  :doc:`12/Flux Security Architecture <spec_12>`
-
+- :doc:`spec_6`
+- :doc:`spec_12`
 - `ZeroMQ Message Transfer Protocol (ZMTP) <https://rfc.zeromq.org/spec:23/ZMTP>`_
 
 

--- a/spec_3.rst
+++ b/spec_3.rst
@@ -2,7 +2,6 @@
    GitHub is NOT the preferred viewer for this file. Please visit
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_3.html
 
-#######################
 3/Flux Message Protocol
 #######################
 
@@ -19,13 +18,11 @@ messages, Version 1.
   * - **State**
     - draft
 
-********
 Language
 ********
 
 .. include:: common/language.rst
 
-*****************
 Related Standards
 *****************
 
@@ -33,8 +30,6 @@ Related Standards
 - :doc:`spec_12`
 - `ZeroMQ Message Transfer Protocol (ZMTP) <https://rfc.zeromq.org/spec:23/ZMTP>`_
 
-
-*****
 Goals
 *****
 
@@ -63,7 +58,6 @@ the following specific goals:
 -  Ensure that messages between any pair of endpoints are received in
    transmission order.
 
-**********
 Background
 **********
 
@@ -111,8 +105,6 @@ There are four distinct Flux message types:  *request* and *response* messages
 for remote procedure call;  *event* messages for publish-subscribe, and
 *control* messages for internal use by the overlay network implementation.
 
-
-**************
 Implementation
 **************
 
@@ -139,7 +131,7 @@ example, a ZeroMQ ROUTER socket implements source-address routing by adding
 a message part in one direction and removing one in the opposite direction.
 
 Optional Message Parts
-^^^^^^^^^^^^^^^^^^^^^^
+----------------------
 
 The following message parts MAY appear in Flux messages, in the following
 order:
@@ -165,7 +157,7 @@ payload
   content.
 
 Required Message Parts
-^^^^^^^^^^^^^^^^^^^^^^
+----------------------
 
 Flux messages are REQUIRED to have one message part that acts as a protocol
 header and is encoded as described by the following ABNF [#f2]_ grammar.
@@ -241,7 +233,6 @@ following about the message header:
    ; unused 4-byte field
    unused          = %x00.00.00.00
 
-
 Request Message Type
 ====================
 
@@ -270,7 +261,7 @@ the following rules apply:
   be suppressed.
 
 Request Routing
-^^^^^^^^^^^^^^^
+---------------
 
 Request messages received by a broker are routed in three ways, depending on
 the value of the *nodeid* header field and the *upstream* header flag:
@@ -306,7 +297,6 @@ as in the first case, until a service is matched or an error is generated.
   upstream broker's rank, but that requires knowledge of the topology, which
   is a little more involved than setting a message flag.
 
-
 Response Message Type
 =====================
 
@@ -332,7 +322,6 @@ the following rules apply:
 
    Example of (a) Flux request message, and (b) Flux response message.  Integer
    values are in hex.
-
 
 Event Message Type
 ==================
@@ -378,7 +367,6 @@ the following rules apply:
   also used between broker modules and the broker module loader to communicate
   module status.  Since they are not routed, they are not of much use outside
   of those contexts.
-
 
 Payload Conventions
 ===================
@@ -443,6 +431,8 @@ their length fields.
    Example of a Flux request message with framing for transmission over a
    UNIX domain stream socket.
 
+References
+**********
 
 .. [#f1] `RFC 7159: The JavaScript Object Notation (JSON) Data Interchange Format <https://www.rfc-editor.org/rfc/rfc7159.txt>`__, T. Bray, Google, Inc, March 2014.
 

--- a/spec_3.rst
+++ b/spec_3.rst
@@ -23,10 +23,7 @@ messages, Version 1.
 Language
 ********
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
-
+.. include:: common/language.rst
 
 *****************
 Related Standards

--- a/spec_30.rst
+++ b/spec_30.rst
@@ -7,12 +7,15 @@
 
 This specification describes the Flux job urgency parameter.
 
--  Name: github.com/flux-framework/rfc/spec_30.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Jim Garlick <garlick@llnl.gov>
-
--  State: raw
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_30.rst
+  * - **Editor**
+    - Jim Garlick <garlick@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_30.rst
+++ b/spec_30.rst
@@ -24,7 +24,7 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 -----------------
 
--  :doc:`21/Job States and Events <spec_21>`
+- :doc:`spec_21`
 
 
 Background

--- a/spec_30.rst
+++ b/spec_30.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_30.html
 
 30/Job Urgency
-==============
+##############
 
 This specification describes the Flux job urgency parameter.
 
@@ -18,18 +18,18 @@ This specification describes the Flux job urgency parameter.
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Related Standards
------------------
+*****************
 
 - :doc:`spec_21`
 
 
 Background
-----------
+**********
 
 The Flux job *urgency* parameter reflects the job owner's idea of the job's
 importance relative to other work queued on the system.  It is one factor
@@ -40,9 +40,8 @@ presented to the scheduler.
 The urgency MAY be provided by the job owner at job submission time.
 It MAY be adjusted by the job owner while the job is pending.
 
-
 Implementation
---------------
+**************
 
 Job *urgency* SHALL be an integer with range of 0 through 31.
 

--- a/spec_30.rst
+++ b/spec_30.rst
@@ -20,9 +20,7 @@ This specification describes the Flux job urgency parameter.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
+.. include:: common/language.rst
 
 Related Standards
 -----------------

--- a/spec_31.rst
+++ b/spec_31.rst
@@ -22,8 +22,8 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 -----------------
 
--  :doc:`14/Canonical Job Specification <spec_14>`
--  :doc:`20/Resource Set Specification Version 1 <spec_20>`
+- :doc:`spec_14`
+- :doc:`spec_20`
 
 Goals
 -----

--- a/spec_31.rst
+++ b/spec_31.rst
@@ -21,9 +21,7 @@ job constraints.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
+.. include:: common/language.rst
 
 Related Standards
 -----------------

--- a/spec_31.rst
+++ b/spec_31.rst
@@ -8,9 +8,15 @@
 This specification describes an extensible format for the description of
 job constraints.
 
--  Name: github.com/flux-framework/rfc/spec_31.rst
--  Editor: Mark A. Grondona <mgrondona@llnl.gov>
--  State: raw
+.. list-table::
+  :widths: 25 75
+
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_31.rst
+  * - **Editor**
+    - Mark A. Grondona <mgrondona@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_31.rst
+++ b/spec_31.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_31.html
 
 31/Job Constraints Specification
-================================
+################################
 
 This specification describes an extensible format for the description of
 job constraints.
@@ -19,24 +19,24 @@ job constraints.
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Related Standards
------------------
+*****************
 
 - :doc:`spec_14`
 - :doc:`spec_20`
 
 Goals
------
+*****
 
 -  Define a format for the specification of general constraints in jobspec
 -  Embed extensibility into the format to allow for growth of feature set
 
 Background
-----------
+**********
 
 It is common practice for resource management systems to allow job
 requests to contain constraints beyond the size and count of resources
@@ -49,7 +49,7 @@ This RFC defines an extensible format for the specification of job
 constraints in JSON.
 
 Representation
---------------
+**************
 
 Job constraints SHALL be represented as a JSON object, which loosely
 follows the `JsonLogic <https://jsonlogic.com/>`_ format of
@@ -114,7 +114,7 @@ In addition, an empty constraint object ``{}`` is similarly defined to
 "always match".
 
 Examples
---------
+********
 
 Constrain resources such that all execution targets have property ``ssd``:
 

--- a/spec_32.rst
+++ b/spec_32.rst
@@ -8,12 +8,15 @@
 This specification describes Version 1 of the Flux Job Execution Protocol
 implemented by the job manager and job execution system.
 
--  Name: github.com/flux-framework/rfc/spec_32.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Jim Garlick <garlick@llnl.gov>
-
--  State: raw
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_32.rst
+  * - **Editor**
+    - Jim Garlick <garlick@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_32.rst
+++ b/spec_32.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_32.html
 
 32/Flux Job Execution Protocol Version 1
-========================================
+########################################
 
 This specification describes Version 1 of the Flux Job Execution Protocol
 implemented by the job manager and job execution system.
@@ -19,12 +19,12 @@ implemented by the job manager and job execution system.
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Related Standards
------------------
+*****************
 
 - :doc:`spec_14`
 - :doc:`spec_15`
@@ -33,7 +33,7 @@ Related Standards
 - :doc:`spec_27`
 
 Background
-----------
+**********
 
 The job execution service launches Flux job shells on execution targets at
 the behest of the job manager.  The job shells in turn launch one or more
@@ -54,7 +54,7 @@ aspects of launching a job as another user are not reflected in the job
 execution protocol.
 
 Design Criteria
----------------
+***************
 
 The job execution protocol must adhere to these criteria:
 
@@ -77,7 +77,7 @@ The job execution protocol must adhere to these criteria:
 - Support execution service override by the Flux simulator.
 
 Implementation
---------------
+**************
 
 As with the scheduler RPCs described in RFC 27, ``<service>.start`` RPCs use
 the job ID to match requests and responses, and set the RFC 6 matchtag message
@@ -103,7 +103,7 @@ field to zero.  It follows that:
 The other RPCs behave conventionally.
 
 Hello
-~~~~~
+=====
 
 The Flux execution service SHALL register a service name with the job manager
 on initialization.  This service MAY be ``job-exec`` or another name.  The
@@ -130,7 +130,7 @@ existing execution service.  The execution service SHALL treat a failure
 response to ``exec-hello`` as fatal.
 
 Start Request
-~~~~~~~~~~~~~
+=============
 
 Once the execution service is registered, the job manager SHALL send
 ``<service>.start`` requests for any jobs that have been allocated resources.

--- a/spec_32.rst
+++ b/spec_32.rst
@@ -21,10 +21,7 @@ implemented by the job manager and job execution system.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
-
+.. include:: common/language.rst
 
 Related Standards
 -----------------

--- a/spec_32.rst
+++ b/spec_32.rst
@@ -26,15 +26,11 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 -----------------
 
--  :doc:`14/Canonical Job Specification <spec_14>`
-
--  :doc:`15/Independent Minister of Privilege for Flux:  The Security IMP <spec_15>`
-
--  :doc:`16/KVS Job Schema <spec_16>`
-
--  :doc:`21/Job States and Events <spec_21>`
-
--  :doc:`27/Flux Resource Allocation Protocol Version 1 <spec_27>`
+- :doc:`spec_14`
+- :doc:`spec_15`
+- :doc:`spec_16`
+- :doc:`spec_21`
+- :doc:`spec_27`
 
 Background
 ----------

--- a/spec_33.rst
+++ b/spec_33.rst
@@ -21,9 +21,7 @@ user-visible container for job requests sorted by priority.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
+.. include:: common/language.rst
 
 Related Standards
 -----------------

--- a/spec_33.rst
+++ b/spec_33.rst
@@ -8,12 +8,15 @@
 This specification describes Flux Job Queues.  A Flux Job Queue is a named,
 user-visible container for job requests sorted by priority.
 
+.. list-table::
+  :widths: 25 75
 
--  Name: github.com/flux-framework/rfc/spec_33.rst
-
--  Editor: Jim Garlick <garlick@llnl.gov>
-
--  State: raw
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_33.rst
+  * - **Editor**
+    - Jim Garlick <garlick@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_33.rst
+++ b/spec_33.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_33.html
 
 33/Flux Job Queues
-==================
+##################
 
 This specification describes Flux Job Queues.  A Flux Job Queue is a named,
 user-visible container for job requests sorted by priority.
@@ -19,12 +19,12 @@ user-visible container for job requests sorted by priority.
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Related Standards
------------------
+*****************
 
 - :doc:`spec_14`
 - :doc:`spec_20`
@@ -32,7 +32,7 @@ Related Standards
 - :doc:`spec_27`
 
 Background
-----------
+**********
 
 Support for multiple queues is motivated by the following use cases:
 
@@ -56,7 +56,7 @@ Support for multiple queues is motivated by the following use cases:
    https://github.com/flux-framework/flux-core/issues/4306
 
 Design Criteria
----------------
+***************
 
 - Handle the motivating use cases in the background section.
 
@@ -76,7 +76,7 @@ Design Criteria
   "expedite", or "exempt" queues).
 
 Implementation
---------------
+**************
 
 A Flux Job Queue is a user-visible container for job requests stored in
 priority order.
@@ -102,7 +102,7 @@ Queues MAY be independently configured with:
 - resource subset
 
 Policy Configuration
-~~~~~~~~~~~~~~~~~~~~
+====================
 
 A ``policy`` TOML table MAY specify queue policy that applies to all queues,
 including the anonymous one, unless overridden on a per-queue basis.  This
@@ -113,7 +113,7 @@ Each queue MAY contain a ``policy`` table.  If present, queue-specific policy
 values SHALL override global policy values.
 
 Jobspec Defaults Policy
-^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------
 
 The ``policy.jobspec.defaults`` table contains default values for jobspec
 attributes that were not explicitly set by the user and MAY contain following
@@ -132,7 +132,7 @@ policy.jobspec.defaults.system.queue
    remains within the signed ``J`` key.
 
 Limits Policy
-^^^^^^^^^^^^^
+-------------
 
 The ``policy.limits`` table configures job limits and MAY contain the following
 OPTIONAL keys.
@@ -153,18 +153,18 @@ policy.limits.duration
   (string) maximum job duration, in Flux Standard Duration format (RFC 23).
 
 Scheduler Policy
-^^^^^^^^^^^^^^^^
+----------------
 
 The ``policy.scheduler`` table is read by the scheduler implementation
 and is opaque to the rest of Flux.
 
 Priority Policy
-^^^^^^^^^^^^^^^
+---------------
 
 TBD
 
 Access Policy
-^^^^^^^^^^^^^
+-------------
 
 The ``policy.access`` table MAY restrict queue access by UNIX user and group.
 It MAY contain following OPTIONAL keys:
@@ -184,7 +184,7 @@ the flux-accounting multi-factor priority plugin controls access to queues
 based on the user and bank information from the accounting database.
 
 Queue Configuration
-~~~~~~~~~~~~~~~~~~~
+===================
 
 A ``queues`` TOML table MAY define one or more named queues.  Each queue
 SHALL be represented as a sub-table that MAY contain the following OPTIONAL
@@ -203,9 +203,8 @@ queues.NAME.policy
   top-level ``policy`` table  and a queue-specific ``policy`` table, the
   queue-specific value takes precedence for jobs submitted to that queue.
 
-
 Initial Assignment of Job to Queue
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------
 
 Job requests MAY specify a queue name at submission time by setting the
 ``system.queue`` jobspec attribute (RFC 14).  If a queue was not explicitly
@@ -213,14 +212,14 @@ named in the jobspec, and a default queue is defined, the queue SHALL be
 assigned by before the jobtap ``job.validate`` callbacks are run.
 
 Request Validation
-~~~~~~~~~~~~~~~~~~
+------------------
 
 A job request SHALL be rejected on submission if it names an unknown queue,
 or if it is possible to determine that the job would exceed limits or violate
 access policy of the assigned queue.
 
 Administrative Tools
-~~~~~~~~~~~~~~~~~~~~
+====================
 
 A Flux command line tool SHALL provide the ability to enable/disable job
 submission on each queue individually, or on all queues.
@@ -237,7 +236,7 @@ become idle, or for all queues to become idle, where idle is defined as
 containing no jobs in RUN or CLEANUP state.
 
 Job Submission and Listing Tools
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------
 
 Job submission and listing tools SHOULD NOT need to parse the ``queues``
 TOML table.

--- a/spec_33.rst
+++ b/spec_33.rst
@@ -25,13 +25,10 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 -----------------
 
--  :doc:`14/Canonical Job Specification <spec_14>`
-
--  :doc:`20/Resource Set Specification Version 1 <spec_20>`
-
--  :doc:`21/Job States and Events <spec_21>`
-
--  :doc:`27/Flux Resource Allocation Protocol Version 1 <spec_27>`
+- :doc:`spec_14`
+- :doc:`spec_20`
+- :doc:`spec_21`
+- :doc:`spec_27`
 
 Background
 ----------

--- a/spec_34.rst
+++ b/spec_34.rst
@@ -22,9 +22,7 @@ The Flux Task Map is a compact mapping between job task ranks and node IDs.
 Language
 ********
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
+.. include:: common/language.rst
 
 *****************
 Related Standards

--- a/spec_34.rst
+++ b/spec_34.rst
@@ -26,11 +26,9 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 *****************
 
-- :doc:`13/Simple Process Manager Interface v1 <spec_13>`
-
-- :doc:`20/Resource Set Specification <spec_20>`
-
-- :doc:`22/Idset String Representation <spec_22>`
+- :doc:`spec_13`
+- :doc:`spec_20`
+- :doc:`spec_22`
 
 **********
 Background

--- a/spec_34.rst
+++ b/spec_34.rst
@@ -8,11 +8,15 @@
 
 The Flux Task Map is a compact mapping between job task ranks and node IDs.
 
-- Name: github.com/flux-framework/rfc/spec_34.rst
+.. list-table::
+  :widths: 25 75
 
-- Editor: Jim Garlick <garlick@llnl.gov>
-
-- State: raw
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_34.rst
+  * - **Editor**
+    - Jim Garlick <garlick@llnl.gov>
+  * - **State**
+    - raw
 
 ********
 Language

--- a/spec_34.rst
+++ b/spec_34.rst
@@ -2,7 +2,6 @@
    GitHub is NOT the preferred viewer for this file. Please visit
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_34.html
 
-################
 34/Flux Task Map
 ################
 
@@ -18,13 +17,11 @@ The Flux Task Map is a compact mapping between job task ranks and node IDs.
   * - **State**
     - raw
 
-********
 Language
 ********
 
 .. include:: common/language.rst
 
-*****************
 Related Standards
 *****************
 
@@ -32,7 +29,6 @@ Related Standards
 - :doc:`spec_20`
 - :doc:`spec_22`
 
-**********
 Background
 **********
 
@@ -56,7 +52,6 @@ A task map can naively represented as a node ID-ordered list of RFC 22 idsets,
 with each idset separated by a semicolon.  We use this format when defining
 test vectors and refer to it as the *raw task map*.
 
-*****
 Goals
 *****
 
@@ -68,7 +63,6 @@ Goals
 
 - Allow custom mappings to be expressed.
 
-************************
 Existing Implementations
 ************************
 
@@ -108,7 +102,6 @@ task map for 1M tasks distributed over 4K nodes in block distribution is
 compact as shown above, but the same job with a cyclic distribution (stride
 of 1) is a string of 2824 characters.
 
-**************
 Implementation
 **************
 
@@ -176,7 +169,6 @@ Example:
 
   {"version":1, "map":[[0,4096,256,1]]}
 
-************
 Test Vectors
 ************
 

--- a/spec_35.rst
+++ b/spec_35.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_31.html
 
 35/Constraint Query Syntax
-==========================
+##########################
 
 This specification describes a simple string syntax which can be used to
 succinctly express constraints as described in RFC 31. The syntax may
@@ -21,23 +21,23 @@ parts of Flux.
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Related Standards
------------------
+*****************
 
 - :doc:`spec_31`
 
 Goals
------
+*****
 
 -  Describe and define a grammar for a simple text-based string syntax for
    generating JSON objects in the constraint format defined in RFC 31.
 
 Background
-----------
+**********
 
 The JSON constraint format described in RFC 31 is not conducive to use
 on the command line or for other cases where constraints are input by
@@ -52,7 +52,7 @@ by Flux tools and commands to generate RFC 31 compatible JSON constraint
 objects.
 
 Description
------------
+***********
 
  * A constraint query string is formed by a series of terms.
  * A term has the form ``operator:operand``, where ``operator:`` is
@@ -73,7 +73,7 @@ Description
    of general expressions, e.g. ``-(a|b)`` SHALL be a syntax error.
 
 Grammar
--------
+*******
 
 The basic grammar for the constraint query language is
 
@@ -107,7 +107,7 @@ The basic grammar for the constraint query language is
      : STRING
 
 Examples
---------
+********
 
 The following examples assume a default operator of ``name``
 

--- a/spec_35.rst
+++ b/spec_35.rst
@@ -10,9 +10,15 @@ succinctly express constraints as described in RFC 31. The syntax may
 also be useful in generating search and match expressions for use in other
 parts of Flux.
 
--  Name: github.com/flux-framework/rfc/spec_35.rst
--  Editor: Mark A. Grondona <mgrondona@llnl.gov>
--  State: raw
+.. list-table::
+  :widths: 25 75
+
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_35.rst
+  * - **Editor**
+    - Mark A. Grondona <mgrondona@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_35.rst
+++ b/spec_35.rst
@@ -23,9 +23,7 @@ parts of Flux.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
+.. include:: common/language.rst
 
 Related Standards
 -----------------

--- a/spec_35.rst
+++ b/spec_35.rst
@@ -24,7 +24,7 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 -----------------
 
--  :doc:`31/Job Constraints Specification <spec_31>`
+- :doc:`spec_31`
 
 Goals
 -----

--- a/spec_36.rst
+++ b/spec_36.rst
@@ -21,9 +21,7 @@ directives into a file for use by utilities that submit jobs to Flux.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
+.. include:: common/language.rst
 
 Goals
 -----

--- a/spec_36.rst
+++ b/spec_36.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_31.html
 
 36/Submission Directives
-========================
+########################
 
 This specification describes a method for embedding options and other
 directives into a file for use by utilities that submit jobs to Flux.
@@ -19,12 +19,12 @@ directives into a file for use by utilities that submit jobs to Flux.
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Goals
------
+*****
 
 - Describe an understandable and easily processed syntax for embedding
   job submission utility options and other directives into a file or
@@ -35,7 +35,7 @@ Goals
 - Allow future extensions to increase the versatility of the syntax
 
 Background
-----------
+**********
 
 Many extant and moribund computational batch systems support embedding job
 submission options within a submitted batch script. For example LoadLeveler's
@@ -44,9 +44,8 @@ submission options within a submitted batch script. For example LoadLeveler's
 options may result in unnecessary copies of batch scripts, the practice
 is well established and many users are now dependent on this behavior.
 
-
 Description
------------
+***********
 
  * An option, flag, or other directive embedded in a file or script SHALL
    be known as a *submission directive*.
@@ -110,7 +109,7 @@ Description
    processing submission utility.
 
 Examples
---------
+********
 
  * Directives in a shell script, maximum nostalgia mode:
 
@@ -197,5 +196,7 @@ Examples
    hostname; date
    #FLUX: --job-name=test
 
+References
+**********
 
 .. [#f1] `Shell Command Language: Quoting <https://pubs.opengroup.org/onlinepubs/009604499/utilities/xcu_chap02.html>`__; The Open Group Base Specifications Issue 6; IEEE Std 1003.1, 2004 Edition

--- a/spec_36.rst
+++ b/spec_36.rst
@@ -8,9 +8,15 @@
 This specification describes a method for embedding options and other
 directives into a file for use by utilities that submit jobs to Flux.
 
--  Name: github.com/flux-framework/rfc/spec_36.rst
--  Editor: Mark A. Grondona <mgrondona@llnl.gov>
--  State: raw
+.. list-table::
+  :widths: 25 75
+
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_36.rst
+  * - **Editor**
+    - Mark A. Grondona <mgrondona@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_37.rst
+++ b/spec_37.rst
@@ -2,7 +2,6 @@
    GitHub is NOT the preferred viewer for this file. Please visit
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_37.html
 
-######################
 37/File Archive Format
 ######################
 
@@ -19,20 +18,17 @@ of file system objects.
   * - **State**
     - raw
 
-********
 Language
 ********
 
 .. include:: common/language.rst
 
-*****************
 Related Standards
 *****************
 
 - :doc:`spec_10`
 - :doc:`spec_14`
 
-**********
 Background
 **********
 
@@ -43,7 +39,6 @@ The File Archive Format is a container of file system objects envisioned for:
 
 - Stage-in and stage-out of job data sets.
 
-*****
 Goals
 *****
 
@@ -64,7 +59,6 @@ Goals
 
 - Enable efficient representation of sparse files.
 
-**************
 Implementation
 **************
 
@@ -144,7 +138,7 @@ Regular Files
 Regular files are represented as follows.
 
 Empty Files
-^^^^^^^^^^^
+-----------
 
 An empty regular file (zero length or sparse with no data) SHALL be
 represented with **size** set to the file size and no **encoding** or
@@ -163,7 +157,7 @@ Example:
   }
 
 JSON Content
-^^^^^^^^^^^^
+------------
 
 A regular file with JSON content MAY be represented without encoding.
 In this case, **size** and **encoding** SHALL NOT be set and **data** SHALL
@@ -186,7 +180,7 @@ Example:
   }
 
 Text Content
-^^^^^^^^^^^^
+------------
 
 A regular file containing text MAY be represented with UTF-8 encoding.
 In this case, **size** SHALL be set to the file size, **encoding** SHALL be
@@ -205,7 +199,7 @@ Example:
   }
 
 Literal Binary Content
-^^^^^^^^^^^^^^^^^^^^^^
+----------------------
 
 A regular file that requires a self-contained representation in the archive
 and whose content is unknown SHALL be represented with base64 encoding.
@@ -225,7 +219,7 @@ Example:
   }
 
 Referenced Binary Content
-^^^^^^^^^^^^^^^^^^^^^^^^^
+-------------------------
 
 A regular file that requires content to be referenced to the associative cache
 described in RFC 10 SHALL be represented with blobvec encoding.  In this case,
@@ -267,5 +261,8 @@ Example:
 
 .. note::
   Only blobvec encoding is capable of representing non-empty sparse files.
+
+References
+**********
 
 .. [#f1] `sys/stat.h - data returned by the stat() function sys/stat.h <https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_stat.h.html>`__; The Open Group Base Specifications Issue 7, 2018 edition IEEE Std 1003.1-2017 (Revision of IEEE Std 1003.1-2008)

--- a/spec_37.rst
+++ b/spec_37.rst
@@ -27,9 +27,8 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 *****************
 
-- :doc:`10/Content Storage <spec_10>`
-
-- :doc:`14/Canonical Job Specification <spec_14>`
+- :doc:`spec_10`
+- :doc:`spec_14`
 
 **********
 Background

--- a/spec_37.rst
+++ b/spec_37.rst
@@ -9,11 +9,15 @@
 The File Archive Format defines a JSON representation of a set or list
 of file system objects.
 
-- Name: github.com/flux-framework/rfc/spec_37.rst
+.. list-table::
+  :widths: 25 75
 
-- Editor: Jim Garlick <garlick@llnl.gov>
-
-- State: raw
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_37.rst
+  * - **Editor**
+    - Jim Garlick <garlick@llnl.gov>
+  * - **State**
+    - raw
 
 ********
 Language

--- a/spec_37.rst
+++ b/spec_37.rst
@@ -23,9 +23,7 @@ of file system objects.
 Language
 ********
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
+.. include:: common/language.rst
 
 *****************
 Related Standards

--- a/spec_38.rst
+++ b/spec_38.rst
@@ -23,9 +23,7 @@ for a series of typed key-value pairs.
 Language
 ********
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
+.. include:: common/language.rst
 
 *****************
 Related Standards

--- a/spec_38.rst
+++ b/spec_38.rst
@@ -9,11 +9,15 @@
 The Flux Security Key Value Encoding is a serialization format
 for a series of typed key-value pairs.
 
-- Name: github.com/flux-framework/rfc/spec_38.rst
+.. list-table::
+  :widths: 25 75
 
-- Editor: Jim Garlick <garlick@llnl.gov>
-
-- State: raw
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_38.rst
+  * - **Editor**
+    - Jim Garlick <garlick@llnl.gov>
+  * - **State**
+    - raw
 
 ********
 Language

--- a/spec_38.rst
+++ b/spec_38.rst
@@ -2,7 +2,6 @@
    GitHub is NOT the preferred viewer for this file. Please visit
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_38.html
 
-###################################
 38/Flux Security Key Value Encoding
 ###################################
 
@@ -19,19 +18,16 @@ for a series of typed key-value pairs.
   * - **State**
     - raw
 
-********
 Language
 ********
 
 .. include:: common/language.rst
 
-*****************
 Related Standards
 *****************
 
 - :doc:`spec_15`
 
-**********
 Background
 **********
 
@@ -43,7 +39,6 @@ communication in the following security-sensitive situations:
 - When communicating options between privileged and unprivileged sections
   of the IMP.
 
-*****
 Goals
 *****
 
@@ -57,7 +52,6 @@ Goals
 
 - Design should allow for a simple, embedded C implementation.
 
-**************
 Implementation
 **************
 
@@ -97,7 +91,6 @@ e.g.  ``key\0Tvalue\0key\0Tvalue\0...key\0Tvalue\0``.
 An implementation defined limit SHALL be imposed on the maximum overall size
 of a serialized object to avoid resource exhaustion.
 
-************
 Test Vectors
 ************
 

--- a/spec_38.rst
+++ b/spec_38.rst
@@ -27,7 +27,7 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 *****************
 
-- :doc:`15/Independent Minister of Privilege for Flux: The Security IMP <spec_15>`
+- :doc:`spec_15`
 
 **********
 Background

--- a/spec_39.rst
+++ b/spec_39.rst
@@ -9,11 +9,15 @@
 The Flux Security Signature is a NUL terminated string that represents
 content secured with a digital signature.
 
-- Name: github.com/flux-framework/rfc/spec_39.rst
+.. list-table::
+  :widths: 25 75
 
-- Editor: Jim Garlick <garlick@llnl.gov>
-
-- State: raw
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_39.rst
+  * - **Editor**
+    - Jim Garlick <garlick@llnl.gov>
+  * - **State**
+    - raw
 
 ********
 Language

--- a/spec_39.rst
+++ b/spec_39.rst
@@ -27,11 +27,9 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 *****************
 
-- :doc:`14/Canonical Job Specification <spec_14>`
-
-- :doc:`15/Independent Minister of Privilege for Flux: The Security IMP <spec_15>`
-
-- :doc:`38/Flux Security Key Value Encoding <spec_38>`
+- :doc:`spec_14`
+- :doc:`spec_15`
+- :doc:`spec_38`
 
 **********
 Background

--- a/spec_39.rst
+++ b/spec_39.rst
@@ -23,9 +23,7 @@ content secured with a digital signature.
 Language
 ********
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
+.. include:: common/language.rst
 
 *****************
 Related Standards

--- a/spec_39.rst
+++ b/spec_39.rst
@@ -2,7 +2,6 @@
    GitHub is NOT the preferred viewer for this file. Please visit
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_39.html
 
-##########################
 39/Flux Security Signature
 ##########################
 
@@ -19,13 +18,11 @@ content secured with a digital signature.
   * - **State**
     - raw
 
-********
 Language
 ********
 
 .. include:: common/language.rst
 
-*****************
 Related Standards
 *****************
 
@@ -33,7 +30,6 @@ Related Standards
 - :doc:`spec_15`
 - :doc:`spec_38`
 
-**********
 Background
 **********
 
@@ -52,7 +48,6 @@ are passed to the IMP exactly as specified by the user.
 RFC 15 refers to the signed jobspec as *J*.  The content of *J* is thus fully
 specified by this document and RFC 14.
 
-*****
 Goals
 *****
 
@@ -66,7 +61,6 @@ Goals
 
 - The signature SHOULD support a configurable time-to-live.
 
-**************
 Implementation
 **************
 
@@ -103,7 +97,6 @@ userid (integer)
 
 Mechanism-specific keys MAY also be included in the header.
 
-**********
 Mechanisms
 **********
 

--- a/spec_4.rst
+++ b/spec_4.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_4.html
 
 4/Flux Resource Model
-=====================
+#####################
 
 The Flux Resource Model describes the conceptual model used for
 resources within the Flux framework.
@@ -19,18 +19,17 @@ resources within the Flux framework.
     - draft
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Related Standards
------------------
+*****************
 
 - :doc:`spec_14`
 
-
 Goals
------
+*****
 
 The Flux Resource Model provides a common conceptual model for resources
 described and managed by the Flux framework and its components. The
@@ -44,9 +43,8 @@ goals of this model are to:
 -  Provide a common storage, access, modification and discovery APIs for
    managing resource information
 
-
 Background
-----------
+**********
 
 As in traditional resource management software, the Flux framework
 requires a method for the description, configuration, tracking, and
@@ -60,9 +58,8 @@ computing (HPC) resources in relation to other resource management components.
 We term the model for describing resources in Flux
 *The Flux Resource Model*.
 
-
 The Flux Resource Model
------------------------
+***********************
 
 The Flux Resource Model combines two basic concepts to describe
 individual resources and various relationships among them.
@@ -107,9 +104,8 @@ connected by these edges SHALL represent a unique subsystem
 of resources (e.g., a compute subsystem, a parallel
 I/O subsystem, a power subsystem, etc).
 
-
 Resource Pool Data Model
-~~~~~~~~~~~~~~~~~~~~~~~~
+========================
 
 This section describes the resource pool data required
 to be stored, tracked, and queried.
@@ -158,9 +154,8 @@ It MAY include, but be not limited to:
 
 -  Scheduling state data such as job allocations and reservations
 
-
 Graph Data Model
-~~~~~~~~~~~~~~~~
+================
 
 A graph consists of a set of vertices and edges.
 The Flux Resource Model uses a vertex to represent a resource pool.
@@ -223,9 +218,8 @@ if this graph belongs to that named hierarchy. Similarly, if the graph
 shown in Figure 2 is a part of the I/O data path of a parallel file system,
 PFS1, its name MAY be "PFS1 I/O bandwidth hierarchy."
 
-
 Common Patterns
----------------
+***************
 
 The Flux Resource Model SHALL support a range of resource sets, from
 all of the resources in the center
@@ -242,9 +236,8 @@ the nodes and cores as the finest resource granularity.
 The following provides common examples to illustrate how Flux composes
 two basic concepts to model some of the common HPC resources.
 
-
 The Composite Resource Pool
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+===========================
 
 The dominant form of the Flux Resource Model is called
 *composite resource pool*, the combination of a *composite type*
@@ -277,9 +270,8 @@ Use of the composite resource pool in Flux has the following properties:
 
 -  High level resources can be created piece-wise from base resource types.
 
-
 The Channeled Resource Pool
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+===========================
 
 As HPC centers are becoming increasingly data- and power-constrained,
 the Flux Resource Model MUST be flexible to be able to model
@@ -306,9 +298,8 @@ MAY allocate the bandwidth capacity required by a job
 on all of the distribution units that lie along the data path
 up to PFS1 when the platform is I/O bandwidth-constrained.
 
-
 Unifying Different Patterns under the Same Model
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+================================================
 
 Because any specialized form of a resource subsystem SHALL be
 itself built out of the same basic concepts, the Flux Resource Model
@@ -327,9 +318,8 @@ generalizes ways to model any resources, their individual
 relationships, and perhaps more importantly subsystems
 of these resources.
 
-
 Abstract Interfaces
--------------------
+*******************
 
 The abstract interfaces of the Flux Resource Model SHALL
 include, but not be limited to the following.
@@ -339,9 +329,8 @@ The implementors of the Flux Resource Model MAY
 use this as a guide to determine the proper abstraction
 level exposed by the implementations.
 
-
 Resource Pool
-~~~~~~~~~~~~~
+=============
 
 When operating on a resource pool as an object, the following methods
 SHALL be supported. The majority of methods are accessors.
@@ -364,9 +353,8 @@ Matching support
    filter can match on both base and extended data (e.g., tags,
    properties, size, type, name, basename, ids, etc).
 
-
 Graph
-~~~~~
+=====
 
 The following are the primary abstract types and their
 roles as relevant to the graph.

--- a/spec_4.rst
+++ b/spec_4.rst
@@ -21,10 +21,7 @@ resources within the Flux framework.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
-
+.. include:: common/language.rst
 
 Related Standards
 -----------------

--- a/spec_4.rst
+++ b/spec_4.rst
@@ -8,12 +8,15 @@
 The Flux Resource Model describes the conceptual model used for
 resources within the Flux framework.
 
--  Name: github.com/flux-framework/rfc/spec_4.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Mark Grondona <mgrondona@llnl.gov>
-
--  State: draft
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_4.rst
+  * - **Editor**
+    - Mark Grondona <mgrondona@llnl.gov>
+  * - **State**
+    - draft
 
 Language
 --------

--- a/spec_4.rst
+++ b/spec_4.rst
@@ -26,7 +26,7 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 -----------------
 
-:doc:`14/Canonical Job Specification <spec_14>`
+- :doc:`spec_14`
 
 
 Goals

--- a/spec_40.rst
+++ b/spec_40.rst
@@ -24,10 +24,7 @@ to store resource graph data in RFC 20 *R* version 1 objects.
 Language
 ********
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
-"SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL"
-in this document are to be interpreted as described in RFC 2119.
-
+.. include:: common/language.rst
 
 *****************
 Related Standards

--- a/spec_40.rst
+++ b/spec_40.rst
@@ -10,12 +10,15 @@
 This specification defines the data format used by the Fluxion scheduler
 to store resource graph data in RFC 20 *R* version 1 objects.
 
--  Name: github.com/flux-framework/rfc/spec_20.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Dong H. Ahn <ahn1@llnl.gov>
-
--  State: Raw
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_40.rst
+  * - **Editor**
+    - Dong H. Ahn <ahn1@llnl.gov>
+  * - **State**
+    - raw
 
 ********
 Language

--- a/spec_40.rst
+++ b/spec_40.rst
@@ -30,15 +30,11 @@ in this document are to be interpreted as described in RFC 2119.
 Related Standards
 *****************
 
--  :doc:`4/Flux Resource Model <spec_4>`
-
--  :doc:`14/Canonical Job Specification <spec_14>`
-
--  :doc:`20/Resource Set Specification Version 1 <spec_20>`
-
--  :doc:`27/Flux Resource Allocation Protocol Version 1 <spec_27>`
-
--  :doc:`28/Flux Resource Aquisition Protocol Version 1 <spec_28>`
+- :doc:`spec_4`
+- :doc:`spec_14`
+- :doc:`spec_20`
+- :doc:`spec_27`
+- :doc:`spec_28`
 
 
 **********

--- a/spec_40.rst
+++ b/spec_40.rst
@@ -2,8 +2,6 @@
    GitHub is NOT the preferred viewer for this file. Please visit
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_40.html
 
-
-#################################
 40/Fluxion Resource Set Extension
 #################################
 
@@ -20,13 +18,11 @@ to store resource graph data in RFC 20 *R* version 1 objects.
   * - **State**
     - raw
 
-********
 Language
 ********
 
 .. include:: common/language.rst
 
-*****************
 Related Standards
 *****************
 
@@ -36,8 +32,6 @@ Related Standards
 - :doc:`spec_27`
 - :doc:`spec_28`
 
-
-**********
 Background
 **********
 
@@ -59,7 +53,6 @@ The ``scheduling`` key is opaque to rest of Flux, but:
 This document describes the resource graph representation used by the Fluxion
 scheduler within the ``scheduling`` key of *R*.
 
-**************
 Implementation
 **************
 
@@ -71,7 +64,6 @@ extensions.  The ``graph`` key SHALL conform to the latest version of the JSON
 Graph Format (JGF).  Thus, its value is a dictionary with two keys, ``nodes``
 and ``edges``, that encode the resource vertices and edges as described in
 RFC 4.
-
 
 Graph Vertices
 ==============
@@ -103,7 +95,6 @@ keys to describe the base data of a resource pool:
 
 It MAY contain other OPTIONAL resource vertex data.
 
-
 Graph Edges
 ===========
 
@@ -127,8 +118,6 @@ as described in RFC 4. It SHALL contain two keys:
    The relationship SHALL only be defined within the subsystem defined
    above. (e.g., "contains" relationship within the "containment" subsystem).
 
-
-**********
 References
 **********
 

--- a/spec_5.rst
+++ b/spec_5.rst
@@ -26,7 +26,7 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 -----------------
 
--  :doc:`3/Flux Message Protocol <spec_3>`
+- :doc:`spec_3`
 
 
 Background

--- a/spec_5.rst
+++ b/spec_5.rst
@@ -8,12 +8,15 @@
 This specification describes the broker extension modules
 used to implement Flux services.
 
--  Name: github.com/flux-framework/rfc/spec_5.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Jim Garlick <garlick@llnl.gov>
-
--  State: raw
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_5.rst
+  * - **Editor**
+    - Jim Garlick <garlick@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_5.rst
+++ b/spec_5.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_5.html
 
 5/Flux Broker Modules
-=====================
+#####################
 
 This specification describes the broker extension modules
 used to implement Flux services.
@@ -19,18 +19,17 @@ used to implement Flux services.
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Related Standards
------------------
+*****************
 
 - :doc:`spec_3`
 
-
 Background
-----------
+**********
 
 Flux services are implemented as dynamically loaded broker plugins called
 "broker modules". They are "actors" in the sense that they have
@@ -67,13 +66,11 @@ message to indicate to the broker when initialization is complete. This
 provides synchronization to the broker module loader as well as useful
 runtime debug information that can be reported by ``flux module list``.
 
-
 Implementation
---------------
-
+**************
 
 Well known Symbols
-~~~~~~~~~~~~~~~~~~
+==================
 
 A broker module SHALL export the following global symbol:
 
@@ -83,9 +80,8 @@ A broker module SHALL export the following global symbol:
    failure.  The POSIX ``errno`` thread-specific variable SHOULD be set to
    indicate the type of error on failure.
 
-
 Status Messages
-~~~~~~~~~~~~~~~
+===============
 
 A broker module SHALL be considered to be in one of the following states,
 represented by the integer values shown in parenthesis:
@@ -138,9 +134,8 @@ code greater than or equal to zero, otherwise the value of ``errno``.
        "errnum":0
    }
 
-
 Load Sequence
-~~~~~~~~~~~~~
+=============
 
 The broker module loader SHALL launch the module’s ``mod_main()`` in a
 new thread. The ``broker.insmod`` response is deferred until the module
@@ -148,9 +143,8 @@ state transitions out of FLUX_MODSTATE_INIT. If it transitions immediately to
 FLUX_MODSTATE_EXITED, and the ``errnum`` value is nonzero, an error response
 SHALL be returned as described in RFC 3.
 
-
 Unload Sequence
-~~~~~~~~~~~~~~~
+===============
 
 The broker module loader SHALL send a ``<service>.shutdown`` request to the
 module when the module loader receives a ``broker.rmmod`` request for the
@@ -161,7 +155,7 @@ clean up the module thread.
 
 
 Built-in Request Handlers
-~~~~~~~~~~~~~~~~~~~~~~~~~
+=========================
 
 All broker modules receive default handlers for the following methods:
 
@@ -192,9 +186,8 @@ All broker modules receive default handlers for the following methods:
    module’s broker handle aux hash, under the key "flux::debug_flags".
    The ``flux-module debug`` sends this request.
 
-
 Built-in Event Handlers
-~~~~~~~~~~~~~~~~~~~~~~~
+=======================
 
 In addition, all broker modules subscribe to and register a handler for
 the following pub/sub events:
@@ -205,7 +198,7 @@ the following pub/sub events:
    The ``flux-module stats --clear-all`` publishes this event.
 
 Module Attributes
-~~~~~~~~~~~~~~~~~
+=================
 
 The following key-value pairs SHALL be provided to broker modules via the
 ``flux_t`` handle AUX container:
@@ -220,7 +213,7 @@ flux::name
    overridden by request at module load time.
 
 Multiple Loading
-~~~~~~~~~~~~~~~~
+================
 
 A properly conditioned broker module MAY be loaded more than once under
 different names.  The following constraints SHOULD be considered:

--- a/spec_5.rst
+++ b/spec_5.rst
@@ -21,10 +21,7 @@ used to implement Flux services.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
-
+.. include:: common/language.rst
 
 Related Standards
 -----------------

--- a/spec_6.rst
+++ b/spec_6.rst
@@ -21,10 +21,7 @@ built on top of request and response messages defined in RFC 3.
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
-
+.. include:: common/language.rst
 
 Related Standards
 -----------------

--- a/spec_6.rst
+++ b/spec_6.rst
@@ -8,12 +8,15 @@
 This specification describes how Flux Remote Procedure Call (RPC) is
 built on top of request and response messages defined in RFC 3.
 
--  Name: github.com/flux-framework/rfc/spec_6.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Jim Garlick <garlick@llnl.gov>
-
--  State: raw
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_6.rst
+  * - **Editor**
+    - Jim Garlick <garlick@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_6.rst
+++ b/spec_6.rst
@@ -26,7 +26,7 @@ be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_
 Related Standards
 -----------------
 
--  :doc:`3/Flux Message Protocol <spec_3>`
+- :doc:`spec_3`
 
 
 Goals

--- a/spec_6.rst
+++ b/spec_6.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_6.html
 
 6/Flux Remote Procedure Call Protocol
-=====================================
+#####################################
 
 This specification describes how Flux Remote Procedure Call (RPC) is
 built on top of request and response messages defined in RFC 3.
@@ -19,18 +19,17 @@ built on top of request and response messages defined in RFC 3.
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Related Standards
------------------
+*****************
 
 - :doc:`spec_3`
 
-
 Goals
------
+*****
 
 Flux RPC protocol enables broker modules, utilities, or other software
 communicating with a Flux instance to call the methods implemented
@@ -45,9 +44,8 @@ by broker modules. Flux RPC has the following goals:
 
 -  Provide a mechanism to abort in-progress RPC calls.
 
-
 Implementation
---------------
+**************
 
 A remote procedure call SHALL consist of one request message
 sent from a client to a server, and zero or more response messages sent
@@ -62,7 +60,7 @@ mutually-exclusive—​ broker modules often act in both roles.
    server.
 
 Request Message
-~~~~~~~~~~~~~~~
+===============
 
 Per RFC 3, the request message SHALL include a nodeid and topic string
 used to aid the broker in selecting appropriate routes to the server.
@@ -79,9 +77,8 @@ FLUX_MSGFLAG_STREAMING message flag.
 A request MAY indicate that the response should be suppressed by
 setting the FLUX_MSGFLAG_NORESPONSE message flag.
 
-
 Response Messages
-~~~~~~~~~~~~~~~~~
+=================
 
 The server SHALL send zero or more responses to each request, as
 established by prior agreement between client and server (e.g. defined
@@ -110,7 +107,7 @@ The server MAY respond to requests in any order.
    Example RPC for ``flux getattr badkey``, which elicits an error response.
 
 Streaming Responses
-~~~~~~~~~~~~~~~~~~~
+===================
 
 Services that send multiple responses to a request SHALL immediately reject
 requests that do not have the FLUX_MSGFLAG_STREAMING flag set by sending
@@ -133,7 +130,7 @@ the response stream. The flag MAY be set in the final error response.
    by ENODATA.
 
 Matchtag Field
-~~~~~~~~~~~~~~
+==============
 
 RFC 3 provisions request and response messages with a 32-bit matchtag field.
 The client MAY assign a unique (to the client) value to this field,
@@ -153,9 +150,8 @@ MAY be reused if a response containing the matchtag arrives with the
 FLUX_MSGFLAG_STREAMING message flag clear, or if the response contains
 a non-zero error number.
 
-
 Exceptional Conditions
-~~~~~~~~~~~~~~~~~~~~~~
+======================
 
 If a request cannot be delivered to the server, the broker MAY respond to
 the sender with an error. For example, per RFC 3, a broker SHALL respond
@@ -169,9 +165,8 @@ MAY cause messages to be lost. It is the client’s responsibility to
 implement any timeouts or other mitigation to handle missing or delayed
 responses.
 
-
 Disconnection
-~~~~~~~~~~~~~
+=============
 
 If a client aborts with an RPC in progress, it or its proxy SHOULD send a
 request to the server with a topic string of "*service*.disconnect".
@@ -188,9 +183,8 @@ frame (closest to routing delimiter frame) from the request message.
 Servers which maintain per-request state SHOULD index it by sender identity
 so that it can be removed upon receipt of the disconnect request.
 
-
 Cancellation
-~~~~~~~~~~~~
+============
 
 A service MAY implement a method which allows pending requests on its
 other methods to be canceled.  If implemented, the cancellation method

--- a/spec_7.rst
+++ b/spec_7.rst
@@ -7,14 +7,18 @@
 
 This specification presents the recommended standards when contributing code to the Flux code base.
 
--  Name: github.com/flux-framework/rfc/spec_7.rst
 
--  Editor: Tom Scogland <scogland1@llnl.gov>
+.. list-table::
+  :widths: 25 75
 
--  Original author: Don Lipari <lipari@llnl.gov>
-
--  State: draft
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_7.rst
+  * - **Editor**
+    - Tom Scogland <scogland1@llnl.gov>
+  * - **Original Author**
+    - Don Lipari <lipari@llnl.gov>
+  * - **State**
+    - draft
 
 Language
 --------

--- a/spec_7.rst
+++ b/spec_7.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_7.html
 
 7/Flux Coding Style Guide
-=========================
+#########################
 
 This specification presents the recommended standards when contributing code to the Flux code base.
 
@@ -21,26 +21,24 @@ This specification presents the recommended standards when contributing code to 
     - draft
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Related Standards
------------------
+*****************
 
 -  https://www.kernel.org/doc/Documentation/CodingStyle
 
-
 Goals
------
+*****
 
 -  Encourage a uniform coding style in flux-framework projects
 
 -  Provide a document to reference when providing style feedback in project pull requests
 
-
 C Coding Style Recommendations
-------------------------------
+******************************
 
 Flux projects written in C SHOULD conform to the C99 version of the language.
 
@@ -66,9 +64,8 @@ In general, Flux follows the "Kernighan & Ritchie coding style" with the followi
 
    int *ptr;
 
-
 Variable Names
-~~~~~~~~~~~~~~
+==============
 
 Variable names SHOULD NOT include upper case letters.
 For example ``msg_count`` is OK, but ``MsgCount`` or ``MSG_COUNT`` do not conform.
@@ -76,9 +73,8 @@ For example ``msg_count`` is OK, but ``MsgCount`` or ``MSG_COUNT`` do not confor
 Preprocessor macro names SHOULD NOT include lower case letters.
 For example ``FLUX_FOO_MAGIC`` is OK but ``flux_foo_magic`` and ``FluxFooMagic`` do not conform.
 
-
 Typedefs
-~~~~~~~~
+========
 
 C typedef names SHOULD NOT include upper case letters.
 
@@ -112,9 +108,8 @@ Typedefs SHOULD NOT be used for fixed length character arrays, as this
 obscures the fact that they are merely pointers when used in function
 prototypes, and give different ``sizeof`` results depending on context.
 
-
 Structures
-~~~~~~~~~~
+==========
 
 Structure tags SHOULD NOT contain the string "struct".
 
@@ -131,9 +126,8 @@ we also should not write:
 
    struct foo_struct {};
 
-
 Enums and constants
-~~~~~~~~~~~~~~~~~~~
+===================
 
 Enumerations SHOULD be used instead of preprocessor macros for integral
 constants. Each ``enum`` SHOULD have a name, to facilitate bindings and avoid
@@ -175,9 +169,8 @@ Examples:
 In order to represent the full range of values, enums that use a zero for none
 or similar SHOULD include an item with the value zero to represent that state.
 
-
 Tools for C formatting
-~~~~~~~~~~~~~~~~~~~~~~
+======================
 
 The flux-core repository includes a ``.clang-format`` file for use with
 clang-format, and SHOULD be used for automated formatting if possible.
@@ -204,6 +197,6 @@ In emacs, add this to your custom-set-variables defs to highlight whitespace err
 
 
 Python coding style
--------------------
+*******************
 
 -  Python code SHALL be formatted with the `Black code style <https://black.readthedocs.io/en/stable/the_black_code_style/index.html>`__.

--- a/spec_7.rst
+++ b/spec_7.rst
@@ -23,10 +23,7 @@ This specification presents the recommended standards when contributing code to 
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
-
+.. include:: common/language.rst
 
 Related Standards
 -----------------

--- a/spec_9.rst
+++ b/spec_9.rst
@@ -18,10 +18,7 @@
 Language
 --------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
-be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`__.
-
+.. include:: common/language.rst
 
 Goals
 -----

--- a/spec_9.rst
+++ b/spec_9.rst
@@ -5,12 +5,15 @@
 9/Distributed Communication and Synchronization Best Practices
 ==============================================================
 
--  Name: github.com/flux-framework/rfc/spec_9.rst
+.. list-table::
+  :widths: 25 75
 
--  Editor: Tom Scogland <scogland1@llnl.gov>
-
--  State: raw
-
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_9.rst
+  * - **Editor**
+    - Tom Scogland <scogland1@llnl.gov>
+  * - **State**
+    - raw
 
 Language
 --------

--- a/spec_9.rst
+++ b/spec_9.rst
@@ -3,7 +3,7 @@
    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_9.html
 
 9/Distributed Communication and Synchronization Best Practices
-==============================================================
+##############################################################
 
 .. list-table::
   :widths: 25 75
@@ -16,12 +16,12 @@
     - raw
 
 Language
---------
+********
 
 .. include:: common/language.rst
 
 Goals
------
+*****
 
 To establish best practices, preferred patterns and anti-patterns for
 distributed services in the flux framework. Several of the core services of
@@ -31,9 +31,8 @@ cases. For now, this is a listing of some common patterns and anti-patterns,
 but may shape into a more comprehensive guide as the most effective patterns
 are identified.
 
-
 Anti-Patterns
--------------
+*************
 
 -  **Watch chaining:** The KVS provides the capability to watch keys for
    changes in value, receiving a callback or value on change. It is tempting
@@ -49,13 +48,11 @@ Anti-Patterns
    such as monotonically increasing counters, MAY prefer replacement since their
    historical values can be inferred.
 
-
 Best-Practices
---------------
-
+**************
 
 General Guidelines
-~~~~~~~~~~~~~~~~~~
+==================
 
 -  Services SHOULD NOT block the reactor any longer than necessary. Prefer to
    place an asynchronous request or RPC and return to the reactor rather than
@@ -67,9 +64,8 @@ General Guidelines
 -  For data which should be persisted and produce a notification, prefer to write to
    the KVS in a way that supports watches.
 
-
 Preferred Patterns
-~~~~~~~~~~~~~~~~~~
+==================
 
 -  **Centralize update triggers:** Services may notify completion or transition
    events through watches on known points in the KVS. Services that use this


### PR DESCRIPTION
This cleans up a few long standing issues

- fix inconsistent use of heading levels
- move repeated Language section to an include file
- let sphinx x-ref fill in titles for referenced RFCs instead of restating the titles
- make the Name/Editor/State block pretty with a table