### PR TITLE
rfc1: require commit message titles and bodies

### DIFF
--- a/spec_1.rst
+++ b/spec_1.rst
@@ -105,7 +105,9 @@ Patch Requirements
 
 -  A patch MUST be accompanied by a commit message.
 
--  A commit message SHOULD consist of a title (50 characters or less) summarizing the change, optionally followed by a blank line and a message body.
+-  A commit message MUST include a title summarizing the change. The title SHOULD be 50 characters or less.
+
+-  A commit message MUST include a body. The body SHOULD include a blank line after the title.
 
 -  A commit message SHOULD be written in the imperative (Fixes or Fix).
 


### PR DESCRIPTION
Problem: our fork of C4 lists commit message titles and bodies as optional, but in practice we require message bodies for flux-framework patches.

Update RFC 1 to reflect this.

Fixes #448