### PR TITLE
rfc14: allow idset and range strings for resource count

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Table of Contents
 - [42/Subprocess Server Protocol](spec_42.rst)
 - [43/Job List Service](spec_43.rst)
 - [44/Resource Events](spec_44.rst)
+- [45/Resource Range String Representation](spec_45.rst)
 
 Build Instructions
 ------------------

--- a/data/spec_14/schema.json
+++ b/data/spec_14/schema.json
@@ -23,6 +23,11 @@
       },
       "additionalProperties": false
     },
+    "idset": {
+      "description": "an RFC 22 idset",
+      "type": "string",
+      "pattern": "(?=^\\[.*]$|^[^][]*$)((^\\[?|,)[1-9]\\d*(-[1-9]\\d*)?)*]?$"
+    },
     "resource_vertex_base": {
       "description": "base schema for slot/other resource vertex",
       "type": "object",
@@ -32,6 +37,7 @@
         "count": {
           "oneOf": [
             { "type": "integer", "minimum" : 1 },
+            { "$ref": "#/definitions/idset" },
             { "$ref": "#/definitions/complex_range" }
           ]
         },

--- a/data/spec_14/schema.json
+++ b/data/spec_14/schema.json
@@ -6,7 +6,7 @@
   "description":         "Flux canonical jobspec",
 
   "definitions": {
-    "complex_range": {
+    "range_dict": {
       "description": "a complex range of numbers",
       "type": "object",
       "properties":{
@@ -23,6 +23,11 @@
       },
       "additionalProperties": false
     },
+    "range_string": {
+      "description": "an RFC 45 range string",
+      "type": "string",
+      "pattern": "^(?=\\[.*]$|[^][]*$)\\[?[1-9]\\d*(\\+|-[1-9]\\d*)?(:[1-9]\\d*(:[+*^])?)?]?$"
+    },
     "idset": {
       "description": "an RFC 22 idset",
       "type": "string",
@@ -38,7 +43,8 @@
           "oneOf": [
             { "type": "integer", "minimum" : 1 },
             { "$ref": "#/definitions/idset" },
-            { "$ref": "#/definitions/complex_range" }
+            { "$ref": "#/definitions/range_string" },
+            { "$ref": "#/definitions/range_dict" }
           ]
         },
         "exclusive": { "type": "boolean" },

--- a/data/spec_14/use_case_1.8.yaml
+++ b/data/spec_14/use_case_1.8.yaml
@@ -1,0 +1,19 @@
+version: 999
+resources:
+  - type: slot
+    count: "4,9,16,25"
+    label: default
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: [ "flux", "start" ]
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 3600.
+    cwd: "/home/flux"
+    environment:
+      HOME: "/home/flux"

--- a/index.rst
+++ b/index.rst
@@ -288,6 +288,12 @@ The Flux Job List Service provides read-only summary information for jobs.
 
 Changes to resource availability are recorded in an RFC 18 eventlog.
 
+:doc:`spec_45`
+~~~~~~~~~~~~~~
+
+This specification describes a compact form for expressing an RFC 14
+resource range defined by a min/max/operand/operator combination.
+
 .. Each file must appear in a toctree
 .. toctree::
    :hidden:
@@ -334,3 +340,4 @@ Changes to resource availability are recorded in an RFC 18 eventlog.
    spec_42
    spec_43
    spec_44
+   spec_45

--- a/spec_14.rst
+++ b/spec_14.rst
@@ -143,17 +143,18 @@ defined in the jobspec.
 A resource vertex SHALL contain the following keys:
 
 **type**
-   The ``type`` key for a resource SHALL indicate the type of resource to
+   The ``type`` key SHALL be a string indicating the type of resource to
    be matched. Some type names MAY be reserved for use in the jobspec
    language itself. The currently reserved type is ``slot``, used to
    define **task slots**. Reserved types are described in the
    **Reserved Resource Types** section below.
 
 **count**
-   The ``count`` key SHALL indicate the desired number or range of
-   resources matching the current vertex. The ``count`` SHALL have one
-   of two possible values: either a single integer value representing
-   a fixed count, or a dictionary which SHALL contain the following keys:
+   The ``count`` key SHALL indicate the desired number or range of resources
+   matching the current vertex and SHALL have one of three possible values:
+   either a single positive integer representing a fixed count, a string
+   containing an :doc:`RFC 22 <spec_22>` idset representing all acceptable
+   counts, or a dictionary which SHALL contain the following key:
 
    **min**
       The ``min`` key SHALL be a positive integer indicating the minimum
@@ -556,6 +557,21 @@ Existing Equivalents
 
 Jobspec YAML
    .. literalinclude:: data/spec_14/use_case_1.7.yaml
+      :language: yaml
+
+Use Case 1.8
+   Request an irregular range of a type of resource
+
+Specific Example
+   Similar to 1.2, request between 3 and 30 nodes, but must be a perfect square
+
+Existing Equivalents
+   +-----------------------------------+-----------------------------------+
+   | Slurm                             | ``salloc -N4,9,16,25``            |
+   +-----------------------------------+-----------------------------------+
+
+Jobspec YAML
+   .. literalinclude:: data/spec_14/use_case_1.8.yaml
       :language: yaml
 
 Section 2: General Requests

--- a/spec_14.rst
+++ b/spec_14.rst
@@ -152,42 +152,47 @@ A resource vertex SHALL contain the following keys:
 **count**
    The ``count`` key SHALL indicate the desired number or range of resources
    matching the current vertex and SHALL have one of three possible values:
-   either a single positive integer representing a fixed count, a string
-   containing an :doc:`RFC 22 <spec_22>` idset representing all acceptable
-   counts, or a dictionary which SHALL contain the following key:
 
-   **min**
-      The ``min`` key SHALL be a positive integer indicating the minimum
-      required count or amount of this resource.
+   1. A single positive integer representing a fixed count.
 
-   Additionally, it MAY contain the following keys (if present, all three
-   MUST be specified):
+   2. A string containing either an :doc:`RFC 22 <spec_22>` idset representing
+      all acceptable counts, or an :doc:`RFC 45 <spec_45>` range as a compact
+      alternative to the dictionary form given next in option 3.
 
-   **max**
-      The ``max`` key SHALL be an integer greater than or equal to ``min``
-      indicating the maximum required count or amount of this resource.
+   3. A dictionary which SHALL contain the following key:
 
-   **operator**
-      The ``operator`` key SHALL be a single character string representing an
-      operator applied between ``min`` and ``max`` which returns the next
-      acceptable value. Currently defined operators are: addition ``+``,
-      multiplication ``*``, or exponentiation ``^``. If ``^`` is specified,
-      then ``min`` MUST be greater than or equal to two.
-
-   **operand**
-      The ``operand`` key SHALL be a positive integer used in conjunction with
-      the given ``operator``. If ``operator`` is either ``*`` or ``^``, then
-      ``operand`` MUST be greater than or equal to two.
-
-   The default value for ``max`` SHALL be *infinite*, therefore a ``count``
-   which specifies only the ``min`` key SHALL be considered a request for
-   *at least* that number of a resource, and the scheduler SHALL generate
-   the *R* that contains the maximum number of the resource that is
-   available and subject to the operator and operand. By contrast,
-   if a fixed count is given to the ``count`` key, the scheduler SHALL
-   match any resource that contains *at least* ``count`` of the resource,
-   but its *R* SHALL contain exactly ``count`` of the resource
-   (potentially leaving excess resources unutilized).
+      **min**
+         The ``min`` key SHALL be a positive integer indicating the minimum
+         required count or amount of this resource.
+   
+      Additionally, it MAY contain the following keys (if present, all three
+      MUST be specified):
+   
+      **max**
+         The ``max`` key SHALL be an integer greater than or equal to ``min``
+         indicating the maximum required count or amount of this resource.
+   
+      **operator**
+         The ``operator`` key SHALL be a single character string representing an
+         operator applied between ``min`` and ``max`` which returns the next
+         acceptable value. Currently defined operators are: addition ``+``,
+         multiplication ``*``, or exponentiation ``^``. If ``^`` is specified,
+         then ``min`` MUST be greater than or equal to two.
+   
+      **operand**
+         The ``operand`` key SHALL be a positive integer used in conjunction with
+         the given ``operator``. If ``operator`` is either ``*`` or ``^``, then
+         ``operand`` MUST be greater than or equal to two.
+   
+      The default value for ``max`` SHALL be *infinite*, therefore a ``count``
+      which specifies only the ``min`` key SHALL be considered a request for
+      *at least* that number of a resource, and the scheduler SHALL generate
+      the *R* that contains the maximum number of the resource that is
+      available and subject to the operator and operand. By contrast,
+      if a fixed count is given to the ``count`` key, the scheduler SHALL
+      match any resource that contains *at least* ``count`` of the resource,
+      but its *R* SHALL contain exactly ``count`` of the resource
+      (potentially leaving excess resources unutilized).
 
 A resource vertex MAY additionally contain one or more of the following keys:
 

--- a/spec_45.rst
+++ b/spec_45.rst
@@ -1,0 +1,86 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_22.html
+
+45/Resource Range String Representation
+#######################################
+
+This specification describes a compact form for expressing an RFC 14
+resource range defined by a min/max/operand/operator combination.
+
+.. list-table::
+  :widths: 25 75
+
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_45.rst
+  * - **Editor**
+    - Sam Maloney <s.maloney@fz-juelich.de>
+  * - **State**
+    - raw
+
+Language
+********
+
+.. include:: common/language.rst
+
+Background
+**********
+
+:doc:`RFC 14 <spec_14>` allows for resource counts to be given as a range
+specified by a min/max/operand/operator combination in a dictionary. A compact
+representation of such a range is useful in certain contexts, such as command 
+line interfaces.
+
+Implementation
+**************
+
+A fully specified range string SHALL have one of two forms:
+
+- *with* a given maximum value: ``min-max:operand:operator``
+
+- *without* a given maximum value: ``min+:operand:operator``
+
+Values for ``min``, ``max``, and ``operand`` in a range string SHALL be
+represented in decimal form and SHALL NOT include leading zeroes.
+
+The ``operator`` in a range string SHALL be a single character, without any
+quotes, e.g. ``+`` not ``'+'``.
+
+A range using the addition ``'+'`` operator MAY omit it (along with the
+preceding colon), e.g. ``1-5:2:+`` MAY be shortened to ``1-5:2``.
+
+A range using the addition ``'+'`` operator and a unit operand MAY omit both
+(along with the preceding colons), e.g. ``1-4:1:+`` MAY be shortened to ``1-4``.
+
+A range string MAY be surrounded by square brackets to promote readability,
+e.g. ``[1-4:2:*]`` or ``[100+]``.
+
+A range string SHALL consist only of the following characters:
+
+-  The decimal digits: ``0 1 2 3 4 5 6 7 8 9``
+
+-  Hyphen: ``-``
+
+-  Plus sign: ``+``
+
+-  Colon: ``:``
+
+-  Square brackets: ``[ ]``
+
+-  Valid operator characters, currently including:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Operator
+     - Character
+     - Unicode Name
+   * - Addition
+     - ``+``
+     - Plus sign
+   * - Multiplication
+     - ``*``
+     - Asterisk
+   * - Exponentiation
+     - ``^``
+     - Circumflex Accent (ASCII Caret)


### PR DESCRIPTION
Problem: irregular ranges of resource counts that do not fit the current min/max/operator/operand paradigm cannot be specified.

Allow a third option (in addition to single integer and range dict) for resource counts to be a string containing an RFC22 idset of acceptable counts.

Obviously new operators could be defined for some cases (including the simple example I included), but for future-proofing it would seem desirable to have a fallback for users to specify any arbitrary set of counts they desire.

[SLURM allows similar strings for its node counts](https://slurm.schedmd.com/salloc.html#OPT_nodes) so this would ensure flux ends up at least as capable as SLURM in this regard ;)

(idset regex created/tested via https://regex101.com/r/65FyDf)
