### PR TITLE
rfc44: add optional reason field to undrain event

### DIFF
--- a/spec_44.rst
+++ b/spec_44.rst
@@ -271,6 +271,11 @@ The event context SHALL contain the following keys:
   (*string*, REQUIRED) An RFC 29 hostlist that can be used to map the idset
   execution target ranks to hostnames.
 
+.. data:: reason
+  :noindex:
+
+  (*string*, OPTIONAL) A message describing why the undrain action was taken.
+
 .. code:: json
 
   {


### PR DESCRIPTION
Problem: At least one documented use case could make use of a reason field in the undrain event, but RFC 44 does not allow that.

Add an optional reason key in the undrain context.