### PR TITLE
rfc42: note response requirements for a successful exec stream, plus cleanup

### DIFF
--- a/spec_42.rst
+++ b/spec_42.rst
@@ -34,8 +34,7 @@ Related Standards
 Background
 **********
 
-The subprocess server protocol is implemented in two distinct Flux
-components:
+The subprocess server protocol is implemented in three Flux components:
 
 .. list-table::
 
@@ -51,6 +50,10 @@ components:
     - :program:`sdexec`
     - If systemd support is configured
 
+  * - Flux shell
+    - :program:`UID-shell-JOBID.rexec`
+    - Only available to the job owner.
+
 The primary use cases are:
 
 #. The job execution service runs job shells on job nodes.
@@ -58,6 +61,8 @@ The primary use cases are:
 #. The job manager perilog plugin runs prolog/epilog scripts on job nodes.
 
 #. The instance owner runs arbitrary processes with :program:`flux exec`.
+
+#. Tool launch such as parallel debugger daemons using :program:`flux exec`.
 
 In a multi-user Flux instance where a user transition is necessary in order
 for the instance owner to run commands with the credentials of a guest user,

--- a/spec_42.rst
+++ b/spec_42.rst
@@ -182,7 +182,12 @@ Several response types are distinguished by the type key:
 .. object:: exec error response
 
 The :program:`exec` response stream SHALL be terminated by an error
-response per RFC 6, with ENODATA (61) indicating success.
+response per RFC 6, with ENODATA (61) indicating success.  The server MUST
+NOT terminate the stream with ENODATA without first returning the
+:program:`exec started` response, :program:`exec finished` response, and
+:program:`exec output` responses with the EOF flag set for each open channel.
+The client MAY consider it a protocol error if one of those responses is
+missing and an ENODATA response is received.
 
 Failure of the remote command SHALL be indicated in finished response
 and SHALL NOT result in an error response.  Other errors, such as an

--- a/spec_42.rst
+++ b/spec_42.rst
@@ -66,10 +66,10 @@ The primary use cases are:
 
 In a multi-user Flux instance where a user transition is necessary in order
 for the instance owner to run commands with the credentials of a guest user,
-the subprocess server delegates this to the IMP.  On its own, the subprocess
-server can only run jobs with the credentials of the process it is embedded
-within (the broker, for example).  For more detail, refer to
-:doc:`RFC 15 <spec_15>`.
+the subprocess server must be instructed to execute tasks using the IMP.  On
+its own, the subprocess server can only run jobs with the credentials of the
+process it is embedded within (the broker, for example).  For more detail,
+refer to :doc:`RFC 15 <spec_15>`.
 
 Goals
 *****


### PR DESCRIPTION
Problem: while tracking down flux-framework/flux-core#5956, it became evident that RFC 42 does not specify which responses must be expected in a successful exec stream.

Add a paragraph that clarifies this.

Also add a couple of other minor cleanups.