### PR TITLE
rfc27: add R to sched.free request

### DIFF
--- a/spec_14.rst
+++ b/spec_14.rst
@@ -674,4 +674,4 @@ References
 
 .. [#f1] `YAML Ain’t Markup Language (YAML) Version 1.1 <http://yaml.org/spec/1.1/current.html>`__, O. Ben-Kiki, C. Evans, B. Ingerson, 2004.
 
-.. [#f2] `JSON Schema: A Media Type for Describing JSON Documents <https://json-schema.org/latest/json-schema-core.html>`__; H. Andrews; 2018
+.. [#f2] `JSON Schema: A Media Type for Describing JSON Documents <https://json-schema.org/draft/2020-12/json-schema-core>`__; H. Andrews; 2022

--- a/spec_25.rst
+++ b/spec_25.rst
@@ -295,4 +295,4 @@ References
 
 .. [#f1] `YAML Ain’t Markup Language (YAML) Version 1.1 <http://yaml.org/spec/1.1/current.html>`__, O. Ben-Kiki, C. Evans, B. Ingerson, 2004.
 
-.. [#f2] `JSON Schema: A Media Type for Describing JSON Documents <https://json-schema.org/latest/json-schema-core.html>`__; H. Andrews; 2018
+.. [#f2] `JSON Schema: A Media Type for Describing JSON Documents <https://json-schema.org/draft/2020-12/json-schema-core>`__; H. Andrews; 2022

--- a/spec_27.rst
+++ b/spec_27.rst
@@ -571,22 +571,37 @@ Free
 
 The job manager SHALL send a ``sched.free`` request when a job that is
 holding resources enters CLEANUP state.  The request payload consists of
-a JSON object with the following REQUIRED key:
+a JSON object with the following REQUIRED keys:
 
 id
   (integer) job ID
+
+R
+  (object) RFC 20 resource set from which the ``scheduling`` key MAY be
+  omitted.
 
 Example:
 
 .. code:: json
 
-   {
-     "id": 1552593348
-   }
+  {
+    "id": 1552593348,
+    "R": {
+      "version": 1,
+      "execution": {
+        "R_lite": [
+          { "rank": "0", "children": { "core": "0-3" } }
+        ],
+        "nodelist": [ "test0" ],
+        "starttime": 1710076092,
+        "expiration": 1710076122
+      }
+    }
+  }
 
-Upon receipt of the ``sched.free`` request, the scheduler MAY look up *R*
-in the KVS by job ID according to the job schema (RFC 16).
-It SHOULD mark the job's resources as available for reuse.
+
+Upon receipt of the ``sched.free`` request, the scheduler SHOULD mark the
+job's resources as available for reuse.
 
 Once the ``sched.free`` request has been processed by the scheduler, it SHALL
 send a response with payload consisting of a JSON object with the following

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -490,3 +490,4 @@ parsable
 bitmasks
 DoS
 lookups
+chu


### PR DESCRIPTION
Problem: flux-framework/flux-core#5783 adds R to the sched.free request to avoid an extra lookup.

Add R to the sched.free request payload definition in RFC 27.