### PR TITLE
rfc43: update roles section

### DIFF
--- a/spec_48.rst
+++ b/spec_48.rst
@@ -90,14 +90,14 @@ Maintainer Review
 Issue Governance
 ----------------
 
-* Both collaborators and project maintainers may propose issues. The participation in the issue discussion is open and must follow the `Code of Conduct <spec_47>`_.
+* Both contributors and project maintainers may propose issues. The participation in the issue discussion is open and must follow the `Code of Conduct <spec_47>`_.
 * The group of project maintainers will be responsible for assigning labels to issues, as well as for assigning the issue to a project maintainer or contributor. The `merge-when-passing` label MAY be applied by a maintainer to allow a pull request to be automatically merged once it has met all requirements.
 * The group of project maintainers SHOULD commit to responding to any issue within **72 hours** of the issue's creation.
 
 Pull Request Governance
 -----------------------
 
-* Both collaborators and project maintainers may propose pull requests.
+* Both contributors and project maintainers may propose pull requests.
 * Pull requests SHOULD describe the contribution. The assignment of labels and assignees to the pull request is the responsibility of the project maintainers.
 * The group of project maintainers SHOULD provide feedback to any pull request within **72 hours** of the pull request's creation.
 * The decision of accepting (or rejecting) a pull request will be taken by the group of project maintainers. The criteria and process for making the decision is described in `RFC 1 "Development Process" <https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_1.html#development-process>`_.


### PR DESCRIPTION
@grondo, @trws, and I had a chat today about this and wanted to add Administrator as a new role in the gov doc.  This would be the people who are able to add/remove projects from the flux-framework organization and do other "root" like tasks within it.

This defines the new role and tries to distinguish between "the project" which is really the organization, and the individual projects within it which follow the rules, but may have different maintainers for example.  (They also may have different policies for development, within the constraints of RFC 1).

Anyway, @trws or @grondo please make sure I captured what we discussed.

p.s. I also added a README.md for the organization that lists me, @grondo, and @trws as the administrators and this doc links to that page.