### PR TITLE
rfc24: fix a typo

### DIFF
--- a/spec_24.rst
+++ b/spec_24.rst
@@ -141,7 +141,7 @@ data
 eof
    (boolean) End of stream indicator.
 
-The following keys are OPTIOINAL in the event context object:
+The following keys are OPTIONAL in the event context object:
 
 encoding
    (string) The encoding of this particular data event when different from


### PR DESCRIPTION
Problem: "OPTIONAL" is misspelled.

Spell it correctly.