### PR TITLE
rfc50: drop re-starting event

### DIFF
--- a/spec_50.rst
+++ b/spec_50.rst
@@ -75,8 +75,8 @@ Example:
 Reattach Event
 ==============
 
-The execution system has recovered the job after a potential restart
-of the execution system or enclosing instance. This event MAY appear
+The execution system has recovered the job's KVS namespace and is
+starting to reattach to its job shells.  This event MAY appear
 one or more times in the execution eventlog after the ``init`` event.
 
 The context SHALL be empty.

--- a/spec_50.rst
+++ b/spec_50.rst
@@ -100,21 +100,6 @@ Example:
 
    {"timestamp":1552593348.088563,"name":"starting"}
 
-Re-starting Event
-=================
-
-The execution system has successfully attached to the already executing
-job shells of a recovered job. This event MAY appear after a
-``reattach`` event.
-
-The context SHALL be empty.
-
-Example:
-
-.. code:: json
-
-   {"timestamp":1552597348.088563,"name":"re-starting"}
-
 Recoverable Event
 =================
 


### PR DESCRIPTION
Problem: the exec.eventlog `re-starting` event description doesn't match what its name implies and it's actually not needed.

Drop it.

Also clarify the `reattach` event description.