### PR TITLE
code of conduct: update contacts

### DIFF
--- a/spec_47.rst
+++ b/spec_47.rst
@@ -52,9 +52,9 @@ We pledge to act and interact in ways that contribute to an open, welcoming, div
 Need Help?
 ----------
 
-If any behavior makes you uncomfortable, or you believe it breaches the intent of this code of conduct, please contact a project maintainer:
+If any behavior makes you uncomfortable, or you believe it breaches the intent of this code of conduct, you can contact a project maintainer:
 
-* `Flux Code of Conduct Contacts <https://github.com/orgs/flux-framework/teams/flux-code-of-conduct-contacts>`_
+* `Flux Administrators <https://github.com/flux-framework/.github/tree/main/profile>`_
 
 ----
 
@@ -105,9 +105,9 @@ The Code of Conduct, and the project leaders, can only address behavior in the p
 
 Enforcement
 -----------
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project maintainers at:
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project administrators:
 
-* `Flux Code of Conduct Contacts <https://github.com/orgs/flux-framework/teams/flux-code-of-conduct-contacts>`_
+* `Flux Administrators <https://github.com/flux-framework/.github/tree/main/profile>`_
 
 Complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
 


### PR DESCRIPTION
We should add back the more explicit list of emails and admin contacts. The team link we initially created will always be private to org members only. The link (as it is now) if you test not logged into GitHub is 404:


https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_47.html

-> https://github.com/orgs/flux-framework/teams/flux-code-of-conduct-contacts (404)

@trws is the two of us for emails sufficient? I remember you saying you were OK with that when we realized teams weren't an option. I'm definitely OK with having mine there. :+1: 