### PR TITLE
rfc7: update link to kernel coding style standard

### DIFF
--- a/spec_7.rst
+++ b/spec_7.rst
@@ -28,7 +28,7 @@ Language
 Related Standards
 *****************
 
--  https://www.kernel.org/doc/Documentation/CodingStyle
+-  https://www.kernel.org/doc/Documentation/process/coding-style.rst
 
 Goals
 *****


### PR DESCRIPTION
Problem: link to kernel coding style documentation is out-of-date

Update link to point directly to correct location