### PR TITLE
rfc13: clarify KVS key constraints

### DIFF
--- a/spec_13.rst
+++ b/spec_13.rst
@@ -432,6 +432,9 @@ Notes:
 Key Value Store
 ===============
 
+KVS keys that begin with ``PMI_`` SHALL be considered part a reserved
+namespace.
+
 KVS value strings SHALL be restricted to the following character set:
 
 .. code-block:: console
@@ -444,6 +447,8 @@ KVS value strings SHALL be restricted to the following character set:
   113 - 126  q r s t u v w x y z { | } ~
 
 That is, all ASCII characters between ``!`` (33) and ``~`` (126), inclusive.
+
+A zero length string value SHALL be considered valid.
 
 .. function:: int PMI_KVS_Put (const char kvsname[], const char key[], const char value[])
 
@@ -519,6 +524,12 @@ Errors:
 -  PMI_ERR_INVALID_LENGTH - invalid length argument
 
 -  PMI_FAIL - get failed
+
+Notes:
+
+-  A key that is part of the ``PMI_`` reserved namespace that is not found
+   is not treated an error.  Instead, an empty string is returned for the
+   value.
 
 .. function:: int PMI_KVS_Get_my_name (char kvsname[], int length)
 .. function:: int PMI_Get_kvs_domain_id (char kvsname[], int length)

--- a/spec_13.rst
+++ b/spec_13.rst
@@ -432,6 +432,19 @@ Notes:
 Key Value Store
 ===============
 
+KVS value strings SHALL be restricted to the following character set:
+
+.. code-block:: console
+
+   33 - 48   ! " # $ % & ' ( ) * + , - . / 0
+   49 - 64   1 2 3 4 5 6 7 8 9 : ; < = > ? @
+   65 - 80   A B C D E F G H I J K L M N O P
+   81 - 96   Q R S T U V W X Y Z [ \ ] ^ _ `
+   97 - 112  a b c d e f g h i j k l m n o p
+  113 - 126  q r s t u v w x y z { | } ~
+
+That is, all ASCII characters between ``!`` (33) and ``~`` (126), inclusive.
+
 .. function:: int PMI_KVS_Put (const char kvsname[], const char key[], const char value[])
 
 Put a key/value pair in a keyval space.
@@ -789,7 +802,7 @@ Protocol Definition
    C:get           = "cmd=get" SP "kvsname=" word SP "key=" word LF
    S:get           = "cmd=get_result"
                      [SP "rc=" int]
-                     [SP "value=" string]
+                     [SP "value=" word]
                      LF
 
    ; Dynamic Process Management


### PR DESCRIPTION
While running down a problem with recent mpich `mpiexec.hydra` not being able to launch flux (flux-framework/flux-core#6072) a discussion with mpich developers over in  pmodels/mpich#7050 resulted in some new knowledge about the PMI-1 wire protocol that we should document and change in our implementation.

Specifically:
- PMI KVS values cannot contain SPACE
- `PMI_` prefixed PMI keys are a reserved namespace
- when a key in the reserved namespace cannot be fetched, the server returns success with an empty string

This PR adds some clarification on those topics to RFC 13.