### PR TITLE
rfc19: specify json encoding rules for FLUIDs

### DIFF
--- a/spec_19.rst
+++ b/spec_19.rst
@@ -200,3 +200,14 @@ SHALL use the following rules to decode the argument:
 
 An implementation decoding FLUID string representations SHALL
 ignore leading and trailing whitespace.
+
+JSON Encoding
+-------------
+
+When a FLUID value is added to a JSON object, it is RECOMMENDED to
+represent it as a JSON string, in F58 encoding as defined above.
+
+FLUDS SHALL NOT be represented as JSON numbers, since
+`IETF RFC 8259 <https://datatracker.ietf.org/doc/html/rfc8259#section-6>`_
+does not specify the range and recommends keeping within
+:math:`[-(2^{53})+1, (2^{53})-1]` for maximum portability.


### PR DESCRIPTION
Problem: it is not safe to encode FLUIDs as JSON numbers, yet we currently do that routinely in Flux.

Require a string encoding going forward.

Note: the proposed language allows any valid FLUID string encoding since they are unambiguous and the public API functions  `flux_jobid_encode(3)` and `flux_jobid_parse(3)` are available.  However, @dirkschubert-linaro requested that a single encoding be used for human readability.  Thoughts on whether that should be required?  It doesn't cost anything to narrow the requirement to one encoding AFAICS such as `f58plain`

References
- flux-framework/flux-core#6171