### PR TITLE
ci: pass with comment on linkcheck fail

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,5 +43,20 @@ jobs:
       run: |
         pip3 install --upgrade -r ./requirements.txt
     - name: make linkcheck
+      id: linkcheck
       run: |
-        make linkcheck
+        status=0
+        make linkcheck || status=$?
+        echo "status=${status}" >> "${GITHUB_OUTPUT}"
+        exit 0 # this step should never fail the overall workflow
+    - name: Comment on PR if linkcheck failed
+      if: ${{ github.event_name == 'pull_request' && steps.linkcheck.outputs.status != 0 }}
+      uses: actions/github-script@v7
+      with:
+        script: |
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: '⚠️  linkcheck failed with status code ${{ steps.linkcheck.outputs.status }}'
+          })


### PR DESCRIPTION
Problem: linkcheck fails frequently for various out-of-our-control reasons

Make the workflow pass regardless of `make linkcheck` outcome, but post a comment to the PR notifying if linkcheck failed.