### PR TITLE
rfc33: add queue aliases

### DIFF
--- a/spec_33.rst
+++ b/spec_33.rst
@@ -219,6 +219,45 @@ queues.NAME.policy
   top-level ``policy`` table  and a queue-specific ``policy`` table, the
   queue-specific value takes precedence for jobs submitted to that queue.
 
+queues.NAME.parent
+  (string) Declare this queue to be a virtual queue backed by another
+  configured queue, as described in `Virtual Queues`_ below.
+
+Virtual Queues
+--------------
+
+A queue configured with a ``parent`` key is a *virtual queue*: an
+alternate name for submitting jobs to the parent queue's resources
+with different policy applied at ingest.
+
+Configuration SHALL be rejected if ``parent`` does not name a
+configured queue, or if the named queue is itself a virtual queue.
+
+A virtual queue SHALL inherit the resource subset and effective policy
+of its parent queue.  It MAY override inherited policy values in its
+own ``policy`` table, but MUST NOT be configured with ``requires`` or
+``policy.scheduler``.  The effective policy of a virtual queue SHALL
+be determined when the configuration is processed.
+
+The queue attribute of a job submitted to a virtual queue SHALL NOT be
+rewritten: the job retains the virtual queue name for job listing,
+accounting, and per-queue policy application.
+
+Jobs submitted to a virtual queue SHALL be scheduled as part of its
+parent queue, in a single priority order with jobs submitted directly
+to the parent queue.
+
+Job submission on a virtual queue MAY be enabled or disabled
+independently of its parent queue.  Since virtual queue jobs are
+scheduled as part of the parent queue, a virtual queue SHALL share its
+parent queue's started or stopped state and SHALL NOT be started or
+stopped directly.  For the same reason, waiting for a virtual queue to
+become empty or idle SHALL NOT be supported, and waiting for a queue
+to become empty or idle SHALL take into account jobs submitted to its
+virtual queues.
+
+A virtual queue MAY be designated as the default queue.
+
 Initial Assignment of Job to Queue
 ----------------------------------
 
@@ -260,6 +299,11 @@ TOML table.
 The service providing data to the job listing tool SHOULD list pending and
 running jobs in the default queue by default.  An option SHALL be provided
 to request jobs in other queues by name, or all queues.
+
+A request for jobs by parent queue name SHOULD include jobs submitted
+to its virtual queues, since all are scheduled in a single priority
+order.  A request by virtual queue name SHOULD include only jobs
+submitted to that virtual queue.
 
 The job submission tools SHOULD leave the queue unset (thereby selecting
 the default.  An option SHALL be provided to direct jobs to other


### PR DESCRIPTION
Opening this RFC 33 proposal to get some discussion going.

Problem: Creating an alternate job submission path with different limits, access, or priority (the "expedite"/"exempt" patterns of flux-framework/flux-core#4306) currently requires configuring a fully independent queue, duplicating resource configuration and creating a separate scheduling queue for no scheduling reason — something RFC 33's design criteria explicitly warn against.

This amendment adds *queue aliases*: an optional `queues.NAME.parent` key declaring a queue to be an alternate name for an existing queue. An alias inherits its parent's resource subset and policy, may override inherited policy at ingest, and shares its parent's scheduling order. The job's queue attribute is never rewritten.

Notes for discussion:

- **Key naming**: `parent` is the proposal; `alias-of` and `inherits-from` were also considered. "Parent" is admittedly overloaded with the parent *instance* concept, but the key only appears within a `queues.NAME.` table where that reading isn't plausible, and prose always qualifies as "parent queue."
- **Priority**: initially handled by flux-accounting's per-queue priority factor (no accounting changes needed). A core-side follow-up could add simple built-in policies, e.g. per-queue default urgency (`urgency = 16` makes an "expedite" alias work out of the box; see also flux-framework/flux-core#5795). Deliberately not specified here.
- **Job listing**: requesting jobs by parent name SHOULD include alias jobs (single scheduling order); requesting by alias name is exact. (More thought needed on implementation here)
- **Administrative state**: submission enable/disable is independent per alias. Started/stopped state follows the parent, and drain/idle are not supported on an alias (even once flux-framework/flux-core#4821 is fixed), since alias jobs are scheduled as part of the parent queue and an alias has no resources of its own to quiesce. Conversely, drain/idle on a queue must count jobs submitted to its aliases.
- **v1 restriction**: an alias's parent must not itself be an alias.

Fluxion support will require one small change to detect aliases and direct jobs to the parent queue internally.