### PR TITLE
rfc42: exec.write should use matchtag not pid

### DIFF
--- a/spec_42.rst
+++ b/spec_42.rst
@@ -205,9 +205,9 @@ specified in the exec request command object.
 
   The request SHALL consist of a JSON object with the following keys:
 
-  .. object:: pid
+  .. object:: matchtag
 
-    (*integer*, REQUIRED) The process ID of the remote process.
+    (*integer*, REQUIRED) The matchtag of the :program:`exec` request.
 
   .. object:: io
 


### PR DESCRIPTION
Problem: requiring the PID as a parameter to `write` complicates client code which must support writing/closing a stream before the `started` response has been received.

Use the `exec` request matchtag instead.

Note: this came up while discussing flux-framework/flux-core#6002