### PR TITLE
propose redacted R stored in KVS as `R_redacted`

### DIFF
--- a/spec_16.rst
+++ b/spec_16.rst
@@ -124,8 +124,8 @@ Guests may access data in the primary KVS namespace only through instance
 services that allow selective guest access, by proxy or by staging copies
 to the guest namespace.
 
-Guest access for primary namespace contents ``R``, ``J``, ``jobspec``, and
-``eventlog`` is provided via a proxy service in the instance.
+Guest access for primary namespace contents ``R``, ``R_redacted``, ``J``,
+``jobspec``, and ``eventlog`` is provided via a proxy service in the instance.
 
 Event Log
 =========
@@ -175,14 +175,26 @@ Content Consumed/Produced by Scheduler
 When the *scheduler* receives an allocation request containing a jobid,
 it reads the jobspec from ``job.<jobid>.jobspec``.
 
-The scheduler allocates resources by writing a resource set
-as described in :doc:`RFC 20 <spec_20>`
-to ``job.<jobid>.R`` and answering the allocation request.
+The scheduler allocates resources by writing the complete resource set as
+described in :doc:`RFC 20 <spec_20>` to ``job.<jobid>.R`` and a copy with the
+OPTIONAL :data:`scheduling` key (RFC 20) omitted to ``job.<jobid>.R_redacted``,
+then answering the allocation request.  ``R_redacted`` is intended for
+consumers that need only the execution portion, such as job shells.
 
-The scheduler frees resources by answering the free request,
-leaving ``R`` in place for job provenance. During a restart, the
-*job manager* uses the eventlog to determine whether ``R`` is currently
-allocated.
+``job.<jobid>.R``
+   The complete resource set including :data:`scheduling` (RFC 20) if present.
+   Read by the scheduler on hello/replay and by the subinstance resource module
+   so that :data:`scheduling` propagates down the instance hierarchy.
+
+``job.<jobid>.R_redacted``
+   A copy of ``job.<jobid>.R`` with the OPTIONAL :data:`scheduling` key (RFC 20)
+   omitted.  A resource set with :data:`scheduling` omitted remains a conformant
+   RFC 20 *R* since :data:`scheduling` is OPTIONAL.  Read by job shells and
+   other consumers that do not require scheduler-specific data.
+
+The scheduler frees resources by answering the free request, leaving ``R`` and
+``R_redacted`` in place for job provenance.  During a restart, the *job manager*
+uses the eventlog to determine whether ``R`` is currently allocated.
 
 Content Consumed/Produced by Exec Service
 =========================================

--- a/spec_20.rst
+++ b/spec_20.rst
@@ -240,6 +240,19 @@ R Format
   (RFC 27) so that it may be included in static configuration, allocated to
   jobs, and passed down a Flux instance hierarchy.
 
+  A component that persists *R* MAY additionally store a copy of *R* with the
+  OPTIONAL :data:`scheduling` key omitted, for distribution to consumers that
+  do not require it.  Such a redacted copy remains a conformant RFC 20 *R*
+  since :data:`scheduling` is OPTIONAL.  The complete *R* including
+  :data:`scheduling` remains available for consumers that require it.
+
+  .. note::
+    :data:`scheduling` is independent of expiration.  The RFC 21
+    ``resource-update`` event updates :data:`execution.expiration` only and
+    never modifies :data:`scheduling`.  Expiration updates may therefore be
+    applied to either the complete or the redacted copy of *R* (by replaying
+    ``resource-update`` events) without affecting :data:`scheduling` in any way.
+
   Linkage to specific resources in :data:`R_lite` SHOULD use hostnames rather
   than execution targets since the scheduler-agnostic re-ranking of *R* that
   occurs when a new Flux instance is started cannot do the same for the opaque

--- a/spec_27.rst
+++ b/spec_27.rst
@@ -327,8 +327,19 @@ If resources can be allocated, the scheduler SHALL ensure that both
 (the copy with :data:`scheduling` omitted) have been successfully committed to
 the KVS per the job schema (RFC 16) before responding.
 
-In addition to the above REQUIRED keys, the SUCCESS response includes
-the OPTIONAL key:
+In addition to the above REQUIRED keys, the SUCCESS response includes the
+following REQUIRED key:
+
+R
+  (object) the allocated resource set (RFC 20).  The job manager consumes this
+  resource set directly and need not read it back from the KVS.  Since the job
+  manager requires only the execution portion, the scheduler MAY omit the
+  OPTIONAL :data:`scheduling` key from *R* in this response; the job manager
+  SHALL NOT rely on :data:`scheduling` being present here.  The complete *R*
+  including :data:`scheduling` is persisted to ``job.<jobid>.R`` (RFC 16),
+  which is how :data:`scheduling` rides the allocation protocol per RFC 20.
+
+The SUCCESS response also includes the following OPTIONAL key:
 
 annotations
   (object) key value pairs
@@ -340,6 +351,20 @@ Example:
    {
      "id": 1552593348,
      "type": 0,
+     "R": {
+       "version": 1,
+       "execution": {
+         "R_lite": [
+           {
+             "rank": "0-1",
+             "children": {"core": "0"}
+           }
+         ],
+         "nodelist": ["host[0-1]"],
+         "starttime": 1552593348.0,
+         "expiration": 1552600548.0
+       }
+     },
      "annotations": {
        "sched": {
          "resource_summary":"rank[0-1]/core0"

--- a/spec_27.rst
+++ b/spec_27.rst
@@ -322,9 +322,10 @@ The ``alloc`` request MAY receive multiple responses.
 Alloc Success
 -------------
 
-If resources can be allocated, the scheduler SHALL ensure that *R* has
-been successfully committed to the KVS per the job schema (RFC 16)
-before responding.
+If resources can be allocated, the scheduler SHALL ensure that both
+``job.<jobid>.R`` (the complete resource set) and ``job.<jobid>.R_redacted``
+(the copy with :data:`scheduling` omitted) have been successfully committed to
+the KVS per the job schema (RFC 16) before responding.
 
 In addition to the above REQUIRED keys, the SUCCESS response includes
 the OPTIONAL key:

--- a/spec_28.rst
+++ b/spec_28.rst
@@ -90,6 +90,9 @@ resources
   (object) RFC 20 (R version 1) resource object that contains the full resource
   inventory, less execution targets excluded by configuration.  The scheduler
   MAY use this set to determine the general satisfiability of job requests.
+  Per RFC 20, the :data:`scheduling` key rides along on this response if
+  present, even though a redacted copy of *R* without :data:`scheduling` may
+  be persisted or distributed to consumers that do not require it.
 
 up
   (string) RFC 22 idset of execution targets in ``resources`` that are


### PR DESCRIPTION
This PR updates relevant RFCs to require that an Rv1 object with any `scheduling` key be stored in the KVS as `R_redacted` co-located with any full `R`. This is to solve the issue of a large scheduling key being unnecessarily fetched from the KVS for consumers that only need the execution section. See flux-framework/flux-core#7615

A commit is also included that adds a missing requirement to the resource acquisition protocol that R be sent in the alloc response (de-facto requirement in the code now). The scheduling key is made OPTIONAL in this response in keeping with the spirit of this PR.