### PR TITLE
rfc50: add job execution eventlog specification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ check: $(SCHEMA_DIRS) spelling
 	./indexcheck spec_*.rst
 
 $(SCHEMA_DIRS):
-	python ./validate.py --schema=$@/schema.json $@/*.yaml
+	python3 ./validate.py --schema=$@/schema.json $@/*.yaml
 
 spelling:
 	@$(SPHINXBUILD) -W -b spelling "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Table of Contents
 - [47/Flux Framework Contributor Code of Conduct](spec_47.rst)
 - [48/Flux Framework Project Governance](spec_48.rst)
 - [49/TreePool Resource Set Extension](spec_49.rst)
+- [50/Job Execution Eventlog](spec_50.rst)
 
 Build Instructions
 ------------------

--- a/index.rst
+++ b/index.rst
@@ -319,6 +319,12 @@ This specification defines the format of the scheduling key used by the
 TreePool scheduler to encode sub-node topology in RFC 20 *R* version 1
 objects.
 
+:doc:`spec_50`
+~~~~~~~~~~~~~~
+
+This specification describes the events posted to the execution eventlog
+maintained by the Flux execution system in a job's guest KVS namespace.
+
 
 .. Each file must appear in a toctree
 .. toctree::
@@ -371,3 +377,4 @@ objects.
    spec_47
    spec_48
    spec_49
+   spec_50

--- a/spec_16.rst
+++ b/spec_16.rst
@@ -32,6 +32,7 @@ Related Standards
 - :doc:`spec_18`
 - :doc:`spec_20`
 - :doc:`spec_21`
+- :doc:`spec_50`
 
 Background
 **********
@@ -194,7 +195,8 @@ The *exec system* creates the job’s guest namespace and links it to
 ``job.<jobid>.guest``. Its initial contents are populated with
 
 ``exec.eventlog``
-   An eventlog for the use of *job shells*, TBD.
+   An eventlog containing events posted by the *exec system* and
+   *job shells*, described in :doc:`RFC 50 <spec_50>`.
 
 Once all *job shells* have exited and all outstanding writes to
 the guest namespace have stopped, the *exec system* links the guest

--- a/spec_41.rst
+++ b/spec_41.rst
@@ -33,6 +33,7 @@ Related Standards
 - :doc:`spec_21`
 - :doc:`spec_24`
 - :doc:`spec_25`
+- :doc:`spec_50`
 
 Background
 **********
@@ -53,7 +54,7 @@ Job info is stored in a job-specific KVS directory as described in
   * - **R**
     - resource set allocated to job (:doc:`RFC 20 <spec_20>`)
   * - **guest.exec.eventlog**
-    - exec system eventlog
+    - exec system eventlog (:doc:`RFC 50 <spec_50>`)
   * - **guest.input**
     - job input (:doc:`RFC 24 <spec_24>`)
   * - **guest.output**

--- a/spec_50.rst
+++ b/spec_50.rst
@@ -29,6 +29,7 @@ Related Standards
 - :doc:`spec_16`
 - :doc:`spec_18`
 - :doc:`spec_21`
+- :doc:`spec_22`
 - :doc:`spec_41`
 
 Background
@@ -151,6 +152,42 @@ Example:
 .. code:: json
 
    {"timestamp":1552593348.089211,"name":"log","context":{"component":"flux-shell","stream":"stderr","rank":"3","data":"example error message"}}
+
+Shell-exit Event
+================
+
+The job shell on the leader (first) broker rank of the job has terminated.
+Services provided to the job by the leader shell, such as the MPIR
+proctable used by tools and debuggers, standard I/O, and the shell
+exception service, are unavailable after this point. Tools observing
+this event SHOULD NOT attempt to contact the leader shell and MAY use
+this event to distinguish permanent loss of leader shell services from
+a transient error.
+
+The execution system SHALL post this event at most once per job, when it
+observes the termination of the leader shell, whether normal or abnormal.
+If the leader shell is lost without its termination status being observed,
+e.g. due to node failure, this event MAY be omitted.
+
+The following keys are REQUIRED in the event context object:
+
+rank
+   (integer) The broker rank on which the leader shell was executing.
+
+wait_status
+   (integer) The POSIX wait(2) status of the leader shell.
+
+The following keys are OPTIONAL in the event context object:
+
+active_ranks
+   (string) An RFC 22 idset of broker ranks on which job shells were
+   still active when the leader shell terminated.
+
+Example:
+
+.. code:: json
+
+   {"timestamp":1552593348.090112,"name":"shell-exit","context":{"rank":42,"wait_status":0,"active_ranks":"43-45"}}
 
 Done Event
 ==========

--- a/spec_50.rst
+++ b/spec_50.rst
@@ -1,0 +1,168 @@
+.. github display
+   GitHub is NOT the preferred viewer for this file. Please visit
+   https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_50.html
+
+50/Job Execution Eventlog
+#########################
+
+This specification describes the events posted to the execution eventlog
+maintained by the Flux execution system in a job's guest KVS namespace.
+
+.. list-table::
+  :widths: 25 75
+
+  * - **Name**
+    - github.com/flux-framework/rfc/spec_50.rst
+  * - **Editor**
+    - Mark A. Grondona <mark.grondona@gmail.com>
+  * - **State**
+    - raw
+
+Language
+********
+
+.. include:: common/language.rst
+
+Related Standards
+*****************
+
+- :doc:`spec_16`
+- :doc:`spec_18`
+- :doc:`spec_21`
+- :doc:`spec_41`
+
+Background
+**********
+
+In addition to the primary job eventlog described in RFC 21, the
+execution system maintains a separate eventlog at the ``exec.eventlog``
+key of the job's guest KVS namespace, found under the ``guest`` key of
+the job's KVS directory as described in RFC 16. Events in this eventlog
+are formatted as described in RFC 18.
+
+Unlike the events in the primary job eventlog, execution eventlog events
+SHALL NOT drive job state transitions and SHALL NOT be used as input to
+job state reconstruction. They provide synchronization points and
+provenance for the execution phase of the job.
+
+Events posted by the execution system itself have no prefix. Event names
+prefixed with ``shell.`` are reserved for events posted by the job shell.
+Such events MAY appear in the execution eventlog and their context
+objects are defined by the job shell implementation.
+
+Events beyond those listed below MAY appear in an execution eventlog.
+
+Execution Eventlog Events
+*************************
+
+Init Event
+==========
+
+The execution system has created the guest KVS namespace and begun
+initializing the job. The ``init`` event SHALL be the first event posted
+to the execution eventlog.
+
+The context SHALL be empty.
+
+Example:
+
+.. code:: json
+
+   {"timestamp":1552593348.073132,"name":"init"}
+
+Reattach Event
+==============
+
+The execution system has recovered the job after a potential restart
+of the execution system or enclosing instance. This event MAY appear
+one or more times in the execution eventlog after the ``init`` event.
+
+The context SHALL be empty.
+
+Example:
+
+.. code:: json
+
+   {"timestamp":1552597348.073132,"name":"reattach"}
+
+Starting Event
+==============
+
+The execution system is about to start the job shells.
+
+The context SHALL be empty.
+
+Example:
+
+.. code:: json
+
+   {"timestamp":1552593348.088563,"name":"starting"}
+
+Re-starting Event
+=================
+
+The execution system has successfully attached to the already executing
+job shells of a recovered job. This event MAY appear after a
+``reattach`` event.
+
+The context SHALL be empty.
+
+Example:
+
+.. code:: json
+
+   {"timestamp":1552597348.088563,"name":"re-starting"}
+
+Complete Event
+==============
+
+All job shells have terminated. The execution system SHALL post this
+event when it notifies the job manager of job completion. The job
+manager posts the corresponding ``finish`` event to the primary job
+eventlog in response to that notification, so the ``complete`` event
+precedes ``finish`` and carries the same wait status.
+
+The following keys are REQUIRED in the event context object:
+
+status
+   (integer) The job wait status as defined for the ``finish`` event
+   in RFC 21.
+
+Example:
+
+.. code:: json
+
+   {"timestamp":1552593348.090857,"name":"complete","context":{"status":0}}
+
+Log Event
+=========
+
+The execution system captured output from a job shell or other process
+launched on its behalf. These events are intended to aid debugging,
+especially of errors that occur before the job shell has initialized its
+own logging.
+
+There are no specific requirements for the event context, but it
+typically includes the component name, stream name, broker rank, and
+captured data.
+
+Example:
+
+.. code:: json
+
+   {"timestamp":1552593348.089211,"name":"log","context":{"component":"flux-shell","stream":"stderr","rank":"3","data":"example error message"}}
+
+Done Event
+==========
+
+Execution is complete and the execution system has ceased writing to the
+guest KVS namespace. The ``done`` event SHALL be the final event posted
+to the execution eventlog, as required by RFC 41.
+
+The context SHALL be empty.
+
+Example:
+
+.. code:: json
+
+   {"timestamp":1552593348.104072,"name":"done"}

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -528,3 +528,4 @@ Rv1
 PowerEdge
 Xeon
 Nvidia
+proctable


### PR DESCRIPTION
The execution system maintains an eventlog at `exec.eventlog` in the job's guest KVS namespace, but the events posted there are not documented in any RFC. RFC 16 declares the eventlog's contents "TBD" and RFC 41 normatively requires its terminating "done" event with no specification to reference.

Add RFC 50/Job Execution Eventlog documenting the events posted by the execution system , note that these events do not drive job state transitions, and reserve the "shell." prefix for events posted by the job shell. Update dangling references to point readers to RFC 50. Finally, propose a new `shell-exit` event that the execution system posts when it records termination of the leader job shell.