### PR TITLE
feat: code of conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Table of Contents
 - [44/Resource Events](spec_44.rst)
 - [45/Resource Range String Representation](spec_45.rst)
 - [46/Command Line Job](spec_46.rst)
+- [47/Flux Framework Contributor Code of Conduct](spec_47.rst)
 
 Build Instructions
 ------------------

--- a/index.rst
+++ b/index.rst
@@ -300,6 +300,12 @@ resource range defined by a min/max/operand/operator combination.
 This specification describes a compact form for expressing an RFC 14 jobspec
 resources list that can be provided to several Flux commands by a user.
 
+:doc:`spec_47`
+~~~~~~~~~~~~~~
+
+This specification outlines the Flux Framework Code of Conduct, adapted
+from the Contributor Covenant, and specifies the enforcement process.
+
 .. Each file must appear in a toctree
 .. toctree::
    :hidden:
@@ -348,3 +354,4 @@ resources list that can be provided to several Flux commands by a user.
    spec_44
    spec_45
    spec_46
+   spec_47

--- a/spec_1.rst
+++ b/spec_1.rst
@@ -32,6 +32,7 @@ Related Standards
 
 - :doc:`spec_2`
 - :doc:`spec_7`
+- :doc:`spec_47`
 
 Goals
 *****

--- a/spec_47.rst
+++ b/spec_47.rst
@@ -1,0 +1,151 @@
+.. github display
+    GitHub is NOT the preferred viewer for this file. Please visit
+    https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_47.html
+
+47/Flux Framework Contributor Code of Conduct
+##############################################
+
+This document outlines the Flux Framework Code of Conduct, adapted from the Contributor Covenant, and specifies the enforcement process.
+
+.. list-table::
+  :widths: 25 75
+
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_47.rst
+  * - **Forked from**
+    - Contributor Covenant v2.1
+  * - **Editor**
+    - Vanessa Sochat <sochat1@llnl.gov>
+  * - **State**
+    - draft
+
+Language
+********
+
+.. include:: common/language.rst
+
+Related Standards
+*****************
+
+- :doc:`spec_1`
+- :doc:`spec_2`
+- :doc:`spec_7`
+
+Goals
+*****
+
+The goal of this Code of Conduct is to clearly define the expectations for acceptable behavior within the Flux Framework community and to provide a consistent, fair process for addressing and resolving unacceptable behavior.
+
+Design
+******
+
+Code of Conduct
+===============
+
+Short Version
+-------------
+We as members, contributors, and leaders pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socioeconomic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+Need Help?
+----------
+
+If any behavior makes you uncomfortable, or you believe it breaches the intent of this code of conduct, please contact a project maintainer:
+
+* `Flux Code of Conduct Contacts <https://github.com/orgs/flux-framework/teams/flux-code-of-conduct-contacts>`_
+
+----
+
+Long Version
+------------
+As contributors and maintainers in this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socioeconomic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+Our Standards
+-------------
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Giving and gracefully accepting constructive feedback
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* Violent threats or language directed against another person.
+* Sexist, racist, or otherwise discriminatory jokes and language.
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+Enforcement Responsibilities
+----------------------------
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+Scope
+-----
+
+This Code of Conduct applies within all project spaces, including contributors, maintainers, administrators, and any kind of participant in the project.
+
+Project maintainers will enforce this code at all times. We expect cooperation from all participants to ensure a safe environment for everyone.
+
+The Code of Conduct, and the project leaders, can only address behavior in the present, not past behavior or fears of what someone might do based on past behavior.
+
+Enforcement
+-----------
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project maintainers at:
+
+* `Flux Code of Conduct Contacts <https://github.com/orgs/flux-framework/teams/flux-code-of-conduct-contacts>`_
+
+Complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+
+The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+Enforcement Guidelines
+----------------------
+
+1. Correction
+^^^^^^^^^^^^^
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+2. Warning
+^^^^^^^^^^
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+3. Temporary Ban
+^^^^^^^^^^^^^^^^
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+4. Permanent Ban
+^^^^^^^^^^^^^^^^
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+Further Reading
+***************
+
+- `Contributor Covenant <https://www.contributor-covenant.org/version/2/1/code_of_conduct>`__
+- `Mozilla’s code of conduct enforcement ladder <https://github.com/mozilla/diversity>`__
+- `SustainOSS Code of Conduct <https://sustainoss.org/code-of-conduct/>`__
+
+For answers to common questions about this code of conduct, see `Contributor Covenant FAQ <https://www.contributor-covenant.org/faq>`__

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -505,3 +505,4 @@ setpgrp
 killpg
 posix
 waitable
+Sochat


### PR DESCRIPTION
Problem: to join HPSF and encourage Flux to have a more broad community, we need a Code of Conduct.
Solution: add rfc spec 47 for a code of conduct.

I wasn't sure who to put for maintainers. I figure we should have one person of each gender, minimally, for different kinds of complaints. I can adjust / add / remove as requested.