### PR TITLE
RFC 14,25: add preemptible-after system attribute

### DIFF
--- a/spec_14.rst
+++ b/spec_14.rst
@@ -316,6 +316,13 @@ Some common system attributes are:
    ``duration`` is configured, and the current instance has no expiration,
    then resources shall be allocated without expiration.
 
+**preemptible-after**
+   A floating point number greater than or equal to zero representing job
+   run time after which the job MAY be canceled in order to make way for
+   other jobs.  A value of zero indicates that the job is immediately
+   preemptible.  The attribute SHALL NOT be set if the job is never
+   preemptible.
+
 **environment**
    The value of the ``environment`` attribute is a dictionary containing the names
    and values of environment variables that should be set (or unset) when spawning

--- a/spec_25.rst
+++ b/spec_25.rst
@@ -159,6 +159,8 @@ definitions can be found in RFC14. Values MAY have any valid YAML type.
 
    -  duration
 
+   -  preemptible-after
+
    -  environment
 
    -  cwd

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -495,3 +495,4 @@ unsatisfiable
 cgroup
 procs
 unencoded
+preemptible


### PR DESCRIPTION
Problem: jobspec has no way to express preemptibility
    
Add the preemptible-after jobspec attribute.
