### PR TITLE
rfc42: clarify background subproc input handling

### DIFF
--- a/spec_42.rst
+++ b/spec_42.rst
@@ -112,7 +112,10 @@ request, a single response SHALL be sent: either an :program:`exec started`
 response if successful, or an :program:`exec error` response on failure. The
 subprocess SHALL continue running as a child of the subprocess server until
 it terminates or the server is shut down. The server MAY log subprocess
-output and exit code to its own log stream.
+output and exit code to its own log stream. The subprocess's standard input,
+and any writable auxiliary channels, SHALL be at end-of-file, since a
+background subprocess that reads them could otherwise silently block while
+no client is attached.
 
 .. object:: exec request
 
@@ -143,7 +146,9 @@ output and exit code to its own log stream.
 
     write-credit (8)
       Send ``add-credit`` exec responses when buffer space is available
-      for standard input or writable auxiliary channels.
+      for standard input or writable auxiliary channels.  This flag SHALL
+      NOT be combined with a non-streaming (background mode) request; doing
+      so is an error.
 
     waitable (16)
       Allow the subprocess to be waited on with a ``wait`` RPC.
@@ -154,7 +159,8 @@ output and exit code to its own log stream.
 
     stdio-fallthrough (1)
       Let subprocess inherit stdin, stdout, and stderr file descriptors
-      from the subprocess server.
+      from the subprocess server.  This flag SHALL NOT be combined with a
+      non-streaming (background mode) request; doing so is an error.
 
     no-setpgrp (2)
       Do not call setpgrp(2) before exec.  Use kill(2) instead of killpg(2)


### PR DESCRIPTION
Problem: the specification does not state how input (standard input and writable auxiliary channels) should be handled in a background subprocess.

There is no strong use case for input processing in background subprocesses, but since the spec does not address this, implementations would presumably need to add support for resuming an input stream on reattach.

Close off this area by stating that a background subprocess's standard input and writable auxiliary channels are at EOF.  As a consequence, the write-credit and stdio-fallthrough flags, which request input handling, are errors when combined with a non-streaming request.

Assisted-by: Claude:opus-4.8