### PR TITLE
rfc27: eliminate sched.free response

### DIFF
--- a/spec_27.rst
+++ b/spec_27.rst
@@ -603,23 +603,7 @@ Example:
 Upon receipt of the ``sched.free`` request, the scheduler SHOULD mark the
 job's resources as available for reuse.
 
-Once the ``sched.free`` request has been processed by the scheduler, it SHALL
-send a response with payload consisting of a JSON object with the following
-REQUIRED key:
-
-id
-  (integer) job ID
-
-Example:
-
-.. code:: json
-
-   {
-     "id": 1552593348
-   }
-
-After the ``sched.free`` response, the request is complete and may be
-retired by the job manager and scheduler.
+There is no response.
 
 Finalization
 ============


### PR DESCRIPTION
Problem: sched.free requires a response, but this adds complexity to the job manager and has little benefit.

Code that drops the sched.free response from flux-core is proposed in flux-framework/flux-core#5786.

Drop the free response.