### PR TITLE
RFC 15: describe external containment helper

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -33,10 +33,6 @@ copyright = '''Copyright 2014 Lawrence Livermore National Security, LLC and Flux
 SPDX-License-Identifier: LGPL-3.0'''
 author = 'This page is maintained by the Flux community.'
 
-# The full version, including alpha/beta/rc tags
-release = '0.13.0'
-
-
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be

--- a/spec_15.rst
+++ b/spec_15.rst
@@ -271,37 +271,57 @@ Device Containment
 Two optional keys control device access for the job shell and its
 descendants.
 
-device-policy
-   A string specifying the device access policy. The only currently
-   defined value is "closed", which permits access to a baseline set
-   of safe pseudo-devices (listed below) plus any devices explicitly
-   listed in *device-allow*. All other device access is denied. If
-   *device-policy* is absent but *device-allow* is present,
-   "closed" SHALL be assumed.
+DevicePolicy
+   A string specifying the device access policy. Recognized values are:
 
-device-allow
-   An array of objects, each permitting access to one device node.
-   Each object SHALL contain:
+   ``"auto"`` (default)
+      If *DeviceAllow* is absent or empty, allow all devices. Otherwise
+      behave like ``"closed"``.
 
-   path
-      The absolute path to the device node, e.g. ``"/dev/nvidia0"``.
+   ``"closed"``
+      Permit access to a baseline set of safe pseudo-devices (listed
+      below) plus any devices explicitly listed in *DeviceAllow*. All
+      other device access is denied.
 
-   access
-      A string consisting of one or more of the characters ``r``
-      (read), ``w`` (write), and ``m`` (mknod), in any order.
+   ``"strict"``
+      Permit access only to the devices explicitly listed in
+      *DeviceAllow*. The baseline pseudo-devices are not added. All
+      other device access is denied.
+
+   If *DevicePolicy* is absent but *DeviceAllow* is present,
+   ``"auto"`` SHALL be assumed.
+
+DeviceAllow
+   An array of ``[specifier, access]`` tuples, each permitting access
+   to one device or device class. The specifier string may be:
+
+   ``/dev/...``
+      Absolute path to a device node. The major and minor numbers are
+      resolved at policy-application time via ``stat(2)``.
+
+   ``char-NAME``
+      All character devices of the named class, looked up by name in
+      ``/proc/devices``.
+
+   ``block-NAME``
+      All block devices of the named class, looked up by name in
+      ``/proc/devices``.
+
+   The access string consists of one or more of the characters ``r``
+   (read), ``w`` (write), and ``m`` (mknod), in any order.
 
    Example:
 
    .. code-block:: json
 
