### PR TITLE
rfc33: document queue status response and add `blocked` state for vqueues

### DIFF
--- a/spec_33.rst
+++ b/spec_33.rst
@@ -316,13 +316,44 @@ stop_reason
   (string) the reason scheduling is stopped.  This key MAY be present
   when ``start`` is false.
 
+blocked
+  (boolean) the queue is started but prevented from scheduling by an
+  external condition.  This key SHALL be present and true when such a
+  condition exists, and SHALL be omitted otherwise.
+
+parent
+  (string) the parent queue name.  This key SHALL be present when the
+  queue is a virtual queue.
+
 Additional keys MAY be present.
 
 A queue that is started but prevented from scheduling by an external
-condition SHALL be reported with ``start`` false and a ``stop_reason``
-identifying the condition.  For example, when no scheduler is loaded,
-every queue SHALL be reported this way with a reason such as
-"Scheduler is offline".
+condition SHALL be reported with ``start`` false, ``blocked`` true, and
+a ``stop_reason`` identifying the condition.  Two such conditions
+exist: no scheduler is loaded (e.g. "Scheduler is offline"), and a
+virtual queue's parent queue is stopped (e.g. "parent queue 'batch' is
+stopped").  A blocked queue resumes scheduling without administrative
+action on the queue itself when the condition clears.  Note that a
+queue's own started state is recoverable from the status as the
+logical OR of ``start`` and ``blocked``.
+
+For example, the status of a virtual queue that has been started while
+its parent queue ``batch`` is stopped:
+
+.. code-block:: json
+
+   {
+     "enable": true,
+     "start": false,
+     "blocked": true,
+     "parent": "batch",
+     "stop_reason": "parent queue 'batch' is stopped"
+   }
+
+``start`` reports the effective state: jobs in this queue are not being
+scheduled.  ``blocked`` reports why: no administrative action stopped
+this queue, and it begins scheduling as soon as its parent queue is
+started.
 
 Job Submission and Listing Tools
 --------------------------------

--- a/spec_33.rst
+++ b/spec_33.rst
@@ -294,6 +294,36 @@ A Flux command line tool SHALL provide the ability to wait for a queue to
 become idle, or for all queues to become idle, where idle is defined as
 containing no jobs in RUN or CLEANUP state.
 
+Queue Status
+------------
+
+A service SHALL provide the status of a queue on request.  The status
+SHALL be a JSON object with the following REQUIRED keys:
+
+enable
+  (boolean) job submission is enabled.
+
+start
+  (boolean) scheduling is started.
+
+The following keys are OPTIONAL:
+
+disable_reason
+  (string) the reason submission is disabled.  This key SHALL be present
+  when ``enable`` is false.
+
+stop_reason
+  (string) the reason scheduling is stopped.  This key MAY be present
+  when ``start`` is false.
+
+Additional keys MAY be present.
+
+A queue that is started but prevented from scheduling by an external
+condition SHALL be reported with ``start`` false and a ``stop_reason``
+identifying the condition.  For example, when no scheduler is loaded,
+every queue SHALL be reported this way with a reason such as
+"Scheduler is offline".
+
 Job Submission and Listing Tools
 --------------------------------
 


### PR DESCRIPTION
Problem: When a virtual queue is started but its parent queue is stopped, the queue is not scheduling: its jobs wait until the parent starts. Reporting this state truthfully with the existing payload forces a bad choice: report `start: true` and the queue looks like it should be scheduling when it isn't (an admin debugging "why won't my job run" is misled), or report `start: false` and it looks like someone stopped the queue when no one did - hiding that it is armed to begin scheduling the moment its parent starts, which an admin needs to know before starting the parent.

This PR first documents the existing queue status protocol, then introduces a `blocked` flag to indicate that a queue has `start: false` due to an external condition, i.e. if a vqueue has `start: false` and `blocked: true` then the vqueue is stopped by an external condition, o/w if `blocked: false` then the vqueue is stopped by an admin and needs a `flux queue start`. This also resolves a similar ambiguity when a normal queue is stopped due to the scheduler being unloaded.

 