### PR TITLE
rfc35: fix grammar syntax highlighting

### DIFF
--- a/spec_35.rst
+++ b/spec_35.rst
@@ -77,7 +77,7 @@ Grammar
 
 The basic grammar for the constraint query language is
 
-.. code-block:: EBNF
+.. code-block:: PEG
 
    expr
      : expr expr
@@ -89,15 +89,15 @@ The basic grammar for the constraint query language is
      | term
 
    and
-     : /&{1,2}|and\b/
+     : &{1,2}|and\b
    or
-     : /\|{1,2}|or\b/
+     : \|{1,2}|or\b
 
    not
-     : /not\b/
+     : not\b
 
    term
-     : operator':'operand
+     : operator ':' operand
      | operand
 
    operator


### PR DESCRIPTION
Problem: there is a lexer warning in `make html` when using EBNF for the grammar and it doesn't render well on readthedocs

Swap EBNF for PEG and tweak to match actual definitions used in `flux-core/src/bindings/python/flux/constraint/parser.py`

This could be totally wrong or out-of-line, in which case sorry! But this warning just irked me when I was building things, so I was trying to figure what might make more sense, and PEG seemed to fit better than EBNF? The explicit forward slashes to indicate regex also didn't play well with the syntax highlighting, and seemed to be an implicit part of such a grammar specification anyway (and aren't in the strings actually used in constraint.py) but feel free to edit as desired :)