### PR TITLE
rfc25: clarify V1 restrictions in tasks section

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SOURCEDIR     = .
 BUILDDIR      = _build
 
 # YAML Validation on these directories
-SCHEMA_DIRS=data/spec_26 data/spec_14
+SCHEMA_DIRS=data/spec_26 data/spec_25 data/spec_14
 
 # Put it first so that "make" without argument is like "make help".
 help:

--- a/data/spec_14/schema.json
+++ b/data/spec_14/schema.json
@@ -52,7 +52,7 @@
         { "$ref": "#/definitions/resource_vertex_base" },
         {
           "properties": {
-            "type": { "enum": ["slot"] }
+            "type": { "const": "slot" }
           },
           "required": ["label"]
         }
@@ -64,7 +64,7 @@
         { "$ref": "#/definitions/resource_vertex_base" },
         {
           "properties": {
-            "type": { "not": { "enum": ["slot"] } }
+            "type": { "not": { "const": "slot" } }
           }
         }
       ]
@@ -117,7 +117,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["command", "slot", "count" ],
+        "required": ["command", "slot", "count"],
         "properties": {
           "command": {
             "type": "array",
@@ -127,8 +127,18 @@
           "slot": { "type": "string" },
           "count": {
             "type": "object",
+            "minProperties": 1,
+            "maxProperties": 1,
             "properties": {
               "per_slot": { "type": "integer", "minimum" : 1 },
+              "per_resource": {
+                "type": "object",
+                "required": ["type", "count"],
+                "properties": {
+                  "type": { "type": "string" },
+                  "count": { "type": "integer", "minimum": 1 }
+                }
+              },
               "total": { "type": "integer", "minimum" : 1 }
             }
           },
@@ -138,7 +148,7 @@
             "properties": {
               "environment": { "type" : "object"}
             },
-	        "additionalProperties": { "type": "string" }
+	    "additionalProperties": { "type": "string" }
           }
         },
 	"additionalProperties": false

--- a/data/spec_25/schema.json
+++ b/data/spec_25/schema.json
@@ -116,10 +116,8 @@
           "slot": { "type": "string" },
           "count": {
             "type": "object",
-            "anyOf": [
-              {"required" : ["per_slot"]},
-              {"required" : ["total"]}
-            ],
+            "minProperties": 1,
+            "maxProperties": 1,
             "additionalProperties": false,
             "properties": {
               "per_slot": { "type": "integer", "const" : 1 },
@@ -127,7 +125,7 @@
             }
           }
         },
-	    "additionalProperties": false
+	"additionalProperties": false
       }
     }
   }

