### PR TITLE
rfc20: reserve leading + for instance-local properties

### DIFF
--- a/spec_20.rst
+++ b/spec_20.rst
@@ -194,6 +194,15 @@ R Format
     result in both ``amd-mi50@gpu`` and ``amd-mi50`` being valid properties
     for resources in the instance.
 
+    A leading ``+`` character marks an *instance-local* property: one that
+    describes the containing instance rather than an attribute of the
+    hardware, for example a property derived from queue membership. The
+    literal property SHALL apply to the defined execution target ranks as
+    usual. Because instance-local properties describe the instance and not
+    the resources themselves, a scheduler SHALL omit them from the *R* it
+    generates to allocate resources to a job. Other components that
+    generate an *R* subset MAY likewise omit them.
+
   .. data:: starttime
 
     (*number*, OPTIONAL) The start time at which the resource set is valid.


### PR DESCRIPTION
Problem: There is no way to differentiate properties in a resource set that were applied automatically by Flux apart from a property configured manually, so tooling cannot know which properties describe the instance versus the resources. This leads to allocated R objects inheriting properties that may have no meaning in a subinstance.

Reserve a leading + in a property name to mark a property that Flux added automatically rather than one configured manually.  The literal property still applies to its execution target ranks, but because it describes the containing instance it is intended for internal use and MAY be omitted from a resource set allocated to a job.

Assisted-by: Claude:Opus-4.8