### PR TITLE
rfc27: add `sched.selection_type` key to example annotations

### DIFF
--- a/spec_27.rst
+++ b/spec_27.rst
@@ -404,6 +404,10 @@ sched.resource_summary
 sched.queue
   (string) human readable identification of job queue
 
+sched.selection_type
+  (string) human readable identification of the scheduler's selected method 
+  invoked to schedule the job (i.e. immediate, reserved, backfilled)
+
 user
   (dictionary) dictionary object containing user specific annotations
 

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -531,3 +531,4 @@ Nvidia
 proctable
 Claude
 validators
+backfilled


### PR DESCRIPTION
I have a work-in-progress prototype of this behavior on my fork of flux-sched (see the [`backfill_annotate`](https://github.com/wihobbs/flux-sched/tree/backfill-annotate) branch.)

This proposal is a small change to the resource allocation protocol to add a "start method" to the list of example scheduler annotations for a successful job. This would capture data about the scheduling 'method' that was invoked when the job was scheduled. 

I don't mind if this waits until a scheduler actually implements it to go in, but wanted to put it up.