### PR TITLE
rfc21: document exec eventlog events and add new `shell-exit` event

### DIFF
--- a/spec_16.rst
+++ b/spec_16.rst
@@ -194,7 +194,8 @@ The *exec system* creates the job’s guest namespace and links it to
 ``job.<jobid>.guest``. Its initial contents are populated with
 
 ``exec.eventlog``
-   An eventlog for the use of *job shells*, TBD.
+   An eventlog containing events posted by the *exec system* and
+   *job shells*, described in :ref:`RFC 21 <spec_21_execution_eventlog>`.
 
 Once all *job shells* have exited and all outstanding writes to
 the guest namespace have stopped, the *exec system* links the guest

--- a/spec_21.rst
+++ b/spec_21.rst
@@ -620,6 +620,138 @@ Example:
 
    {"timestamp":1552594649.848032,"name":"debug.free-request"}
 
+.. _spec_21_execution_eventlog:
+
+Execution Eventlog Events
+=========================
+
+In addition to the primary job eventlog, the execution system maintains
+a separate eventlog at the ``exec.eventlog`` key of the job's guest KVS
+namespace, found under the ``guest`` key of the job's KVS directory as
+described in RFC 16. Events in this eventlog are formatted as described
+in RFC 18.
+
+Unlike the events described above, execution eventlog events SHALL NOT
+drive job state transitions and SHALL NOT be used as input to job state
+reconstruction. They provide synchronization points and provenance for
+the execution phase of the job.
+
+Events posted by the execution system itself have no prefix. Event names
+prefixed with ``shell.`` are reserved for events posted by the job shell.
+Such events MAY appear in the execution eventlog and their context
+objects are defined by the job shell implementation.
+
+Events beyond those listed below MAY appear in an execution eventlog.
+
+Init Event
+----------
+
+The execution system has created the guest KVS namespace and begun
+initializing the job. The ``init`` event SHALL be the first event posted
+to the execution eventlog.
+
+The context SHALL be empty.
+
+Example:
+
+.. code:: json
+
+   {"timestamp":1552593348.073132,"name":"init"}
+
+Reattach Event
+--------------
+
+The execution system has recovered the job after a potential restart
+of the execution system or enclosing instance. This event MAY appear
+one or more times in the execution eventlog after the ``init`` event.
+
+The context SHALL be empty.
+
+Example:
+
+.. code:: json
+
+   {"timestamp":1552597348.073132,"name":"reattach"}
+
+Starting Event
+--------------
+
+The execution system is about to start the job shells.
+
+The context SHALL be empty.
+
+Example:
+
+.. code:: json
+
+   {"timestamp":1552593348.088563,"name":"starting"}
+
+Re-starting Event
+-----------------
+
+The execution system has successfully attached to the already executing
+job shells of a recovered job. This event MAY appear after a
+``reattach`` event.
+
+The context SHALL be empty.
+
+Example:
+
+.. code:: json
+
+   {"timestamp":1552597348.088563,"name":"re-starting"}
+
+Complete Event
+--------------
+
+All job shells have terminated. This event corresponds to the ``finish``
+event in the primary job eventlog.
+
+The following keys are REQUIRED in the event context object:
+
+status
+   (integer) The job wait status as defined for the ``finish`` event
+   above.
+
+Example:
+
+.. code:: json
+
+   {"timestamp":1552593348.090857,"name":"complete","context":{"status":0}}
+
+Log Event
+---------
+
+The execution system captured output from a job shell or other process
+launched on its behalf. These events are intended to aid debugging,
+especially of errors that occur before the job shell has initialized its
+own logging.
+
+There are no specific requirements for the event context, but it
+typically includes the component name, stream name, broker rank, and
+captured data.
+
+Example:
+
+.. code:: json
+
+   {"timestamp":1552593348.089211,"name":"log","context":{"component":"flux-shell","stream":"stderr","rank":"3","data":"example error message"}}
+
+Done Event
+----------
+
+Execution is complete and the execution system has ceased writing to the
+guest KVS namespace. The ``done`` event SHALL be the final event posted
+to the execution eventlog, as required by RFC 41.
+
+The context SHALL be empty.
+
+Example:
+
+.. code:: json
+
+   {"timestamp":1552593348.104072,"name":"done"}
+
 Synchronization
 ===============
 

--- a/spec_21.rst
+++ b/spec_21.rst
@@ -737,6 +737,43 @@ Example:
 
    {"timestamp":1552593348.089211,"name":"log","context":{"component":"flux-shell","stream":"stderr","rank":"3","data":"example error message"}}
 
+Shell-exit Event
+----------------
+
+The job shell on the leader (first) broker rank of the job has
+terminated. Services provided to the job by the leader shell, such as
+the MPIR proctable
+used by tools and debuggers, standard I/O, and the shell exception
+service, are unavailable after this point. Tools observing this event
+SHOULD NOT attempt to contact the leader shell and MAY use this event
+to distinguish permanent loss of leader shell services from a
+transient error.
+
+The execution system SHALL post this event at most once per job, when
+it observes the termination of the leader shell, whether normal or
+abnormal. If the leader shell is lost without its termination status
+being observed, e.g. due to node failure, this event MAY be omitted.
+
+The following keys are REQUIRED in the event context object:
+
+rank
+   (integer) The broker rank on which the leader shell was executing.
+
+wait_status
+   (integer) The POSIX wait(2) status of the leader shell.
+
+The following keys are OPTIONAL in the event context object:
+
+active_ranks
+   (string) An RFC 22 idset of broker ranks on which job shells were
+   still active when the leader shell terminated.
+
+Example:
+
+.. code:: json
+
+   {"timestamp":1552593348.090112,"name":"shell-exit","context":{"rank":42,"wait_status":0,"active_ranks":"43-45"}}
+
 Done Event
 ----------
 

--- a/spec_41.rst
+++ b/spec_41.rst
@@ -53,7 +53,7 @@ Job info is stored in a job-specific KVS directory as described in
   * - **R**
     - resource set allocated to job (:doc:`RFC 20 <spec_20>`)
   * - **guest.exec.eventlog**
-    - exec system eventlog
+    - exec system eventlog (:ref:`RFC 21 <spec_21_execution_eventlog>`)
   * - **guest.input**
     - job input (:doc:`RFC 24 <spec_24>`)
   * - **guest.output**

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -528,3 +528,4 @@ Rv1
 PowerEdge
 Xeon
 Nvidia
+proctable


### PR DESCRIPTION
In flux-framework/flux-core#7673 and flux-framework/flux-core#7660 it was observed that once the leader job shell exits, services it provides (MPIR proctable, standard I/O, the shell exception service) are permanently unavailable, but nothing in the job record marks the transition. Tools get a bare `ENOSYS` and cannot distinguish a transient error from permanent
loss of services, and diagnosing the hang required poking live flux module stats job-exec data that doesn't survive the job.

This PR first adds a new Execution Eventlog Events section to RFC 21 and documents the existing events posted by the job execution system. Then it proposes a new `shell-exit` event, posted when the execution system observes leader shell termination. This will allow tools and other eventlog users to know when leader shell services are no longer available for a job, and also may serve as the start of a shell-exit timeout applied by the job-exec module to jobs to avoid jobs that hang with a job shell that is stuck at exit.