### PR TITLE
document `scheduling.location` in R to allow separate storage of `scheduling` key

### DIFF
--- a/spec_16.rst
+++ b/spec_16.rst
@@ -179,6 +179,21 @@ The scheduler allocates resources by writing a resource set
 as described in :doc:`RFC 20 <spec_20>`
 to ``job.<jobid>.R`` and answering the allocation request.
 
+``job.<jobid>.R`` is the canonical resource set for the job. Its
+:data:`scheduling` object (RFC 20), if present, MAY be stored out-of-line
+in ``job.<jobid>.scheduling`` and referenced by a :data:`scheduling.location`
+key rather than stored directly within *R*. Consumers that require the
+complete *R* (e.g. the scheduler during hello/replay, or a subinstance
+resource module) SHALL obtain it by reading both ``job.<jobid>.R`` and
+``job.<jobid>.scheduling`` and merging them, or by requesting the complete
+*R* from a service that performs this reassembly.
+
+``job.<jobid>.scheduling`` is an OPTIONAL write-once key that holds the
+complete :data:`scheduling` object referenced by :data:`scheduling.location`
+in ``job.<jobid>.R``. It SHALL be written before ``job.<jobid>.R`` is
+committed so that the referenced data is available as soon as the reference
+is visible.
+
 The scheduler frees resources by answering the free request,
 leaving ``R`` in place for job provenance. During a restart, the
 *job manager* uses the eventlog to determine whether ``R`` is currently

--- a/spec_20.rst
+++ b/spec_20.rst
@@ -233,12 +233,40 @@ R Format
     components SHALL be interpreted by the named scheduler.  If not
     provided, a value of ``fluxion`` SHALL be assumed.
 
+  .. data:: location
+
+    (*string*, OPTIONAL) A KVS key path at which the :data:`scheduling`
+    object is stored out-of-line. When :data:`scheduling` is stored
+    out-of-line, :data:`location` SHALL be present and the referenced KVS
+    key SHALL contain a complete :data:`scheduling` object. The referenced
+    key is written once and never rewritten. Per-job the conventional key
+    is ``job.<id>.scheduling``; for the instance resource inventory the
+    conventional key is ``resource.scheduling``.
+
+    A consumer that requires the complete :data:`scheduling` object SHALL
+    obtain it either by fetching the key named by :data:`location` itself,
+    or by requesting a complete *R* from a service that performs the
+    reassembly on its behalf. A service that provides *R* (such as a job
+    information service) MAY offer this reassembly on demand, controlled by
+    a request option. The default behavior of such a service is
+    implementation-defined and MAY change over time, so a requester that
+    requires a specific behavior SHOULD request it explicitly.
+
   Remaining scheduler-specific keys SHOULD be ignored by other Flux components.
 
-  When used, :data:`scheduling` SHALL ride along on the
-  resource acquisition protocol (RFC 28) and resource allocation protocol
-  (RFC 27) so that it may be included in static configuration, allocated to
-  jobs, and passed down a Flux instance hierarchy.
+  When used, :data:`scheduling` SHALL ride along on the resource acquisition
+  protocol (RFC 28) and resource allocation protocol (RFC 27) so that it may
+  be included in static configuration, allocated to jobs, and passed down a
+  Flux instance hierarchy. When :data:`scheduling` is stored out-of-line via
+  :data:`location`, it rides these protocols by virtue of being retrievable
+  from the KVS and reassembled by the persistence layer.
+
+  A component persisting *R* to the KVS MAY store the :data:`scheduling`
+  object out-of-line via :data:`location` to keep the stored *R* compact while
+  still providing access to the complete scheduler data via the referenced
+  key. Because :data:`scheduling` is independent of expiration, only the
+  stored *R* is rewritten when expiration is updated per RFC 21; the
+  out-of-line :data:`scheduling` key is never rewritten.
 
   Linkage to specific resources in :data:`R_lite` SHOULD use hostnames rather
   than execution targets since the scheduler-agnostic re-ranking of *R* that

--- a/spec_27.rst
+++ b/spec_27.rst
@@ -326,8 +326,24 @@ If resources can be allocated, the scheduler SHALL ensure that *R* has
 been successfully committed to the KVS per the job schema (RFC 16)
 before responding.
 
