### PR TITLE
rfc43: add `t_priority`, `t_sched` attributes

### DIFF
--- a/spec_43.rst
+++ b/spec_43.rst
@@ -103,6 +103,12 @@ The job list service SHALL support the following attributes.
    * - ``t_run``
      - time job entered run state
      - real
+   * - ``t_priority``
+     - time job first entered priority state
+     - real
+   * - ``t_sched``
+     - time job first entered sched state
+     - real
    * - ``t_cleanup``
      - time job entered cleanup state
      - real


### PR DESCRIPTION
#### Problem

The "Job Attributes" section in RFC43 does not list the `t_priority` or `t_sched` attributes, which were added to the `job-list` service in flux-framework/flux-core#7684.

---

This PR just adds them to the table.