### PR TITLE
rfc48: admin role in direction/conflict resolution

### DIFF
--- a/spec_48.rst
+++ b/spec_48.rst
@@ -63,7 +63,10 @@ the flux-framework organization:
 
 Administrator
   A person with GitHub administrator access to the organization and all its
-  projects.  The organization `README.md <https://github.com/flux-framework/.github/blob/main/profile/README.md>`_
+  projects.  As a group, the administrators provide technical direction to the
+  project. The administrators will vote on any matters on which the community is
+  unable to reach consensus.
+  The organization `README.md <https://github.com/flux-framework/.github/blob/main/profile/README.md>`_
   defines the GitHub identities of the organization administrators.
 
 Development Workflow


### PR DESCRIPTION
Problem: the current text explains the administrative aspects of the admin role, but doesn't clarify the role in a way that would work for some of the asks of projects in the HPSF charter for conflict resolution or overall project direction.

Solution: Adapt some text from the HPCToolkit TSC
https://gitlab.com/hpctoolkit/governance/-/blob/main/GOVERNANCE.md#role to clarify.

I think this matches what we discussed @garlick, @grondo, and sorry for not getting in on it when you had your PR @garlick. Otherwise I think everything looks great in here.  I like the way the "lazy consensus model" ties into the way we mostly do things, it covers a lot of ground without having to discuss a lot of details.