### PR TITLE
rfc50: add recoverable event

### DIFF
--- a/spec_50.rst
+++ b/spec_50.rst
@@ -30,6 +30,7 @@ Related Standards
 - :doc:`spec_18`
 - :doc:`spec_21`
 - :doc:`spec_22`
+- :doc:`spec_32`
 - :doc:`spec_41`
 
 Background
@@ -113,6 +114,29 @@ Example:
 .. code:: json
 
    {"timestamp":1552597348.088563,"name":"re-starting"}
+
+Recoverable Event
+=================
+
+The execution system has determined that the job has reached a state from
+which its job shells can be recovered if the execution system or enclosing
+instance restarts. A reattaching execution service MAY consult the execution
+eventlog for this event to distinguish a job whose shells are recoverable
+from one that never reached that state.
+
+Whether a job ever becomes recoverable depends on the execution mechanism:
+a service that cannot recover running shells SHALL NOT post this event, and
+a service that can SHALL post it at most once per job, when the job first
+becomes recoverable. This event MAY appear before a ``complete`` event, and
+if present SHALL follow the ``starting`` event.
+
+The context SHALL be empty.
+
+Example:
+
+.. code:: json
+
+   {"timestamp":1552593348.089012,"name":"recoverable"}
 
 Complete Event
 ==============


### PR DESCRIPTION
Problem: RFC 32 lets a reloaded execution service recover a job's already-running shells "if still present," but nothing in the execution eventlog records whether a job ever reached a state from which its shells can be recovered, so a reattaching service cannot deterministically decide between adopting the job and raising an exception.

Add an optional "recoverable" event to the RFC 50 execution eventlog, posted by the execution service when a job first becomes recoverable. The event is deliberately mechanism-agnostic: whether and when a job becomes recoverable is a property of the execution mechanism, so a service that cannot recover running shells never posts it.

Assisted-by: Claude:opus-4.8