### PR TITLE
rfc21: add clarification on multiple exceptions

### DIFF
--- a/spec_21.rst
+++ b/spec_21.rst
@@ -148,7 +148,9 @@ immediately transition to ``CLEANUP``. Exception events with a severity
 other than zero do not affect job state, and are assumed to be meaningful
 to other components managing non-fatal exceptions.
 
-More than one exception MAY occur per job.
+More than one exception MAY occur per job.  If more than one exception
+of severity zero occurs, the first one SHALL be considered the root
+cause of the job failure for reporting purposes.
 
 The exception event format is described below.
 


### PR DESCRIPTION
Problem: RFC21 implies that the first exception of severity 0 is the "most severe" exception because it is the one that transitions a job state to CLEANUP.  However, it is not explicitly stated.

Add some additional language that notes that if multiple exceptions of severity 0 occur, the first one is considered the "most severe" for reporting purposes.

----

Just a minor thing I noticed, as I began thinking of work on job-sql database stuff.