-      "device-allow": [
-        {"path": "/dev/nvidia0",        "access": "rw"},
-        {"path": "/dev/nvidiactl",      "access": "rw"},
-        {"path": "/dev/nvidia-uvm",     "access": "rw"},
-        {"path": "/dev/dri/renderD128", "access": "rw"}
+      "DeviceAllow": [
+        ["/dev/nvidia0",        "rw"],
+        ["/dev/nvidiactl",      "rw"],
+        ["/dev/nvidia-uvm",     "rw"],
+        ["/dev/dri/renderD128", "rw"]
       ]
 
-When *device-allow* appears in the optional keys, the IMP SHALL apply
+When *DeviceAllow* appears in the optional keys, the IMP SHALL apply
 device containment via a cgroup BPF program attached to the job’s cgroup
 before executing the job shell. The IMP SHALL always include a set of
 internal baseline devices deemed required for basic job functionality.
@@ -309,21 +329,21 @@ The suggested baseline devices are described below.
 
 .. note::
 
-   The *device-allow* / *device-policy* keys mirror the semantics of
-   the systemd ``DeviceAllow=`` and ``DevicePolicy=`` unit properties.
-   When the IMP is started as a systemd transient unit (e.g. via sdexec),
-   the :envvar:`FLUX_IMP_EXEC_HELPER` helper MAY read these properties directly
-   from the unit and populate the *options* object accordingly. This
-   allows device containment to be configured in one place (the Flux
-   system configuration) and enforced either by systemd natively (if and
-   when it gains support for this in user sessions) or by the IMP as
-   described here.
+   The *DeviceAllow* / *DevicePolicy* keys mirror the names and
+   semantics of the systemd ``DeviceAllow=`` and ``DevicePolicy=`` unit
+   properties. When the IMP is started as a systemd transient unit
+   (e.g. via sdexec), the :envvar:`FLUX_IMP_EXEC_HELPER` helper MAY
+   read these properties directly from the unit via D-Bus and populate
+   the *options* object accordingly. This allows device containment to
+   be configured in one place (the Flux system configuration) and
+   enforced either by systemd natively (if and when it gains support for
+   this in user sessions) or by the IMP as described here.
 
 Baseline Devices
 ----------------
 
 When device containment is active the following devices SHALL always be
-permitted, regardless of the *device-allow* list. This matches the
+permitted, regardless of the *DeviceAllow* list. This matches the
 static device list applied by systemd for ``DevicePolicy=closed``
 (``bpf_devices_allow_list_static()`` in ``src/core/bpf-devices.c``,
 verified against systemd v260.1; unchanged since v244):

--- a/spec_15.rst
+++ b/spec_15.rst
@@ -265,6 +265,8 @@ The *options* object in the IMP input MAY contain any of the following
 keys. The resource owner is trusted, therefore these options do not
 require a user signature. Unrecognized keys SHALL be ignored.
 
+.. _device_containment:
+
 Device Containment
 ==================
 
@@ -379,6 +381,58 @@ verified against systemd v260.1; unchanged since v244):
    * - ``/dev/pts/*``
      - rw
      - Pseudoterminal slaves (mknod not permitted)
+
+External Containment Helper
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The device containment scheme defined in :ref:`device_containment` MAY be
+applied outside the IMP execution context by callers that manage cgroups
+independently of jobs. For example, flux-pam may apply device containment
+to systemd user slices managed by Flux prolog and housekeeping scripts.
+
+To support these use cases and avoid code duplication, the flux-security
+project SHALL provide a helper binary, :program:`cgroup-device-apply`,
+that applies the *device-allow* / *device-policy* schema defined in
+:ref:`device_containment` to an arbitrary cgroup. The helper is installed
+at ``$libexecdir/flux/cgroup-device-apply`` and SHALL be invoked as:
+
+::
+
+    cgroup-device-apply CGROUP_PATH
+
+*CGROUP_PATH* is the absolute path to a cgroup v2 directory under
+``/sys/fs/cgroup/``. The helper SHALL read a single JSON object from
+standard input containing the *DevicePolicy* and *DeviceAllow* keys
+with semantics as defined in :ref:`device_containment`. Unrecognized keys
+SHALL be ignored.
+
+The helper SHALL exit with one of the following statuses:
+
+0
+    Success, including the case where *DeviceAllow* is absent or empty
+    (no operation performed).
+
+1
+    Runtime failure: JSON parse error, cgroup path access failure, or BPF
+    program build or attach failure.
+
+2
+    Usage error: missing argument, invalid *CGROUP_PATH* form.
+
+The helper SHALL write a human-readable diagnostic message to standard
+error on non-zero exit. Callers MAY capture and report this output to
+provide context to administrators, for example in job drain reasons,
+syslog, or operator logs.
+
+The helper MUST be invoked as root, as attaching a BPF cgroup program
+requires CAP_BPF and CAP_SYS_ADMIN. The helper SHALL NOT be installed setuid.
+
+The baseline devices defined in *Baseline Devices* SHALL always be permitted
+by the helper, matching IMP behavior.
+
+The argv signature, stdin JSON format, and exit code semantics form a
+stable interface contract. Future incompatible changes SHALL use a new
+helper name or argument flag rather than modifying this interface.
 
 IMP Internal Operation
 **********************


### PR DESCRIPTION
Problem: External projects that want or need to modify cgroup device containment would need to duplicate code from the IMP to construct and load BPF programs.

Specify a cgroup device containment helper that privileged processes can invoke to apply device containment to existing cgroups. The motivating use case is for flux-pam, which will want to manage device access for user slices on shared node systems.

Also, remove a stale `release` entry in the rfc project's `conf.py` so the RFC readthedocs site stops claiming `Flux 0.13.0`