### PR TITLE
rfc42: guarantee EOF delivery on attach

### DIFF
--- a/spec_42.rst
+++ b/spec_42.rst
@@ -315,6 +315,13 @@ streaming :program:`exec` responses. The server SHALL send:
 - :program:`exec attached` response to indicate successful attachment
 - :program:`exec output` responses for any buffered output and subsequent
   output matching the target subprocess flags
+- exactly one :program:`exec output` response with the EOF flag set for each
+  forwarded output stream, whether the stream reaches end-of-file before or
+  after the attach request, and on every attach regardless of how many times
+  the subprocess has been attached and detached (output *data* produced before
+  the attach request MAY be lost as noted above, but the end-of-file
+  indication is always delivered so the client can reconcile the forwarded
+  streams named by the flags)
 - :program:`exec stopped` response if the subprocess is stopped
 - :program:`exec finished` response when the subprocess terminates
 - :program:`exec error` response with ENODATA (61) to indicate successful


### PR DESCRIPTION
Problem: The attach RPC reports the flags the subprocess was originally started with, which tell the client which output streams to expect, but if a stream reaches EOF prior to the attach, the specification does not require an EOF response to be synthesized.

State in the attach response stream requirements that the server sends exactly one EOF output response for each forwarded stream, whether the stream ends before or after the attach and on every attach

Assisted-by: Claude:opus-4.8