### PR TITLE
rfc42: rename flags to forwarding_flags

### DIFF
--- a/spec_42.rst
+++ b/spec_42.rst
@@ -108,7 +108,7 @@ are defined as follows:
 
     See `Command Object`_ below.
 
-  .. object:: flags
+  .. object:: forwarding_flags
 
     (*integer*, REQUIRED) A bitfield comprised of zero or more flags:
 


### PR DESCRIPTION
Problem: The exec request uses a field named "flags" to indicate what should be forwarded to the client.  The use of the generic term "flags" can be ambiguous, as it could be easily confused for other "flags" used within subprocess code.

Rename the field to "forwarding_flags".

----

side note, this is mostly b/c in the future we would like to pass the actual "subprocess" flags to the remote server.  So this is just mini-prep for that.  

Obviously can debate the name.  I considered "callback_flags" as well.