### PR TITLE
rfc15: IMP may linger post-shell to clean cgroup

### DIFF
--- a/spec_15.rst
+++ b/spec_15.rst
@@ -360,8 +360,9 @@ SHALL spawn the **job shell path** specified in :math:`J`, or a IMP
 configuration default with the guest user credentials.
 
 The IMP MUST remain active while the job shell executes and forward any
-signals it receives to the shell as described below.  Once the job shell has
-terminated, the IMP MAY perform privileged clean-up tasks such as
+signals it receives to the shell as described below.  The IMP MAY remain
+active until its cgroup is empty, if applicable.  Once its signal forwarding
+role is complete, the IMP MAY perform privileged clean-up tasks such as
 
 -  Finalize the PAM session
 


### PR DESCRIPTION
Problem: RFC 15 states that the IMP may exit after the job shell exits, but then it cannot forward SIGUSR1->SIGKILL to stuck processes if the shell exits early.

Change the wording to allow the imp to linger after the shell exits.