### PR TITLE
rfc14: resource 'with' key should be a list

### DIFF
--- a/spec_14.rst
+++ b/spec_14.rst
@@ -209,9 +209,10 @@ A resource vertex MAY additionally contain one or more of the following keys:
    and their associated resources.
 
 **with**
-   The ``with`` key SHALL indicate an edge of type ``out`` from this resource
-   vertex to another resource. Therefore, the value of the ``with`` key
-   SHALL be a dictionary conforming to the resource vertex specification.
+   The ``with`` key SHALL indicate one or more edges of type ``out`` from this
+   resource vertex to other resources. Therefore, the value of the ``with`` key
+   SHALL be a strict list of dictionaries conforming to the resource vertex
+   specification and MUST contain at least one such vertex.
 
 **label**
    The ``label`` key SHALL be a string that may be used to reference this


### PR DESCRIPTION
Problem: the 'with' key in a resource vertex dictionary should be a list of dictionaries, not just a dictionary.

Update the text to clarify the type specification.