### PR TITLE
rfc14: clarify resource range keys restrictions and/or default behaviour

### DIFF
--- a/spec_14.rst
+++ b/spec_14.rst
@@ -156,19 +156,27 @@ A resource vertex SHALL contain the following keys:
    a fixed count, or a dictionary which SHALL contain the following keys:
 
    **min**
-      The minimum required count or amount of this resource
+      The ``min`` key SHALL be a positive integer indicating the minimum
+      required count or amount of this resource.
 
-   and additionally MAY contain the following keys:
+   Additionally, it MAY contain the following keys (if present, all three
+   MUST be specified):
 
    **max**
-      The maximum required count or amount of this resource
+      The ``max`` key SHALL be an integer greater than or equal to ``min``
+      indicating the maximum required count or amount of this resource.
 
    **operator**
-      An operator applied between ``min`` and ``max`` which
-      returns the next acceptable value
+      The ``operator`` key SHALL be a single character string representing an
+      operator applied between ``min`` and ``max`` which returns the next
+      acceptable value. Currently defined operators are: addition ``+``,
+      multiplication ``*``, or exponentiation ``^``. If ``^`` is specified,
+      then ``min`` MUST be greater than or equal to two.
 
    **operand**
-      The operand used in conjunction with ``operator``
+      The ``operand`` key SHALL be a positive integer used in conjunction with
+      the given ``operator``. If ``operator`` is either ``*`` or ``^``, then
+      ``operand`` MUST be greater than or equal to two.
 
    The default value for ``max`` SHALL be *infinite*, therefore a ``count``
    which specifies only the ``min`` key SHALL be considered a request for
@@ -180,8 +188,7 @@ A resource vertex SHALL contain the following keys:
    but its *R* SHALL contain exactly ``count`` of the resource
    (potentially leaving excess resources unutilized).
 
-A resource vertex MAY additionally contain one or more of the
-following keys
+A resource vertex MAY additionally contain one or more of the following keys:
 
 **unit**
    The ``unit`` key, if supplied, SHALL have a string value indicating


### PR DESCRIPTION
Problem: the acceptable values for the keys within a resource range dictionary are not entirely clear from the text, and some behaviour differs between flux-core and flux-sched

Firstly, once I started testing some resource ranges, it's clear that having an operand of 1 for either the '*' or '^' operators is nonsensical, since min*1 or min^1 don't change anything. Also for the '^' operator having min==1 is nonsensical, since 1^operand also goes nowhere. However, once I got looking at the implementation in flux-sched, I noticed that if an operand of 1 is given with either the '*' or '^' operators, there is an if statement which simply short circuits to return the min value. I personally think this is non-intuitive behaviour; it feels to me like such nonsensical input is likely an unintentional mistake from the user that should be failed with a useful error message to have the user clarify what they actually intended, rather than quietly using the min and potentially hiding the mistake from them.

Seondly, the flux-core validator and the jsonschema in RFC 14 both require that either none or all of max/operator/operand keys MUST be specified; however, flux-sched doesn't... because RFC 14 declares that "The default value for max SHALL be infinite, therefore a count which specifies only the min key SHALL be considered a request for at least that number of a resource", this implies a default operator of '+' with a default operand of 1, which is how flux-sched implements this. I personally think either choice is reasonable (require all three, or use defaults), but obviously it should be consistent between the various flux components, and fully documented either way.

This pull request currently updates the RFC 14 text to require all three keys be co-dependent, and clearly defines the limits on operator/operand combinations, because that is what I had written up before realizing that flux-sched had some things implemented differently. But I'm happy to write an update instead specifying the default behaviours of min/max/operand if that route is preferred! I'm also happy to try and implement some of the actual changes in core/sched once a consensus is reached, but figured a discussion here was needed first on the preferred interpretation :)