### PR TITLE
rfc14: add bank and project as optional jobspec attributes

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -65,6 +65,7 @@ source_suffix = '.rst'
 
 linkcheck_ignore = [
     "https://help.github.com/en/pull-requests", # 403 Forbidden
+    r"https://blog\.twitter\.com/.*", # 403 Forbidden
 ]
 
 

--- a/spec_14.rst
+++ b/spec_14.rst
@@ -334,6 +334,18 @@ Some common system attributes are:
    The value of the ``queue`` attribute is a string containing the name of
    the job queue this job should be submitted to.
 
+**bank**
+   The value of the ``bank`` attribute is a string containing the name of
+   an accounting bank requested for this job. Support for the ``bank``
+   attribute MAY depend on installation and configuration of optional
+   framework components, such as an accounting or other plugin.
+
+**project**
+  The value of the ``project`` attribute is a string containing the
+  name of an accounting project requested for this job. Support for the
+  ``project`` attribute MAY depend on installation and configuration of
+  optional framework components, such as an accounting or other plugin.
+
 **dependencies**
    The value of the ``dependencies`` attribute SHALL be a
    list of dictionaries following the format specified in RFC 26.


### PR DESCRIPTION
Problem: The canonical jobspec attributes for `bank` and `project` are not specified in RFC 14. Even though these attributes only apply for multi-user instances with an accounting plugin configured, they are common enough concepts that it would be useful to standardize their name, location in jobspec, and purpose.

Define `bank` and `project` attributes in RFC 14. Add a note that these attributes may have no effect unless an accounting package is installed and configured.