### PR TITLE
conf.py: ignore anl.gov in linkcheck

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -67,6 +67,7 @@ linkcheck_ignore = [
     "https://help.github.com/en/pull-requests", # 403 Forbidden
     r"https://blog\.twitter\.com/.*", # 403 Forbidden
     r"https://github.com/pmodels/mpich/commit/.*", # 406 client not acceptable
+    r"https://www\.mcs\.anl\.gov/.*f", # 403 Forbidden
 ]
 
 


### PR DESCRIPTION
Problem: Access to https://www.mcs.anl.gov gets 403 Forbidden with `make linkcheck` in CI.

Add this URL to the ignore list for linkcheck.

Fixes #456