### PR TITLE
rfc42: add output key to wait response

### DIFF
--- a/spec_42.rst
+++ b/spec_42.rst
@@ -501,12 +501,29 @@ with the waitable flag set.
 
 .. object:: wait response
 
-  A successful response SHALL consist of a JSON object with the following key:
+  A successful response SHALL consist of a JSON object with the following keys:
 
   .. object:: status
 
     (*integer*, REQUIRED) The UNIX wait status value as returned by
     :func:`waitpid`.
+
+  .. object:: output
+
+    (*array*, OPTIONAL) Output produced by the subprocess and retained by the
+    server. Each element SHALL be an I/O object (see `I/O Object`_) of the same
+    form carried by the :program:`exec output` response. The array SHALL
+    preserve the order in which the output was produced.
+
+    The amount of output retained is server-defined and MAY be zero. The
+    retained output MAY be incomplete, and the server has no obligation to
+    indicate that output was discarded or lost.
+
+    The wait response is sent only after the subprocess has terminated and is
+    self-terminating. Retained I/O objects SHALL NOT be required to include an
+    end-of-file marker.
+
+    The key MAY be omitted if the server retained no output.
 
 Request Authentication
 ======================


### PR DESCRIPTION
Problem: the subprocess wait RPC cannot return any output, but this may be useful in a future design where wait reaps background flux-shell processes that may have emitted important failure telemetry on stderr.

Add an optional 'output' key to the wait response.  The key is purposefully specified to be incomplete and optional so that server retention (and thus the wait response message size) can be capped to scalable levels.  This framing also permits a server implementation such as sdexec to remain conformant while allowing an I/O monitoring lapse across a server restart.

Assisted-by: Claude:opus-4.8