--- a/data/spec_25/schema.json
+++ b/data/spec_25/schema.json
@@ -22,7 +22,7 @@
       "type": "object",
       "required": ["type", "count", "with"],
       "properties": {
-        "type": { "enum" : ["node"] },
+        "type": { "const" : "node" },
         "count": { "type": "integer", "minimum" : 1 },
         "unit": { "type": "string" },
         "with": {
@@ -43,7 +43,7 @@
       "type": "object",
       "required": ["type", "count", "with", "label"],
       "properties": {
-        "type": { "enum" : ["slot"] },
+        "type": { "const" : "slot" },
         "count": { "type": "integer", "minimum" : 1 },
         "unit": { "type": "string" },
         "label": { "type": "string" },
@@ -68,7 +68,7 @@
     "version": {
       "description": "the jobspec version",
       "type": "integer",
-      "enum": [1]
+      "const": 1
     },
     "resources": {
       "description": "requested resources",
@@ -106,7 +106,7 @@
       "maxItems": 1,
       "items": {
         "type": "object",
-        "required": ["command", "slot", "count" ],
+        "required": ["command", "slot", "count"],
         "properties": {
           "command": {
             "type": ["string", "array"],
@@ -116,9 +116,13 @@
           "slot": { "type": "string" },
           "count": {
             "type": "object",
+            "anyOf": [
+              {"required" : ["per_slot"]},
+              {"required" : ["total"]}
+            ],
             "additionalProperties": false,
             "properties": {
-              "per_slot": { "type": "integer", "minimum" : 1 },
+              "per_slot": { "type": "integer", "const" : 1 },
               "total": { "type": "integer", "minimum" : 1 }
             }
           }

--- a/spec_14.rst
+++ b/spec_14.rst
@@ -236,45 +236,45 @@ Reserved Resource Types
 Tasks
 =====
 
-The value of the ``tasks`` key SHALL be a strict list which MUST
-define at least one task. Each list element SHALL be a dictionary
-representing a task or tasks to run as part of the program. A task
-descriptor SHALL contain the following keys:
+The ``tasks`` key SHALL be a strict list which MUST define at least one task.
+Each list element SHALL be a dictionary representing a task or tasks to run as
+part of the program. A task descriptor SHALL contain the following keys:
 
 **command**
-   The value of the ``command`` key SHALL be a list representing an
-   executable and its arguments.
+   The ``command`` key SHALL be a list representing an executable and its
+   arguments.
 
 **slot**
-   The value of the ``slot`` key SHALL match a ``label`` of a resource vertex
-   of type ``slot``. It is used to indicate the **task slot**
+   The ``slot`` key SHALL be a string matching the ``label`` of a resource
+   vertex of type ``slot``. It is used to indicate the **task slot**
    on which this task or tasks shall be contained and executed. The
    number of tasks executed per task slot SHALL be a function of the
    number of resource slots and total number of tasks requested to execute.
 
 **count**
-   The value of the ``count`` key SHALL be a dictionary supporting at
-   least the keys ``per_slot``, ``per_resource``, and ``total``, with other keys
-   reserved for future or site-specific extensions.
+   The ``count`` key SHALL be a dictionary supporting at least the keys
+   ``per_slot``, ``per_resource``, and ``total``, with other keys reserved for
+   future or site-specific extensions, and SHALL contain exactly one supported
+   key.
 
    **per_slot**
-      The value of ``per_slot`` SHALL be a number indicating the number
+      The ``per_slot`` key SHALL be a positive integer indicating the number
       of tasks to execute per task slot allocated to the program.
 
    **per_resource**
-      The value of ``per_resource`` SHALL be a dictionary which
-      SHALL contain the following keys:
+      The ``per_resource`` SHALL be a dictionary which SHALL contain the
+      following keys:
 
-      -  **type** The value of the ``type`` key SHALL be a resource type explicitly
-         declared in the associated task’s slot.
+      -  **type** The ``type`` key SHALL be a string matching a resource type
+         explicitly declared in the associated task’s slot.
 
-      -  **count** The value of the ``count`` key SHALL be a number indicating the number
-         of tasks to execute per resource of type ``type`` occurring in the task’s
-         slot.
+      -  **count** The ``count`` key SHALL be a positive integer indicating
+         the number of tasks to execute per resource of type ``type`` occurring
+         in the task’s slot.
 
    **total**
-      The value of the ``total`` field SHALL indicate the total number of
-      tasks to be run across all task slots, possibly oversubscribed.
+      The ``total`` key SHALL be a positive integer indicating the total number
+      of tasks to be run across all task slots, possibly oversubscribed.
 
 **attributes**
    The ``attributes`` key SHALL be a free-form dictionary of keys which may

--- a/spec_25.rst
+++ b/spec_25.rst
@@ -143,20 +143,19 @@ key:
 
 -  count
 
-The ``count`` key SHALL contain at least one of the following keys:
+The ``count`` key SHALL contain exactly one of the following keys:
 
 -  per_slot
 
 -  total
 
-If both of these keys are set, the ``total`` key SHALL prevail. The definitions
-of these keys SHALL match those provided in :doc:`RFC 14 <spec_14>`, with the
-following restrictions in V1: if ``per_slot`` is used, its value MUST be one,
-and if ``total`` is used its value MUST be less than or equal to the ``count``
-key of the associated slot and greater than or equal to the number of allocated
-nodes (if no ``node`` resource vertex is explicitly given in the jobspec, then
-this minimum value will depend on the instance resource configuration and/or
-scheduler used).
+The definitions of these keys SHALL match those provided in
+:doc:`RFC 14 <spec_14>`, with the following restrictions in V1: if ``per_slot``
+is used, its value MUST be one, and if ``total`` is used its value MUST be less
+than or equal to the ``count`` key of the associated slot and greater than or
+equal to the number of allocated nodes (if no ``node`` resource vertex is
+explicitly given in the jobspec, then this minimum value will depend on the
+instance resource configuration and/or scheduler used).
 
 Attributes
 ==========

--- a/spec_25.rst
+++ b/spec_25.rst
@@ -130,10 +130,12 @@ well. Therefore, the complete enumeration of valid resource graphs in V1 is:
 Tasks
 =====
 
-The value of the ``tasks`` key SHALL be a strict list which MUST define exactly
-one task. The list element SHALL be a dictionary representing a task to run as
-part of the program. A task descriptor SHALL contain the following keys, whose
-definitions SHALL match those provided in RFC14:
+The ``tasks`` key SHALL be a strict list which MUST define exactly one task.
+The list element SHALL be a dictionary representing a task to run as part of
+the program. A task descriptor SHALL contain the following keys, whose
+definitions SHALL match those provided in :doc:`RFC 14 <spec_14>`, with the
+restriction in V1 that the ``count`` key does not support the ``per_resource``
+key:
 
 -  command
 
@@ -141,17 +143,28 @@ definitions SHALL match those provided in RFC14:
 
 -  count
 
-   -  per_slot
+The ``count`` key SHALL contain at least one of the following keys:
 
-   -  total
+-  per_slot
+
+-  total
+
+If both of these keys are set, the ``total`` key SHALL prevail. The definitions
+of these keys SHALL match those provided in :doc:`RFC 14 <spec_14>`, with the
+following restrictions in V1: if ``per_slot`` is used, its value MUST be one,
+and if ``total`` is used its value MUST be less than or equal to the ``count``
+key of the associated slot and greater than or equal to the number of allocated
+nodes (if no ``node`` resource vertex is explicitly given in the jobspec, then
+this minimum value will depend on the instance resource configuration and/or
+scheduler used).
 
 Attributes
 ==========
 
-The ``attributes`` key SHALL be a dictionary of
-dictionaries. The ``attributes`` dictionary MUST contain ``system`` key and MAY
-contain the ``user`` key. Common ``system`` keys are listed below, and their
-definitions can be found in RFC14. Values MAY have any valid YAML type.
+The ``attributes`` key SHALL be a dictionary of dictionaries. The ``attributes``
+dictionary MUST contain the ``system`` key and MAY contain the ``user`` key.
+Common ``system`` keys are listed below, and their definitions can be found in
+:doc:`RFC 14 <spec_14>`. Values MAY have any valid YAML type.
 
 -  user
 


### PR DESCRIPTION
Problem: the "Tasks" section of RFC 25 basically just points back to RFC 14, but in my testing there does seem to be several noteworthy restrictions on the "count" key that I couldn't find documented anywhere.

This PR is basically my attempt at clarifying what I would have found useful to have in the documentation, based on my best understanding of how the keys seem to behave in my testing. My apologies if I'm not totally correct on the true behavior, but hopefully it won't be too difficult for someone with more knowledge than me to tweak the wordings if necessary!