### PR TITLE
rfc27: drop sched.queue as scheduler annotation

### DIFF
--- a/spec_27.rst
+++ b/spec_27.rst
@@ -401,9 +401,6 @@ sched.reason_pending
 sched.resource_summary
   (string) human readable overview of assigned resources
 
-sched.queue
-  (string) human readable identification of job queue
-
 sched.selection_type
   (string) human readable identification of the scheduler's selected method 
   invoked to schedule the job (i.e. immediate, reserved, backfilled)


### PR DESCRIPTION
Problem: RFC 27 lists `sched.queue` as a known scheduler annotation, but this annotation is not used anywhere since schedulers do not assign queues.

Drop the annotation to avoid confusion.

For background, Fluxion did set a `sched.queue` annotation early on when it had a default queue config parameter, but this was removed in flux-framework/flux-sched#971.