### PR TITLE
rfc1: add AI coding assistant policy

### DIFF
--- a/spec_1.rst
+++ b/spec_1.rst
@@ -88,6 +88,8 @@ Licensing and Ownership
 
 -  The copyrights in the project SHALL be owned collectively by all its Contributors.
 
+-  A Contributor SHALL ensure that a patch is compatible with the project license and does not incorporate material under an incompatible license, including material reproduced by an AI coding assistant.
+
 -  The git commit history SHALL be considered the primary source of contributor identities.
 
 Patch Requirements
@@ -124,6 +126,12 @@ Patch Requirements
 -  Where applicable, a commit message body SHOULD reference an Issue by number (e.g. Fixes #33").
 
 -  A commit message body SHOULD begin with ``Problem:`` and a short paragraph describing the problem solved by the commit.  Even commits that add features MAY include such a problem statement.
+
+-  A Contributor SHALL take full responsibility for a patch, including its correctness, quality, and license compliance, regardless of whether an AI coding assistant was used in its preparation.
+
+-  An AI coding assistant SHOULD NOT be credited as an author or co-author of a patch (e.g. via a ``Co-authored-by`` trailer), because authorship implies a responsibility that only a human Contributor can hold. This does not apply to human co-authors, who SHOULD continue to be credited.
+
+-  Where an AI coding assistant was used to prepare a patch, the commit message body SHOULD record this with an ``Assisted-by:`` trailer of the form ``Assisted-by: NAME:MODEL_VERSION``, for example ``Assisted-by: Claude:claude-opus-4-8``.
 
 -  A "Correct Patch" is one that satisfies the above requirements.
 

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -529,3 +529,4 @@ PowerEdge
 Xeon
 Nvidia
 proctable
+Claude


### PR DESCRIPTION
Problem: When AI coding assistants are used to prepare a patch, a Co-authored-by trailer crediting the model asserts authorship, which could be read as shifting responsibility for the contribution away from the human Contributor.

Emphasize that a Contributor takes full responsibility for a patch regardless of AI assistance, including its correctness, quality, and license compliance.  Discourage crediting an AI coding assistant as an author or co-author and recommend recording AI assistance with an Assisted-by trailer instead.

This tracks loosely with the linux kernel's coding assistant policy which I think we generally agreed was sensible.  We've been using Co-authored-by until now.  This is not intended to be a retroactive change, just for contributions going forward.