-In addition to the above REQUIRED keys, the SUCCESS response includes
-the OPTIONAL key:
+In addition to the above REQUIRED keys, the SUCCESS response includes the
+following REQUIRED key:
+
+R
+  (object) the allocated resource set (RFC 20). The job manager consumes this
+  resource set directly and need not read it back from the KVS. Since the job
+  manager requires only the execution portion, the scheduler MAY omit the
+  OPTIONAL :data:`scheduling` key from *R* in this response; the job manager
+  SHALL NOT rely on :data:`scheduling` being present here. The scheduler SHALL
+  persist *R* to ``job.<jobid>.R`` (RFC 16) before responding; if the
+  scheduler stores :data:`scheduling` out-of-line (RFC 20), it SHALL write the
+  complete :data:`scheduling` object to ``job.<jobid>.scheduling`` and
+  reference it with a :data:`scheduling.location` key in ``job.<jobid>.R``.
+  This is how :data:`scheduling` rides the allocation protocol per RFC 20: it
+  is retrievable from the KVS and reassembled by the persistence layer for
+  consumers that require the complete *R*.
+
+The SUCCESS response also includes the following OPTIONAL key:
 
 annotations
   (object) key value pairs
@@ -339,6 +355,20 @@ Example:
    {
      "id": 1552593348,
      "type": 0,
+     "R": {
+       "version": 1,
+       "execution": {
+         "R_lite": [
+           {
+             "rank": "0-1",
+             "children": {"core": "0"}
+           }
+         ],
+         "nodelist": ["host[0-1]"],
+         "starttime": 1552593348.0,
+         "expiration": 1552600548.0
+       }
+     },
      "annotations": {
        "sched": {
          "resource_summary":"rank[0-1]/core0"

--- a/spec_28.rst
+++ b/spec_28.rst
@@ -90,6 +90,12 @@ resources
   (object) RFC 20 (R version 1) resource object that contains the full resource
   inventory, less execution targets excluded by configuration.  The scheduler
   MAY use this set to determine the general satisfiability of job requests.
+  This object's :data:`scheduling` object (RFC 20) MAY be stored out-of-line
+  and referenced by a :data:`scheduling.location` key rather than stored
+  directly within the object; in that case the complete :data:`scheduling`
+  data is available at the referenced KVS key (conventionally
+  ``resource.scheduling``) and the resource module is responsible for
+  reassembling the complete *R* for consumers that require it.
 
 up
   (string) RFC 22 idset of execution targets in ``resources`` that are


### PR DESCRIPTION
Based on @garlick's idea in #523, this alternate proposal specifies a new `scheduling.location` key in R which, when present, denotes a separate storage location for the R `scheduling` key in the KVS. Components reading R directly from the KVS will therefore read only the base R by default and will need to separately fetch any `scheduling` key if required.

A couple design decisions of note:
- A new `scheduling.location` key was chosen rather than extending the `scheduling.writer` as suggested in #523 as a separation of concerns approach. This allows `scheduling.writer` to appear in its original form in the separately stored `scheduling` object. The object itself is self-contained and the writer key can be read from there.
- RFC 27 is updated to explicitly require R as REQUIRED in a alloc success response. Since the job manager immediately deletes the R `scheduling` key anyway, the scheduler is allowed to drop the `scheduling` key in the response. Not sure if it would be useful to keep it when it only contains a `location` key.

This proposal as-is would break backwards compatibility with any component that assumes the full R will be returned when R is fetched from the KVS, job-info service, etc. This includes the `resource` and `sched-fluxion-resource` modules in subinstances, which make use of `job-info`. For a seamless transition, one plan would be to introduce two new flags in the `job-info` lookup protocol:
- `assemble` - if the key (e.g. R) is stored in parts, job-info returns the fully assembled result
- `no-assemble` - if the key is stored in parts, job-info does *not* assemble the result

Then, `assemble` is the default in the initial version of the implementation. This keeps backwards compatibility for subinstances of differing Flux versions. Components that do not need the scheduling key in R (like same-version job shells), add the `no-assemble` flag to the `job-info.lookup` RPC. After awhile, we switch the default and all components keep working as is. The `no-assemble` flag could eventually be retired.

Components that fetch R directly from the KVS will always get the unassembled version. However, these are all same-version components and for the most part (except for resource module restart) want only the unassembled R so I don't think there's an compatibility issue there.