### PR TITLE
mergify: update YAML config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,14 @@
 queue_rules:
   - name: default
+    batch_size: 1
     update_method: rebase
     merge_method: merge
+
+# Avoid temporary branches created by mergify for parallel checks
+# These do not work with the pr-validator since the temporary PR
+# branch is updated with a merge commit.
+merge_queue:
+  max_parallel_checks: 1
 
 pull_request_rules:
   - name: rebase and merge when passing all checks


### PR DESCRIPTION
#### Problem

Mergify is complaining that the setting to require branches to be up to date before merging is not compatible with draft PR checks.

---

This PR updates the Mergify configuration to enable in-place checks by setting `merge_queue.max_parallel_check` to 1 and setting every queue_rule's `batch_size` to 1.

Because this is making a change to mergify config, this will need a manual merge.