### PR TITLE
align RFC 1 with current project practice

### DIFF
--- a/spec_1.rst
+++ b/spec_1.rst
@@ -182,7 +182,7 @@ Release Process
 Creating Stable Releases
 ========================
 
--  The project SHALL have one branch ("master") that always holds the latest in-progress version and SHOULD always build.
+-  The project SHALL have one branch (that SHOULD be named "main") that always holds the latest in-progress version and SHOULD always build.
 
 -  The project SHALL NOT use topic branches for any reason. Personal forks MAY use topic branches.
 


### PR DESCRIPTION
Problem: there are currently some rules in RFC 1 that were inherited from 0MQ that are at odds with our current practice and ought to be updated.

Update the RFC as needed.