### PR TITLE
mergify: fix wip regex

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -16,7 +16,7 @@ pull_request_rules:
       - base=master
       - label="merge-when-passing"
       - label!="work-in-progress"
-      - -title~="^\[*(WIP|wip)"
+      - -title~=(?i)^(\[)?wip
       - "approved-reviews-by=@flux-framework/core"
       - "#approved-reviews-by>0"
       - "#changes-requested-reviews-by=0"


### PR DESCRIPTION
Problem: The condition in the mergify config which attempts to prevent WIP PRs from being merged has an incorrect regex.

Rewrite the regex without quotes so it will match PR titles. Simplify the expression using a case insensitive match, and only match one or zero brackets instead of zero or more.
