### PR TITLE
rfc1: drop Project Administration section

### DIFF
--- a/spec_1.rst
+++ b/spec_1.rst
@@ -218,17 +218,6 @@ Evolution of Public Contracts
 
 -  When old names are removed, their implementations MUST provoke an exception (assertion) if used by applications.
 
-Project Administration
-======================
-
--  The project founders SHALL act as Administrators to manage the set of project Maintainers.
-
--  The Administrators SHALL ensure their own succession over time by promoting the most effective Maintainers.
-
--  A new Contributor who makes a correct patch SHALL be invited to become a Maintainer.
-
--  Administrators MAY remove Maintainers who are inactive for an extended period of time, or who repeatedly fail to apply this process accurately.
-
 Further Reading
 ***************
 


### PR DESCRIPTION
Problem: the Project Administration section of RFC 1 was inherited from 0MQ and is neither sufficient nor correct for flux-framework.

Remove that section from RFC 1.
A new project governance RFC will cover this topic.